### PR TITLE
fix(intern-v2/audio): fill in ALSA card mapping

### DIFF
--- a/devices/intern-v2/rootfs/etc/asound.conf
+++ b/devices/intern-v2/rootfs/etc/asound.conf
@@ -1,57 +1,52 @@
 # ALSA aliases for the Autonomous Intern (v2) device.
 #
-# ⚠️ TEMPLATE — NOT YET CONFIGURED FOR REAL HARDWARE.
-# Intern v2 is an OrangePi (same board as Lamp) but wired differently, so the
-# card mapping below is a PLACEHOLDER. The `REPLACE_*` card names will NOT
-# resolve ("Unknown PCM") until filled in with this unit's actual cards.
+# Part of the device rootfs overlay (devices/intern-v2/rootfs/) — the whole tree
+# is copied onto / at image build and on every device-profile OTA
+# (`software-update device`). One overlay per device type, so the routing matches
+# THIS device's actual audio wiring, not the board's.
 #
-# To configure on a real Intern v2 (mirror what devices/lamp/rootfs did):
-#   1. SSH in, list hardware:
-#        aplay -l ; arecord -l ; cat /proc/asound/cards
-#   2. Identify each role and its card *name* (the [id] in /proc/asound/cards):
-#        - speaker     -> the card wired to the amp / speaker (USB DAC or onboard)
-#        - voice mic   -> the mic used for speech capture
-#        - sensing mic -> the mic used for ambient sound sensing
-#   3. Replace the REPLACE_* card names below. Address by NAME, not index —
-#      USB card numbers reorder across boots; the card id string is stable.
+# Current Intern v2 HW (OrangePi 4 Pro / A733 — same board as Lamp, simpler audio:
+# no USB speaker DAC, no camera):
+#   - Speaker:     onboard ES8389 codec.   ALSA card "sndi2s4".
+#   - Voice mic:   Jieli USB mic.          ALSA card "Device".
+#   - Sensing mic: onboard ES8389 codec.   ALSA card "sndi2s4".
 #
-# The alias NAMES are the device-agnostic contract (same on every device) — HAL's
-# .env binds them and must NOT change:
+# Cards are addressed by NAME, not index: USB card numbers reorder across boots,
+# but the card id string is stable. The HAL .env binds the aliases:
 #   HAL_AUDIO_OUTPUT_ALSA=plug:device_speaker
 #   HAL_AUDIO_INPUT_ALSA=plug:device_micro2     (voice)
 #   HAL_AUDIO_SENSING_DEVICE=plug:device_micro1 (ambient sensing)
-# Only the `card "..."` targets below are device-specific.
 
-# Speaker
+# Speaker -> onboard ES8389 codec
 pcm.device_speaker {
     type plug
     slave.pcm {
         type hw
-        card "REPLACE_SPEAKER_CARD"
+        card "sndi2s4"
         device 0
     }
 }
-ctl.device_speaker { type hw card "REPLACE_SPEAKER_CARD" }
+ctl.device_speaker { type hw card "sndi2s4" }
 
-# Voice capture (HAL_AUDIO_INPUT_ALSA)
+# Voice capture (HAL_AUDIO_INPUT_ALSA) -> Jieli USB mic
 pcm.device_micro2 {
     type plug
     slave.pcm {
         type hw
-        card "REPLACE_VOICE_MIC_CARD"
+        card "Device"
         device 0
     }
 }
-ctl.device_micro2 { type hw card "REPLACE_VOICE_MIC_CARD" }
+ctl.device_micro2 { type hw card "Device" }
 
-# Ambient sensing capture (HAL_AUDIO_SENSING_DEVICE)
+# Ambient sensing capture (HAL_AUDIO_SENSING_DEVICE) -> onboard ES8389 codec
 pcm.device_micro1 {
     type plug
     slave.pcm {
         type hw
-        card "REPLACE_SENSING_MIC_CARD"
+        card "sndi2s4"
         device 0
     }
     route_policy average
 }
-ctl.device_micro1 { type hw card "REPLACE_SENSING_MIC_CARD" }
+ctl.device_micro1 { type hw card "sndi2s4" }


### PR DESCRIPTION
## Problem
`devices/intern-v2/rootfs/etc/asound.conf` shipped as a `REPLACE_*` **template**, so every intern-v2 deploy landed with **broken audio** — `device_speaker` / `device_micro1` / `device_micro2` all resolved to "Unknown PCM" until someone SSH'd in and filled it by hand. Confirmed on unit 172.168.20.72 (still unconfigured).

## Fix
Fill in the actual cards (verified from `/proc/asound/cards` on the unit):

| Alias | Role | Card |
|---|---|---|
| `device_speaker` | speaker out | `sndi2s4` (onboard ES8389) |
| `device_micro2` | voice (STT) | `Device` (Jieli USB) |
| `device_micro1` | ambient sensing | `sndi2s4` (onboard), `route_policy average` |

Addressed by card **name** (stable) not index. Mirrors `devices/lamp/rootfs` style — intern audio is the same as Lamp minus the USB speaker DAC and the camera mic.

## Verification
Unit 172.168.20.72 cards: `sndi2s4` (onboard) + `Device` (Jieli USB Composite). udev rules already correct on the box (`91-pulseaudio-hal-ignore` includes Jieli `4c4a:4155`, `99-t527-permissions`, `99-lamp-dev-interfaces`). Only `asound.conf` was the template — this PR makes the deploy ship it pre-configured.
