### PR TITLE
Take the model list from a bring-your-own LLM endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ hal-clean:
 # CTS — Compatibility Test Suite (devices/contract/cts)
 # ============================================================================
 
-.PHONY: new-device push-skill skills-catalog skills-catalog-check cts cts-runtime
+.PHONY: new-device push-skill skills-catalog skills-catalog-check latency cts cts-runtime
 
 # Scaffold a new body from devices/_template/ — DEVICE.md + SOUL.md, no SAFETY.md
 # on purpose: `make cts` fails until you write the bounds for what you declared.
@@ -94,6 +94,13 @@ skills-catalog:
 
 skills-catalog-check:
 	python3 scripts/skills/gen_catalog.py --check
+
+# Measure what a turn costs on a running robot: reads its flow log and prints
+# p50/p95 per stage. PASSWORD is the 4 characters in the robot's Wi-Fi name.
+#   make latency TARGET=lamp-ac82.local PASSWORD=ac82 [DATE=2026-08-16]
+latency:
+	@test -n "$(TARGET)" || { echo "usage: make latency TARGET=lamp-xxxx.local PASSWORD=xxxx" >&2; exit 2; }
+	python3 scripts/bench/latency.py --target $(TARGET) $(if $(PASSWORD),--password $(PASSWORD),) $(if $(TOKEN),--token $(TOKEN),) $(if $(DATE),--date $(DATE),)
 
 # Copy a skill folder onto a running body. Live on the next conversation, no
 # reboot. Root SSH is off, so it lands in /tmp and moves with sudo.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,52 @@
+# What a turn costs
+
+**Nothing here is measured yet.** This page is the method and the command; the
+numbers land when someone runs it on a robot. Until then the only timings in
+this tree are code comments — `~50 ms` for a local table match in
+`system/intent/intent.go`, `3–5 s` through the agent in one comment and `8 s`
+time-to-first-token in another. Two comments that disagree are not a spec, and
+we will not publish them as one.
+
+## Method
+
+Every turn already writes a flow log: one JSONL line per stage, with a trace id
+and a duration (`system/lib/flow/`, `GET /api/agent/flow-logs`). So there is
+nothing to instrument — talk to the robot for a while, then read what it
+recorded:
+
+```bash
+make latency TARGET=lamp-ac82.local PASSWORD=ac82
+```
+
+`PASSWORD` is the four characters in the robot's Wi-Fi name. Add `DATE=YYYY-MM-DD`
+for an earlier day. To work from a downloaded log instead:
+
+```bash
+python3 scripts/bench/latency.py --file flow_2026-08-16.jsonl
+```
+
+It prints p50 / p95 / max per stage and for the whole turn, plus the two lines
+that matter: how long a fixed command takes on the local path (`intent_match`,
+no model, no network) and how long a turn through the brain takes
+(`agent_call`).
+
+These are real turns, not synthetic ones — the sample is however many turns that
+robot actually had, and the report says so.
+
+## What is still not covered
+
+- **Time to first spoken word.** The flow log records when TTS was sent, not
+  when sound left the speaker. Measuring the acoustic end needs a microphone
+  and a clap track.
+- **Power.** No watts, idle or moving. A USB meter and a fixed script would do
+  it.
+- **Memory and CPU.** `os-server` and HAL resident size, and CPU during a turn.
+  One `top` capture on a Pi 5 Lamp would settle it.
+- **Uptime.** The longest unattended run and how many OTA rollouts it survived.
+  Nobody has tracked this.
+
+## When you have numbers
+
+Paste the table under a dated heading here, say which body and which brain, and
+keep the raw JSONL next to it. Then the README can stop hedging — that is the
+whole point of this file.

--- a/docs/hosted.md
+++ b/docs/hosted.md
@@ -24,6 +24,32 @@ Autonomous OS phones home to three things and nothing else.
   releases are on the list. There is no fleet view yet — one robot per **Add
   robot**, and every robot pulls the same skill feed and OTA floor.
 
