### PR TITLE
fix(factory-reset): wipe workspace-attestations on openclaw reset

### DIFF
--- a/os/services/internal/openclaw/reset.go
+++ b/os/services/internal/openclaw/reset.go
@@ -25,6 +25,7 @@ func (s *OpenclawService) ResetAgent() error {
 var openclawStatePaths = []string{
 	"/root/.openclaw/agents",                  // conversation sessions + history
 	"/root/.openclaw/workspace",               // agent memory (HEARTBEAT.md, SOUL.md, USER.md, memory/)
+	"/root/.openclaw/workspace-attestations", // workspace integrity proofs — must wipe with workspace or onboard re-entry fails
 	"/root/.openclaw/devices",                 // paired devices list
 	"/root/.openclaw/tasks",                   // background task runs
 	"/root/.openclaw/logs",                    // runtime logs


### PR DESCRIPTION
## Summary
- F_R xóa `/root/.openclaw/workspace` nhưng bỏ sót `workspace-attestations/`
- Sau F_R, `openclaw onboard` thấy attestation hash nhưng workspace đã mất → `WorkspaceVanishedError` → refuses to reinitialize → setup fails hoàn toàn
- Fix: thêm `workspace-attestations` vào danh sách wipe trong `openclawStatePaths`

## Test plan
- [ ] F_R device → chạy setup wizard → openclaw onboard không bị WorkspaceVanishedError
- [ ] Setup hoàn thành bình thường, openclaw.service active

🤖 Generated with [Claude Code](https://claude.com/claude-code)