### PR TITLE
fix(hal): use pull-up bias for TTP223 touch lines

### DIFF
--- a/os/hal/drivers/ttp223.py
+++ b/os/hal/drivers/ttp223.py
@@ -140,7 +140,7 @@ class TTP223Handler:
         for line in self._lines:
             try:
                 lgpio.gpio_claim_alert(
-                    self._handle, line, lgpio.BOTH_EDGES, lgpio.SET_PULL_DOWN
+                    self._handle, line, lgpio.BOTH_EDGES, lgpio.SET_PULL_UP
                 )
                 cb = lgpio.callback(
                     self._handle, line, lgpio.BOTH_EDGES, self._on_edge

--- a/os/hal/test_ttp223_probe_orangepi.py
+++ b/os/hal/test_ttp223_probe_orangepi.py
@@ -8,11 +8,11 @@ CHIP = "/dev/gpiochip0"
 LINES = [96, 97, 99]
 NAMES = {96: "S1", 97: "S2", 99: "S4"}
 
-settings = gpiod.LineSettings(direction=Direction.INPUT, bias=Bias.PULL_DOWN)
+settings = gpiod.LineSettings(direction=Direction.INPUT, bias=Bias.PULL_UP)
 config = {l: settings for l in LINES}
 
 with gpiod.request_lines(CHIP, consumer="ttp223-probe", config=config) as req:
-    print("Probing", LINES, "(PULL_DOWN). Touch each pad. Ctrl+C to exit.")
+    print("Probing", LINES, "(PULL_UP). Touch each pad. Ctrl+C to exit.")
     last = {l: None for l in LINES}
     while True:
         vals = req.get_values(LINES)


### PR DESCRIPTION
## What

Switch the internal GPIO bias for the TTP223 touch lines from **pull-down** to **pull-up**, in both the runtime driver and the standalone probe script.

## Why

The TTP223 pads rest **HIGH** and drop **LOW** on touch (FastMode active-low output) — as documented in the driver comments. The bias was previously configured as `PULL_DOWN`, which mismatched the resting level. With pull-up, a floating/disconnected line defaults HIGH (= "not touched") instead of LOW.

Note: the TTP223 output is push-pull (actively driven), so this bias mainly affects the resting level of an unwired/floating line; normal touch behavior is unchanged.

## Changes

- `os/hal/drivers/ttp223.py` — `lgpio.SET_PULL_DOWN` → `lgpio.SET_PULL_UP`
- `os/hal/test_ttp223_probe_orangepi.py` — `Bias.PULL_DOWN` → `Bias.PULL_UP` (+ probe print label)