### PR TITLE
fix(hal): replace undefined PI_DEBOUNCE_NS with 0 in GPIOButtonHandler.__init__

### DIFF
--- a/os/hal/drivers/gpio_button.py
+++ b/os/hal/drivers/gpio_button.py
@@ -80,7 +80,7 @@ class GPIOButtonHandler:
         self._hold_watcher_stop = None
         self._chip = 0
         self._pin = 0
-        self._debounce_ns = PI_DEBOUNCE_NS
+        self._debounce_ns = 0  # overwritten in start() from board_profile().button.debounce_ns
         self._last_press_tick = 0
         self._last_release_tick = 0
 


### PR DESCRIPTION
## Problem

`GPIOButtonHandler.__init__()` references `PI_DEBOUNCE_NS` which no longer exists — it was removed when debounce config was moved to `boards.json`. This causes a `NameError` on instantiation, silently caught by `server.py`'s try/except, so **the GPIO button never starts and no button actions work at all**.

```
NameError: name 'PI_DEBOUNCE_NS' is not defined
```

## Fix

Replace `PI_DEBOUNCE_NS` with `0` as the placeholder default. `start()` always overwrites `self._debounce_ns` from `board_profile().button.debounce_ns`, so the default value is never used in practice.

```python
# before
self._debounce_ns = PI_DEBOUNCE_NS

# after
self._debounce_ns = 0  # overwritten in start() from board_profile().button.debounce_ns
```

## Verified on Pi Smith (172.168.20.159 — OrangePi sun60)

Patched directly on the device, restarted HAL, confirmed button events appear in log:
```
GPIO button 2 clicks -- ignored (only 1=stop, 3=reboot)
```
Button is now detected and routed correctly.