### PR TITLE
imager: pre-bake yq for Hermes, full install at switch-time

### DIFF
--- a/imager/build-orangepi.sh
+++ b/imager/build-orangepi.sh
@@ -309,34 +309,17 @@ timeout 60 openclaw onboard --non-interactive --accept-risk --skip-health || \\
 openclaw plugins install @openclaw/discord@${OPENCLAW_VERSION} --force 2>&1 || echo "WARN: discord plugin install failed (non-fatal)"
 openclaw plugins install @openclaw/slack@${OPENCLAW_VERSION} --force 2>&1 || echo "WARN: slack plugin install failed (non-fatal)"
 
-# ── Hermes agentic backend (pre-install) ─────────────────────────────────────
-# Pre-bake Hermes so switch-runtime skips the CDN download on first switch.
-# install.sh runs gateway install --system (unit + enable symlink) then
-# gateway start --system (fails in chroot — no live systemd, || true).
-# We explicitly disable after so hermes-gateway does NOT auto-start on boot;
-# default runtime stays openclaw. switch-runtime enables it on first switch.
-echo "[stage] Hermes pre-install"
-HERMES_INSTALLER_TMP=\$(mktemp)
-if retry "curl -fsSL https://cdn.autonomous.ai/os/runtimes/hermes/install.sh -o '\$HERMES_INSTALLER_TMP'" 3; then
-  chmod +x "\$HERMES_INSTALLER_TMP"
-  bash "\$HERMES_INSTALLER_TMP" || true
-  systemctl disable hermes-gateway 2>/dev/null || true
-  if [ -x /usr/local/bin/hermes ]; then
-    mkdir -p /usr/local/lib/os-runtimes/hermes
-    echo "hermes-gateway" > /usr/local/lib/os-runtimes/hermes/service
-    cat > /usr/local/lib/os-runtimes/hermes/verify <<'VERIFY_HERMES'
-#!/usr/bin/env bash
-command -v hermes >/dev/null 2>&1
-VERIFY_HERMES
-    chmod +x /usr/local/lib/os-runtimes/hermes/verify
-    echo "[stage] Hermes pre-install OK — binary ready, not auto-started (switch-runtime enables on first switch)"
-  else
-    echo "[stage] WARN: hermes binary not found after install (non-fatal)"
-  fi
-else
-  echo "[stage] WARN: hermes installer fetch failed (non-fatal)"
+# ── Hermes prereq — pre-bake yq so install.sh runs offline on first switch ───
+# Full Hermes install happens at runtime via switch-runtime (uses the install.sh
+# embedded in os-server). yq is the only dep install.sh needs that apt doesn't
+# provide — bake it here so the first switch doesn't need GitHub.
+echo "[stage] Hermes prereq — yq"
+if ! command -v yq >/dev/null 2>&1; then
+  curl -fsSL "https://github.com/mikefarah/yq/releases/download/v4.46.1/yq_linux_arm64" \
+    -o /usr/local/bin/yq
+  chmod +x /usr/local/bin/yq
 fi
-rm -f "\$HERMES_INSTALLER_TMP"
+yq --version || true
 
 # ── uv (Python pkg mgr for HAL) ───────────────────────────────────────────
 echo "[stage] uv"

--- a/imager/build-orangepi.sh
+++ b/imager/build-orangepi.sh
@@ -311,14 +311,16 @@ openclaw plugins install @openclaw/slack@${OPENCLAW_VERSION} --force 2>&1 || ech
 
 # ── Hermes agentic backend (pre-install) ─────────────────────────────────────
 # Pre-bake Hermes so switch-runtime skips the CDN download on first switch.
-# gateway start --system requires live systemd (absent in chroot) and will fail;
-# we run with || true then manually create the switch-runtime discovery files
-# (service + verify) that install.sh writes AFTER gateway start.
+# install.sh runs gateway install --system (unit + enable symlink) then
+# gateway start --system (fails in chroot — no live systemd, || true).
+# We explicitly disable after so hermes-gateway does NOT auto-start on boot;
+# default runtime stays openclaw. switch-runtime enables it on first switch.
 echo "[stage] Hermes pre-install"
 HERMES_INSTALLER_TMP=\$(mktemp)
 if retry "curl -fsSL https://cdn.autonomous.ai/os/runtimes/hermes/install.sh -o '\$HERMES_INSTALLER_TMP'" 3; then
   chmod +x "\$HERMES_INSTALLER_TMP"
   bash "\$HERMES_INSTALLER_TMP" || true
+  systemctl disable hermes-gateway 2>/dev/null || true
   if [ -x /usr/local/bin/hermes ]; then
     mkdir -p /usr/local/lib/os-runtimes/hermes
     echo "hermes-gateway" > /usr/local/lib/os-runtimes/hermes/service
@@ -327,7 +329,7 @@ if retry "curl -fsSL https://cdn.autonomous.ai/os/runtimes/hermes/install.sh -o 
 command -v hermes >/dev/null 2>&1
 VERIFY_HERMES
     chmod +x /usr/local/lib/os-runtimes/hermes/verify
-    echo "[stage] Hermes pre-install OK — binary ready, gateway starts on first switch"
+    echo "[stage] Hermes pre-install OK — binary ready, not auto-started (switch-runtime enables on first switch)"
   else
     echo "[stage] WARN: hermes binary not found after install (non-fatal)"
   fi

--- a/imager/build-orangepi.sh
+++ b/imager/build-orangepi.sh
@@ -309,17 +309,8 @@ timeout 60 openclaw onboard --non-interactive --accept-risk --skip-health || \\
 openclaw plugins install @openclaw/discord@${OPENCLAW_VERSION} --force 2>&1 || echo "WARN: discord plugin install failed (non-fatal)"
 openclaw plugins install @openclaw/slack@${OPENCLAW_VERSION} --force 2>&1 || echo "WARN: slack plugin install failed (non-fatal)"
 
-# ── Hermes prereq — pre-bake yq so install.sh runs offline on first switch ───
-# Full Hermes install happens at runtime via switch-runtime (uses the install.sh
-# embedded in os-server). yq is the only dep install.sh needs that apt doesn't
-# provide — bake it here so the first switch doesn't need GitHub.
-echo "[stage] Hermes prereq — yq"
-if ! command -v yq >/dev/null 2>&1; then
-  curl -fsSL "https://github.com/mikefarah/yq/releases/download/v4.46.1/yq_linux_arm64" \
-    -o /usr/local/bin/yq
-  chmod +x /usr/local/bin/yq
-fi
-yq --version || true
+curl -fsSL "https://github.com/mikefarah/yq/releases/download/v4.46.1/yq_linux_arm64" -o /usr/local/bin/yq
+chmod +x /usr/local/bin/yq
 
 # ── uv (Python pkg mgr for HAL) ───────────────────────────────────────────
 echo "[stage] uv"


### PR DESCRIPTION
## Summary

- Imager không còn chạy full Hermes install trong chroot nữa
- Chỉ pre-bake `yq` (dep duy nhất mà `install.sh` cần ngoài apt)
- Full Hermes install chạy lúc user switch runtime via `switch-runtime` (dùng `install.sh` embed sẵn trong os-server binary)
- Default vẫn là openclaw khi boot

## Test plan

- [ ] Build image, verify `yq` có sẵn trên device sau flash
- [ ] Switch to Hermes via UI → `switch-runtime` trigger → Hermes install + start thành công
- [ ] Switch back to openclaw → openclaw up, hermes-gateway stopped