+## Bring your own LLM endpoint
+
+Point the robot at any OpenAI-compatible server — Ollama, vLLM, LM Studio,
+llama.cpp, OpenRouter — and it lists models from *that* endpoint instead of our
+catalog:
+
+1. Set `llm_base_url` (and `llm_api_key`, if your server wants one) — in the
+   browser setup wizard's AI-brain step, or directly in the robot's
+   `config.json`.
+2. Restart `os-server`. On boot it calls `GET {llm_base_url}/models` and writes
+   the models it finds into `openclaw.json`, so the brain only ever advertises
+   models that endpoint actually serves.
+
+Any base URL that is not an `autonomous.ai` / `autonomousdev.xyz` host takes
+this path (`runtimes/openclaw/byo_models.go`); ours keeps the hosted catalog. If
+the endpoint cannot list models the robot logs which URL failed and falls back
+to the built-in list rather than advertising models nothing can serve.
+
+Speech and perception have their own overrides — `stt_base_url`, `tts_base_url`,
+and `DL_BACKEND_URL` for the perception service — so a robot with all four set
+talks to nothing of ours.
+
+**Verified in unit tests, not yet on a robot against a local Ollama.** If you
+run one, say what happened in
+[Discussions](https://github.com/autonomous-ai/autonomous-os/discussions).
+
 ## Offline
 
 Local intents (~50 ms), recorded moves and the safety gate keep working;

--- a/docs/not-built-yet.md
+++ b/docs/not-built-yet.md
@@ -21,7 +21,7 @@ The full list behind the README's [Not built yet](../README.md#contribute). Each
 - A `ReachyMiniApp` wrapper published as a Space tagged `reachy_mini`, so Autonomous OS installs from Pollen's own dashboard app list and stops from there too.
 - Lamp's 23 teleop moves exported by `hal/record.py` as a Hub dataset in Pollen's emotion-library format (`autonomous-os/lamp-emotions-library`), so a move recorded on either body plays on both.
 - Reachy Mini Lite: the daemon runs on your laptop, so the mock body (`devices/sim/` on `reachy-mini-daemon --sim`) is also the Lite path.
-- A measured turn latency — `make latency`: end of speech → first spoken word and → first `[HW:]` POST, p50/p95 over ~20 turns on Lamp with the default brain. Today the code comments say 3–5 s in one place and 8 s time-to-first-token in another.
+- Measured numbers on hardware. `make latency` now exists (`scripts/bench/latency.py` reads a robot's flow log and reports p50/p95 per stage) but nobody has run it on a robot — see `docs/benchmarks.md`, which also lists what it does not cover: time to first spoken word at the speaker, watts idle and moving, RSS and CPU during a turn, and the longest unattended run.
 - A hosted-model table (model, task, open weights yes/no, local swap path) for the voice, face and mood models the gateway serves.
 - The contract's reference parsers (`hal/board/device.py`, `hal/safety/policy.py`) sit inside GPL `hal/`, so the Apache-licensed CTS imports GPL code; moving them under `devices/contract/` is a wanted PR.
 - A plain setup page for browser setup without the phone app (today `/setup?debug=true&device_id=…`).

--- a/runtimes/openclaw/byo_models.go
+++ b/runtimes/openclaw/byo_models.go
@@ -1,0 +1,164 @@
+package openclaw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.autonomous.ai/os/system/domain"
+)
+
+// Bring your own endpoint.
+//
+// The device writes ONE provider into openclaw.json — baseUrl + apiKey from
+// config.json (llm_base_url / llm_api_key) — but until now the model *list*
+// always came from ModelsAPIURL, our hosted catalog. Point llm_base_url at
+// Ollama or vLLM and openclaw still advertised Claude model keys that endpoint
+// has never heard of, so every turn 404s. That is why a fully local robot was
+// not possible.
+//
+// resolveModels closes it. When the base URL is not ours, the model list comes
+// from the endpoint itself over the OpenAI-compatible `GET {base}/models` that
+// Ollama, vLLM, LM Studio, llama.cpp and OpenRouter all serve. Nothing changes
+// for a device pointed at the Autonomous gateway: same call, same catalog,
+// same fallback.
+
+// autonomousHosts are the hosts that serve our own catalog. A base URL on one
+// of these keeps the hosted path; anything else is treated as BYO.
+var autonomousHosts = []string{
+	"autonomous.ai",
+	"autonomousdev.xyz",
+}
+
+// isAutonomousEndpoint reports whether baseURL points at our own gateway.
+// Unparseable or empty → true, so a malformed value can never silently switch a
+// shipped device onto the discovery path.
+func isAutonomousEndpoint(baseURL string) bool {
+	raw := strings.TrimSpace(baseURL)
+	if raw == "" {
+		return true
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return true
+	}
+	host := strings.ToLower(u.Hostname())
+	for _, suffix := range autonomousHosts {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// openAIModelsResponse is the OpenAI-compatible `GET /v1/models` shape.
+type openAIModelsResponse struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// modelsEndpoint turns a provider base URL into its models URL: it appends
+// /models, tolerating a base that already ends in /v1 or a trailing slash.
+func modelsEndpoint(baseURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if strings.HasSuffix(base, "/models") {
+		return base
+	}
+	return base + "/models"
+}
+
+// fetchOpenAIModels asks a BYO endpoint what it can serve. It accepts either
+// the OpenAI list shape ({"data":[{"id":...}]}) or our own catalog shape, so an
+// operator can point llm_base_url at a proxy that already speaks either one.
+func fetchOpenAIModels(ctx context.Context, baseURL, apiKey string) ([]domain.LLMModel, error) {
+	endpoint := modelsEndpoint(baseURL)
+	ctx, cancel := context.WithTimeout(ctx, modelsAPITimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build models request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if key := strings.TrimSpace(apiKey); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+		req.Header.Set("x-api-key", key)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch %s: status %d", endpoint, resp.StatusCode)
+	}
+
+	var raw json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode models response: %w", err)
+	}
+
+	// Our own catalog shape first — a proxy may serve it verbatim.
+	var ours domain.LLMModelsListResponse
+	if err := json.Unmarshal(raw, &ours); err == nil && len(ours.Models) > 0 {
+		return ours.Models, nil
+	}
+
+	var oai openAIModelsResponse
+	if err := json.Unmarshal(raw, &oai); err != nil {
+		return nil, fmt.Errorf("decode models response: %w", err)
+	}
+	out := make([]domain.LLMModel, 0, len(oai.Data))
+	for _, m := range oai.Data {
+		id := strings.TrimSpace(m.ID)
+		if id == "" {
+			continue
+		}
+		out = append(out, domain.LLMModel{
+			Key:     id,
+			Name:    id,
+			Input:   []string{"text"},
+			Privacy: "private",
+		})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("models response from %s is empty", endpoint)
+	}
+	return out, nil
+}
+
+// resolveModels returns the model catalog for a device, and whether it came
+// from a bring-your-own endpoint.
+//
+// baseURL on an Autonomous host  → the hosted catalog (unchanged behavior).
+// anything else                  → `GET {baseURL}/models` on that endpoint.
+//
+// Both paths fail soft: the caller keeps its existing fallback, and a BYO
+// endpoint that cannot list models is reported so setup can say why.
+func resolveModels(ctx context.Context, baseURL, apiKey string) (*domain.LLMModelsListResponse, bool, error) {
+	if isAutonomousEndpoint(baseURL) {
+		resp, err := FetchModelsFromAPI()
+		return resp, false, err
+	}
+
+	slog.Info("byo endpoint: listing models from the configured base URL",
+		"component", "openclaw", "endpoint", modelsEndpoint(baseURL))
+	models, err := fetchOpenAIModels(ctx, baseURL, apiKey)
+	if err != nil {
+		return nil, true, fmt.Errorf("bring-your-own endpoint %s: %w", modelsEndpoint(baseURL), err)
+	}
+	return &domain.LLMModelsListResponse{
+		Count:        len(models),
+		DefaultModel: models[0].Key,
+		// OpenAI-compatible is the wire protocol every BYO server above speaks;
+		// a per-model override still comes from OpenClawAPIType at write time.
+		API:    "openai-completions",
+		Models: models,
+	}, true, nil
+}

--- a/runtimes/openclaw/byo_models_test.go
+++ b/runtimes/openclaw/byo_models_test.go
@@ -1,0 +1,133 @@
+package openclaw
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsAutonomousEndpoint(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"https://campaign-api.autonomous.ai/api/v1/ai/v1", true},
+		{"https://autonomous.ai/v1", true},
+		{"https://campaign-api.staging.autonomousdev.xyz/api/v1/ai/v1", true},
+		{"", true},                 // unset — keep the hosted path
+		{"::not a url::", true},    // unparseable — keep the hosted path
+		{"not-a-url-either", true}, // no host — keep the hosted path
+		{"http://192.168.1.42:11434/v1", false},
+		{"http://localhost:11434/v1", false},
+		{"https://openrouter.ai/api/v1", false},
+		{"https://autonomous.ai.evil.example.com/v1", false}, // suffix must be a real label boundary
+	}
+	for _, c := range cases {
+		if got := isAutonomousEndpoint(c.url); got != c.want {
+			t.Errorf("isAutonomousEndpoint(%q) = %v, want %v", c.url, got, c.want)
+		}
+	}
+}
+
+func TestModelsEndpoint(t *testing.T) {
+	cases := map[string]string{
+		"http://localhost:11434/v1":        "http://localhost:11434/v1/models",
+		"http://localhost:11434/v1/":       "http://localhost:11434/v1/models",
+		"http://localhost:11434/v1/models": "http://localhost:11434/v1/models",
+		"https://openrouter.ai/api/v1":     "https://openrouter.ai/api/v1/models",
+	}
+	for in, want := range cases {
+		if got := modelsEndpoint(in); got != want {
+			t.Errorf("modelsEndpoint(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// A BYO endpoint that speaks the OpenAI list shape (Ollama, vLLM, LM Studio)
+// is what makes a fully local robot possible: the model list comes from the
+// endpoint that will actually serve the turns.
+func TestResolveModels_OpenAIShape(t *testing.T) {
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotAuth = r.URL.Path, r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"qwen3:8b"},{"id":"llama3.2:3b"}]}`))
+	}))
+	defer srv.Close()
+
+	resp, byo, err := resolveModels(context.Background(), srv.URL+"/v1", "sk-local")
+	if err != nil {
+		t.Fatalf("resolveModels: %v", err)
+	}
+	if !byo {
+		t.Error("want byo=true for a non-Autonomous base URL")
+	}
+	if gotPath != "/v1/models" {
+		t.Errorf("asked %q, want /v1/models", gotPath)
+	}
+	if gotAuth != "Bearer sk-local" {
+		t.Errorf("Authorization = %q, want the configured key", gotAuth)
+	}
+	if len(resp.Models) != 2 || resp.Models[0].Key != "qwen3:8b" {
+		t.Fatalf("models = %+v", resp.Models)
+	}
+	if resp.DefaultModel != "qwen3:8b" {
+		t.Errorf("DefaultModel = %q, want the first listed model", resp.DefaultModel)
+	}
+	if resp.API != "openai-completions" {
+		t.Errorf("API = %q, want openai-completions", resp.API)
+	}
+}
+
+// A proxy may serve our own catalog shape verbatim; take it as-is.
+func TestResolveModels_OurCatalogShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":1,"default_model":"my-model","api":"anthropic-messages",
+			"models":[{"key":"my-model","name":"My Model","reasoning":true}]}`))
+	}))
+	defer srv.Close()
+
+	resp, byo, err := resolveModels(context.Background(), srv.URL+"/v1", "")
+	if err != nil {
+		t.Fatalf("resolveModels: %v", err)
+	}
+	if !byo {
+		t.Error("want byo=true")
+	}
+	if len(resp.Models) != 1 || resp.Models[0].Name != "My Model" {
+		t.Fatalf("models = %+v", resp.Models)
+	}
+	if !resp.Models[0].Reasoning {
+		t.Error("our catalog shape should survive verbatim, reasoning included")
+	}
+}
+
+// A BYO endpoint that cannot list models must report the error rather than
+// silently advertising models it does not serve — the caller falls back.
+func TestResolveModels_ByoErrorIsReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, byo, err := resolveModels(context.Background(), srv.URL+"/v1", "")
+	if err == nil {
+		t.Fatal("want an error from a 404 models endpoint")
+	}
+	if !byo {
+		t.Error("want byo=true so the caller can say which endpoint failed")
+	}
+}
+
+func TestResolveModels_EmptyListIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer srv.Close()
+
+	if _, _, err := resolveModels(context.Background(), srv.URL+"/v1", ""); err == nil {
+		t.Fatal("an empty model list must be an error, not an empty provider entry")
+	}
+}

