### PR TITLE
fix(factory-reset): keep bootstrap.json when wiping /root/config

### DIFF
--- a/os/services/server/system/factoryreset.go
+++ b/os/services/server/system/factoryreset.go
@@ -19,7 +19,7 @@ import (
 const configFilePath = "/root/config/config.json"
 
 var deviceWipePaths = []string{
-	"/root/config",                                  // os-server config.json (API keys, channel tokens, MQTT creds)
+	"/root/config/config.json",                      // os-server config (API keys, channel tokens, MQTT creds) — bootstrap.json in the same dir is intentionally kept
 	"/root/local/users",                             // face + voice enrollments (owner)
 	"/root/local/strangers",                         // face + voice enrollments (stranger)
 	"/var/lib/hal/snapshots",                        // persistent camera snapshots (sensing_face / motion / emotion, 72h TTL)


### PR DESCRIPTION
## Summary
- Factory reset wiped `/root/config` entirely (`os.RemoveAll`), deleting `bootstrap.json` alongside `config.json`
- `bootstrap.json` is a system file baked at image build time — losing it breaks `software-update` after every factory reset
- Fix: change wipe path from `/root/config` (whole dir) to `/root/config/config.json` (user config only)

## Root cause
`deviceWipePaths` listed `/root/config` as a directory path. `wipePath()` calls `os.RemoveAll()` which removes the entire directory tree.

## Test plan
- [ ] Factory reset → `software-update hal` still works (bootstrap.json present)
- [ ] Factory reset still clears config.json (device returns to setup AP mode)