### PR TITLE
hal: fix TTS crackling (XRUN) on ARM when mic is active

### DIFF
--- a/os/hal/drivers/voice/tts_service.py
+++ b/os/hal/drivers/voice/tts_service.py
@@ -207,12 +207,13 @@ class TTSService:
         self._invalidate_stream()
 
     def _silence_keepalive(self):
-        """Write 20ms of silence every 500ms when idle to keep the codec out of
-        suspend. WM8960/Rockchip codecs power down PCM after ~1s idle, which
-        forces a multi-second snd_pcm_prepare on the next write."""
+        """Write 100ms of silence every 100ms when idle to keep the codec out of
+        suspend and prevent XRUN on ARM (buffer must stay filled >= latency window).
+        WM8960/Rockchip codecs power down PCM after ~1s idle, which forces a
+        multi-second snd_pcm_prepare on the next write."""
         np = self._np
         while True:
-            time.sleep(0.5)
+            time.sleep(0.1)
             if self._speaking:
                 continue
             try:
@@ -221,7 +222,7 @@ class TTSService:
                         continue
                     if self._speaking:
                         continue
-                    silence = np.zeros((self._stream_rate // 50, 1), dtype=np.float32)
+                    silence = np.zeros((self._stream_rate // 10, 1), dtype=np.float32)
                     self._stream.write(silence)
             except Exception as e:
                 logger.debug("Silence keepalive write failed, invalidating: %s", e)

--- a/os/hal/drivers/voice/tts_service.py
+++ b/os/hal/drivers/voice/tts_service.py
@@ -178,6 +178,7 @@ class TTSService:
             channels=TTS_CHANNELS,
             dtype="float32",
             device=self._output_device,
+            latency=0.2,
         )
         stream.start()
         self._stream = stream


### PR DESCRIPTION
## Summary
- Add `latency=0.2` to `TTSService._ensure_stream()` OutputStream
- Silence keepalive: 20ms/500ms → 100ms/100ms to keep buffer continuously filled
- Fixes audio crackling (xè xè) on OrangePi when TTS plays while mic capture is active

## Root cause
**XRUN (buffer underrun)** — two compounding issues:

1. Default PortAudio latency on Linux ALSA = ~8ms buffer. When mic capture (`arecord plug:lamp_micro1`) runs concurrently with TTS playback on the same ES8389 codec, ARM CPU can't feed the OutputStream callback within 8ms — GIL contention from concurrent threads (arecord, sensing, WebSocket, LED SPI) causes missed callbacks → XRUN → crackling.

2. Previous keepalive wrote only 20ms silence every 500ms. With a 200ms latency buffer, the 480ms gap between writes lets the buffer drain to empty → XRUN. Raising keepalive to 100ms/100ms keeps the buffer continuously topped up.

Previously silent because `lamp_micro2` (USB Jieli mic) didn't exist → no concurrent capture → no I2S contention → no XRUN.

## Fix
- `latency=0.2` on OutputStream → 200ms buffer gives ARM enough headroom even under full concurrent load
- Keepalive writes 100ms silence every 100ms → buffer never empties between writes

## Test plan
- [x] Verified on Pi Smith (`lamp-e82d`) — crackling gone after both patches applied
- [ ] Test TTS playback quality (no regression on speech clarity)
- [ ] Test barge-in still works (user can interrupt TTS mid-sentence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)