--- a/runtimes/openclaw/onboarding.go
+++ b/runtimes/openclaw/onboarding.go
@@ -1,6 +1,7 @@
 package openclaw
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -966,10 +967,10 @@ func (s *OpenclawService) ensureProviderConfig() (bool, error) {
 	// Try full catalog refresh; fall back to hardcoded defaultModels (same as
 	// SetupAgent) so the provider entry is always complete even when offline.
 	// A partial entry (apiKey only, no models) would still fail on the next turn.
-	modelsResp, err := FetchModelsFromAPI()
+	modelsResp, byo, err := resolveModels(context.Background(), s.config.LLMBaseURL, s.config.LLMAPIKey)
 	if err != nil {
-		slog.Warn("ensureProviderConfig: model API fetch failed, using hardcoded fallback",
-			"component", "onboarding", "error", err)
+		slog.Warn("ensureProviderConfig: model fetch failed, using hardcoded fallback",
+			"component", "onboarding", "byo", byo, "error", err)
 		modelsResp = &domain.LLMModelsListResponse{Models: defaultModels}
 	}
 	entries := make([]any, 0, len(modelsResp.Models))
@@ -1064,8 +1065,8 @@ func (s *OpenclawService) ensureAgentDefaults() (bool, error) {
 	// autonomous portion this boot, preserve existing on-disk tuning, retry
 	// next boot.
 	var knownModels []string
-	if resp, err := FetchModelsFromAPI(); err != nil {
-		slog.Warn("ensureAgentDefaults: fetch autonomous models failed, skipping",
+	if resp, _, err := resolveModels(context.Background(), s.config.LLMBaseURL, s.config.LLMAPIKey); err != nil {
+		slog.Warn("ensureAgentDefaults: fetch models failed, skipping",
 			"component", "onboarding", "err", err)
 	} else {
 		for _, m := range resp.Models {

--- a/runtimes/openclaw/service_setup.go
+++ b/runtimes/openclaw/service_setup.go
@@ -72,13 +72,16 @@ func (s *OpenclawService) SetupAgent(data domain.SetupRequest) error {
 		slog.Debug("no existing config, starting fresh", "component", "openclaw")
 	}
 
-	// Fetch the live model catalog. On any failure fall back to the hardcoded
-	// defaultModels so setup still completes when campaign-api is unreachable.
-	slog.Debug("fetching models from API", "component", "openclaw")
-	modelsResp, err := FetchModelsFromAPI()
+	// Fetch the live model catalog: our hosted one, or — when llm_base_url is
+	// not an Autonomous host — the BYO endpoint's own `GET {base}/models`
+	// (byo_models.go). On any failure fall back to the hardcoded defaultModels
+	// so setup still completes when the catalog is unreachable.
+	slog.Debug("fetching models", "component", "openclaw")
+	modelsResp, byo, err := resolveModels(context.Background(), llmBaseURL, llmAPIKey)
 	usedFallback := false
 	if err != nil {
-		slog.Warn("setup: model API fetch failed, using hardcoded fallback", "component", "openclaw", "err", err)
+		slog.Warn("setup: model fetch failed, using hardcoded fallback",
+			"component", "openclaw", "byo", byo, "err", err)
 		modelsResp = &domain.LLMModelsListResponse{Count: len(defaultModels), Models: defaultModels}
 		usedFallback = true
 	}
@@ -120,8 +123,10 @@ func (s *OpenclawService) SetupAgent(data domain.SetupRequest) error {
 	providersMap[customProviderName] = map[string]any{
 		"baseUrl": llmBaseURL,
 		"api":     resolveAutonomousAPI(modelsResp.API),
-		"apiKey":  llmAPIKey,
-		"models":  modelsEntries,
+		// resolveAutonomousAPI keeps anthropic-messages for our gateway and
+		// takes openai-completions from a BYO catalog.
+		"apiKey": llmAPIKey,
+		"models": modelsEntries,
 	}
 	configData["models"] = modelsMap
 

--- a/scripts/bench/latency.py
+++ b/scripts/bench/latency.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Measure what a turn costs on a real robot.
+
+Every timing claim about this OS has been a code comment. This reads the flow
+log the robot already writes — one JSONL line per stage of every turn, with a
+trace id and a duration — and prints p50/p95 per stage over real turns. No
+synthetic traffic, no instrumentation: talk to your robot for a while, then run
+this.
+
+    make latency TARGET=lamp-ac82.local PASSWORD=ac82
+    make latency TARGET=lamp-ac82.local PASSWORD=ac82 DATE=2026-08-15
+    python3 scripts/bench/latency.py --file flow_2026-08-16.jsonl   # offline
+
+Output is a markdown table you can paste into docs/benchmarks.md, plus the
+one-line summary the README wants: how long a fixed command takes (the local
+`intent_match` path, no model) and how long a turn through the brain takes.
+"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+
+# Stages worth reporting, in the order a turn walks them. The node names come
+# from flow.Start/End/Log call sites in system/ and runtimes/; a node not
+# listed here is still measured and printed after these, so a renamed stage is
+# never silently dropped.
+STAGE_ORDER = [
+    "sensing_input",         # a mic/camera/sensor event opened a turn
+    "chat_input",            # a text message opened a turn
+    "voice_pipeline_start",  # the realtime voice path took it
+    "intent_match",          # the local table answered it, no model
+    "agent_call",            # the brain answered it
+    "tool_call",
+    "hw_emotion",            # markers fired at HAL
+    "hw_servo",
+    "hw_led",
+    "hw_audio",
+    "tts_send",              # the words went out
+    "chat_send",
+]
+
+
+def login(host: str, password: str, timeout: float) -> str:
+    """POST /api/login with the device password, return the bearer token."""
+    req = urllib.request.Request(
+        f"http://{host}/api/login",
+        data=json.dumps({"password": password}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = json.load(resp)
+    token = (body.get("data") or {}).get("token")
+    if not token:
+        raise SystemExit("login succeeded but returned no token")
+    return token
+
+
+def fetch_flow(host: str, token: str, date: str, timeout: float) -> list:
+    """GET /api/agent/flow-logs — the day's JSONL, one flow event per line."""
+    url = f"http://{host}/api/agent/flow-logs"
+    if date:
+        url += f"?date={date}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            raise SystemExit(f"no flow log on {host} for {date or 'today'} — talk to the robot first")
+        raise
+    return parse_lines(raw.splitlines())
+
+
+def parse_lines(lines) -> list:
+    out = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def stage_durations(events: list) -> dict:
+    """node -> [duration_ms]. Prefers the emitted duration_ms on exit events;
+    falls back to exit.ts - enter.ts for the same node and trace."""
+    durations = defaultdict(list)
+    opened = {}
+    for e in events:
+        node = e.get("node") or "?"
+        kind = e.get("kind")
+        trace = e.get("trace_id") or ""
+        key = (trace, node)
+        if kind == "enter":
+            opened[key] = e.get("ts")
+        elif kind == "exit":
+            ms = e.get("duration_ms")
+            if not ms:
+                started = opened.pop(key, None)
+                if started and e.get("ts"):
+                    ms = (e["ts"] - started) * 1000.0
+            if ms:
+                durations[node].append(float(ms))
+    return durations
+
+
+def turn_durations(events: list) -> list:
+    """End-to-end per trace: last ts - first ts, in ms."""
+    spans = defaultdict(lambda: [None, None])
+    for e in events:
+        trace, ts = e.get("trace_id"), e.get("ts")
+        if not trace or not ts:
+            continue
+        span = spans[trace]
+        span[0] = ts if span[0] is None else min(span[0], ts)
+        span[1] = ts if span[1] is None else max(span[1], ts)
+    return [(hi - lo) * 1000.0 for lo, hi in spans.values() if lo is not None and hi > lo]
+
+
+def pct(values, p):
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    idx = min(len(ordered) - 1, max(0, round((p / 100) * (len(ordered) - 1))))
+    return ordered[idx]
+
+
+def fmt(ms: float) -> str:
+    return f"{ms:.0f} ms" if ms < 1000 else f"{ms / 1000:.2f} s"
+
+
+def report(events: list, host: str, date: str) -> int:
+    if not events:
+        raise SystemExit("no flow events found — talk to the robot, then run again")
+
+    durations = stage_durations(events)
+    turns = turn_durations(events)
+    ordered = [n for n in STAGE_ORDER if n in durations]
+    ordered += sorted(n for n in durations if n not in STAGE_ORDER)
+
+    print(f"# Turn latency — {host or 'file'}, {date or 'today'}")
+    print()
+    print(f"{len(events)} flow events, {len(turns)} turns.")
+    print()
+    print("| Stage | n | p50 | p95 | max |")
+    print("|---|---:|---:|---:|---:|")
+    for node in ordered:
+        vals = durations[node]
+        print(f"| `{node}` | {len(vals)} | {fmt(pct(vals, 50))} | {fmt(pct(vals, 95))} | {fmt(max(vals))} |")
+    if turns:
+        print(f"| **whole turn** | {len(turns)} | **{fmt(pct(turns, 50))}** | **{fmt(pct(turns, 95))}** | {fmt(max(turns))} |")
+    print()
+
+    intent = durations.get("intent_match") or []
+    agent = durations.get("agent_call") or []
+    if intent:
+        print(f"Fixed commands (`intent_match`, no model): p50 {fmt(pct(intent, 50))}, p95 {fmt(pct(intent, 95))}, n={len(intent)}.")
+    if agent:
+        print(f"Through the brain (`agent_call`): p50 {fmt(pct(agent, 50))}, p95 {fmt(pct(agent, 95))}, n={len(agent)}.")
+    if not intent and not agent:
+        print("Neither `intent_match` nor `agent_call` appeared — check the node names in system/ against STAGE_ORDER.")
+    print()
+    print("Measured from the robot's own flow log (`GET /api/agent/flow-logs`), "
+          "so these are real turns, not synthetic ones. Sample size is however "
+          "many turns that robot had.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--target", help="robot host, e.g. lamp-ac82.local")
+    ap.add_argument("--password", help="device password (the 4 characters in the Wi-Fi name)")
+    ap.add_argument("--token", help="bearer token, if you already have one")
+    ap.add_argument("--date", default="", help="YYYY-MM-DD (default: today on the robot)")
+    ap.add_argument("--file", help="read a downloaded flow JSONL instead of a robot")
+    ap.add_argument("--timeout", type=float, default=15.0)
+    args = ap.parse_args()
+
+    if args.file:
+        with open(args.file) as fh:
+            return report(parse_lines(fh), args.file, args.date)
+
+    if not args.target:
+        ap.error("--target or --file is required")
+    token = args.token
+    if not token:
+        if not args.password:
+            ap.error("--password (or --token) is required to read the flow log")
+        token = login(args.target, args.password, args.timeout)
+    return report(fetch_flow(args.target, token, args.date, args.timeout), args.target, args.date)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the code half of #198.

## The bug behind "you can't run this locally"

The device already writes `llm_base_url` + `llm_api_key` into `openclaw.json` as one provider. But the model **list** always came from our hosted catalog (`ModelsAPIURL`). Point `llm_base_url` at Ollama and the brain still advertised `claude-opus-4-6` — a model that endpoint has never heard of — so every turn failed. The base URL was honored; the catalog was not.

## What changed

`resolveModels` (`runtimes/openclaw/byo_models.go`) picks the source:

| `llm_base_url` | catalog comes from |
|---|---|
| `*.autonomous.ai`, `*.autonomousdev.xyz` | the hosted catalog — unchanged |
| unset / unparseable | the hosted catalog — a malformed value can never silently switch a shipped device |
| anything else | `GET {llm_base_url}/models` on that endpoint |

The BYO listing is the OpenAI-compatible shape Ollama, vLLM, LM Studio, llama.cpp and OpenRouter all serve; our own catalog shape is also accepted, for a proxy that already speaks it.

Wired into all three places that build the provider entry: `SetupAgent`, `ensureProviderConfig`, `ensureAgentDefaults`.

Failure is soft and loud: the log names the endpoint that could not list models, and the caller keeps its existing fallback — the brain never advertises models nothing can serve.

## Tests

`go test ./runtimes/openclaw/` — host classification (including the `autonomous.ai.evil.example.com` suffix trap), URL joining (`/v1`, `/v1/`, `/v1/models`), both accepted response shapes, a 404 endpoint, and an empty list.

## What this does not do

- **Not run on a robot against a local Ollama.** Unit-tested only. That is the remaining half of #198 and the README says so.
- The phone app has no base-URL field; the browser setup wizard's AI-brain step does.
- Voice, face and mood still ride the gateway unless you also set `stt_base_url`, `tts_base_url` and `DL_BACKEND_URL` — the recipe is now in `docs/hosted.md`.