### PR TITLE
fix(network): sync NTP immediately after WiFi connect

### DIFF
--- a/os/services/internal/network/service.go
+++ b/os/services/internal/network/service.go
@@ -486,14 +486,25 @@ func (s *Service) SetupNetwork(ssid string, password string) (bool, error) {
 		slog.Error("save config failed", "component", "network", "error", err)
 	}
 	slog.Info("network setup success", "component", "network")
-	// Force NTP step now that internet is up. Devices without an RTC battery
-	// boot with a stale clock (base-image build date); chrony can't sync in AP
-	// mode (no internet). Without this, the first LLM call after setup fails
-	// with CERT_NOT_YET_VALID because the TLS cert predates the device clock.
-	if out, err := exec.Command("chronyc", "makestep").CombinedOutput(); err != nil {
-		slog.Warn("chronyc makestep failed", "component", "network", "error", err, "output", strings.TrimSpace(string(out)))
-	} else {
-		slog.Info("NTP stepped after WiFi connect", "component", "network")
+	// Kick systemd-timesyncd now that internet is up. Devices without an RTC
+	// battery boot with a stale clock (base-image build date); timesyncd can't
+	// sync in AP mode (no internet). Without this, the first LLM call after
+	// setup fails with CERT_NOT_YET_VALID because the TLS cert predates the
+	// device clock.
+	if out, err := exec.Command("systemctl", "restart", "systemd-timesyncd").CombinedOutput(); err != nil {
+		slog.Warn("systemd-timesyncd restart failed", "component", "network", "error", err, "output", strings.TrimSpace(string(out)))
+	}
+	// Poll until NTPSynchronized=yes (max ~10 s); non-fatal if it times out.
+	for i := range 10 {
+		time.Sleep(time.Second)
+		out, err := exec.Command("timedatectl", "show", "-p", "NTPSynchronized", "--value").Output()
+		if err == nil && strings.TrimSpace(string(out)) == "yes" {
+			slog.Info("NTP synchronized after WiFi connect", "component", "network", "attempts", i+1)
+			break
+		}
+		if i == 9 {
+			slog.Warn("NTP not yet synchronized after WiFi connect", "component", "network")
+		}
 	}
 	return true, nil
 }

--- a/os/services/internal/network/service.go
+++ b/os/services/internal/network/service.go
@@ -486,13 +486,16 @@ func (s *Service) SetupNetwork(ssid string, password string) (bool, error) {
 		slog.Error("save config failed", "component", "network", "error", err)
 	}
 	slog.Info("network setup success", "component", "network")
-	// Kick systemd-timesyncd now that internet is up. Devices without an RTC
-	// battery boot with a stale clock (base-image build date); timesyncd can't
-	// sync in AP mode (no internet). Without this, the first LLM call after
-	// setup fails with CERT_NOT_YET_VALID because the TLS cert predates the
-	// device clock.
-	if out, err := exec.Command("systemctl", "restart", "systemd-timesyncd").CombinedOutput(); err != nil {
-		slog.Warn("systemd-timesyncd restart failed", "component", "network", "error", err, "output", strings.TrimSpace(string(out)))
+	// Kick the NTP daemon now that internet is up. Devices without an RTC
+	// battery boot with a stale clock (base-image build date); NTP can't sync
+	// in AP mode (no internet). Without this, the first LLM call after setup
+	// fails with CERT_NOT_YET_VALID because the TLS cert predates the clock.
+	// Images may ship chrony OR systemd-timesyncd — try both, non-fatal.
+	if out, err := exec.Command("chronyc", "makestep").CombinedOutput(); err != nil {
+		slog.Warn("chronyc makestep failed, trying systemd-timesyncd", "component", "network", "error", err, "output", strings.TrimSpace(string(out)))
+		if out2, err2 := exec.Command("systemctl", "restart", "systemd-timesyncd").CombinedOutput(); err2 != nil {
+			slog.Warn("systemd-timesyncd restart failed", "component", "network", "error", err2, "output", strings.TrimSpace(string(out2)))
+		}
 	}
 	// Poll until NTPSynchronized=yes (max ~10 s); non-fatal if it times out.
 	for i := range 10 {

--- a/os/services/internal/network/service.go
+++ b/os/services/internal/network/service.go
@@ -486,6 +486,15 @@ func (s *Service) SetupNetwork(ssid string, password string) (bool, error) {
 		slog.Error("save config failed", "component", "network", "error", err)
 	}
 	slog.Info("network setup success", "component", "network")
+	// Force NTP step now that internet is up. Devices without an RTC battery
+	// boot with a stale clock (base-image build date); chrony can't sync in AP
+	// mode (no internet). Without this, the first LLM call after setup fails
+	// with CERT_NOT_YET_VALID because the TLS cert predates the device clock.
+	if out, err := exec.Command("chronyc", "makestep").CombinedOutput(); err != nil {
+		slog.Warn("chronyc makestep failed", "component", "network", "error", err, "output", strings.TrimSpace(string(out)))
+	} else {
+		slog.Info("NTP stepped after WiFi connect", "component", "network")
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
## Summary
- Devices without an RTC battery boot with a stale clock (base-image build date from `fake-hwclock`)
- In AP mode there's no internet so NTP can't sync before setup
- Without this fix, the first LLM call after setup fails with `CERT_NOT_YET_VALID` because the TLS cert predates the device clock
- Fix: after WiFi connects, kick the NTP daemon and poll `timedatectl` for up to ~10s
- Try `chronyc makestep` first (hardware team base image ships chrony), fallback to `systemctl restart systemd-timesyncd` for other images

## Test plan
- [ ] Flash device → setup → verify first LLM call succeeds without CERT_NOT_YET_VALID
- [ ] Verify `NTP synchronized after WiFi connect` in os-server log
- [ ] If chrony not found: verify fallback warn + systemd-timesyncd path