### PR TITLE
imager: fix buddy service unit missing on OTA update

### DIFF
--- a/imager/build-orangepi.sh
+++ b/imager/build-orangepi.sh
@@ -763,6 +763,30 @@ elif [ "\$APP" = "claude-desktop-buddy" ]; then
   unzip -o -q "\$ZIP_TMP" -d "\$DIR_TMP"
   [ -f "\$DIR_TMP/buddy-plugin" ] && cp -f "\$DIR_TMP/buddy-plugin" "\$BUDDY_DIR/buddy-plugin" && chmod +x "\$BUDDY_DIR/buddy-plugin"
   [ ! -f "/root/config/buddy.json" ] && [ -f "\$DIR_TMP/config/buddy.json" ] && mkdir -p /root/config && cp -f "\$DIR_TMP/config/buddy.json" /root/config/buddy.json
+  if [ ! -f /etc/systemd/system/claude-desktop-buddy.service ]; then
+    cat > /etc/systemd/system/claude-desktop-buddy.service <<'BUDDY_UNIT'
+[Unit]
+Description=Claude Desktop Buddy (BLE)
+After=bluetooth.target os-server.service
+Wants=bluetooth.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/claude-desktop-buddy
+ExecStart=/opt/claude-desktop-buddy/buddy-plugin -config /root/config/buddy.json
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=claude-desktop-buddy
+
+[Install]
+WantedBy=multi-user.target
+BUDDY_UNIT
+    systemctl daemon-reload
+    systemctl enable claude-desktop-buddy
+  fi
   echo "\$VERSION" > "\$BUDDY_DIR/VERSION_BUDDY"
   systemctl restart claude-desktop-buddy
   echo "claude-desktop-buddy updated to \$VERSION"


### PR DESCRIPTION
## Problem

Devices flashed before `claude-desktop-buddy` was added to the image bake had no `claude-desktop-buddy.service` unit file. When bootstrap OTA ran `software-update claude-desktop-buddy`:

1. Binary copied to `/opt/claude-desktop-buddy/buddy-plugin` ✅
2. `VERSION_BUDDY` written ✅ ← locks OTA out of future retries
3. `systemctl restart claude-desktop-buddy` → **FAIL** (unit file missing)

Result: buddy binary exists, OTA thinks it's current (VERSION matches), but service never starts. Silent permanent failure.

**Leo's door lamp** was the reported case — flashed before buddy was baked in, stuck in this state ever since.

## Fix

In the `software-update claude-desktop-buddy` path, recreate the service unit file + `daemon-reload` + `enable` when the unit is absent. Idempotent — no-op on devices that already have the unit from the bake phase.

## Test plan

- [ ] Verify on Leo's door lamp: `software-update claude-desktop-buddy` → service unit created, service starts
- [ ] Verify on already-baked device: no-op (unit file already present, skip block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)