### PR TITLE
make latency: measure a turn from the robot's own flow log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ hal-clean:
 # CTS — Compatibility Test Suite (devices/contract/cts)
 # ============================================================================
 
-.PHONY: new-device push-skill skills-catalog skills-catalog-check cts cts-runtime
+.PHONY: new-device push-skill skills-catalog skills-catalog-check latency cts cts-runtime
 
 # Scaffold a new body from devices/_template/ — DEVICE.md + SOUL.md, no SAFETY.md
 # on purpose: `make cts` fails until you write the bounds for what you declared.
@@ -94,6 +94,13 @@ skills-catalog:
 
 skills-catalog-check:
 	python3 scripts/skills/gen_catalog.py --check
+
+# Measure what a turn costs on a running robot: reads its flow log and prints
+# p50/p95 per stage. PASSWORD is the 4 characters in the robot's Wi-Fi name.
+#   make latency TARGET=lamp-ac82.local PASSWORD=ac82 [DATE=2026-08-16]
+latency:
+	@test -n "$(TARGET)" || { echo "usage: make latency TARGET=lamp-xxxx.local PASSWORD=xxxx" >&2; exit 2; }
+	python3 scripts/bench/latency.py --target $(TARGET) $(if $(PASSWORD),--password $(PASSWORD),) $(if $(TOKEN),--token $(TOKEN),) $(if $(DATE),--date $(DATE),)
 
 # Copy a skill folder onto a running body. Live on the next conversation, no
 # reboot. Root SSH is off, so it lands in /tmp and moves with sudo.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,52 @@
+# What a turn costs
+
+**Nothing here is measured yet.** This page is the method and the command; the
+numbers land when someone runs it on a robot. Until then the only timings in
+this tree are code comments — `~50 ms` for a local table match in
+`system/intent/intent.go`, `3–5 s` through the agent in one comment and `8 s`
+time-to-first-token in another. Two comments that disagree are not a spec, and
+we will not publish them as one.
+
+## Method
+
+Every turn already writes a flow log: one JSONL line per stage, with a trace id
+and a duration (`system/lib/flow/`, `GET /api/agent/flow-logs`). So there is
+nothing to instrument — talk to the robot for a while, then read what it
+recorded:
+
+```bash
+make latency TARGET=lamp-ac82.local PASSWORD=ac82
+```
+
+`PASSWORD` is the four characters in the robot's Wi-Fi name. Add `DATE=YYYY-MM-DD`
+for an earlier day. To work from a downloaded log instead:
+
+```bash
+python3 scripts/bench/latency.py --file flow_2026-08-16.jsonl
+```
+
+It prints p50 / p95 / max per stage and for the whole turn, plus the two lines
+that matter: how long a fixed command takes on the local path (`intent_match`,
+no model, no network) and how long a turn through the brain takes
+(`agent_call`).
+
+These are real turns, not synthetic ones — the sample is however many turns that
+robot actually had, and the report says so.
+
+## What is still not covered
+
+- **Time to first spoken word.** The flow log records when TTS was sent, not
+  when sound left the speaker. Measuring the acoustic end needs a microphone
+  and a clap track.
+- **Power.** No watts, idle or moving. A USB meter and a fixed script would do
+  it.
+- **Memory and CPU.** `os-server` and HAL resident size, and CPU during a turn.
+  One `top` capture on a Pi 5 Lamp would settle it.
+- **Uptime.** The longest unattended run and how many OTA rollouts it survived.
+  Nobody has tracked this.
+
+## When you have numbers
+
+Paste the table under a dated heading here, say which body and which brain, and
+keep the raw JSONL next to it. Then the README can stop hedging — that is the
+whole point of this file.

--- a/docs/not-built-yet.md
+++ b/docs/not-built-yet.md
@@ -21,7 +21,7 @@ The full list behind the README's [Not built yet](../README.md#contribute). Each
 - A `ReachyMiniApp` wrapper published as a Space tagged `reachy_mini`, so Autonomous OS installs from Pollen's own dashboard app list and stops from there too.
 - Lamp's 23 teleop moves exported by `hal/record.py` as a Hub dataset in Pollen's emotion-library format (`autonomous-os/lamp-emotions-library`), so a move recorded on either body plays on both.
 - Reachy Mini Lite: the daemon runs on your laptop, so the mock body (`devices/sim/` on `reachy-mini-daemon --sim`) is also the Lite path.
-- A measured turn latency — `make latency`: end of speech → first spoken word and → first `[HW:]` POST, p50/p95 over ~20 turns on Lamp with the default brain. Today the code comments say 3–5 s in one place and 8 s time-to-first-token in another.
+- Measured numbers on hardware. `make latency` now exists (`scripts/bench/latency.py` reads a robot's flow log and reports p50/p95 per stage) but nobody has run it on a robot — see `docs/benchmarks.md`, which also lists what it does not cover: time to first spoken word at the speaker, watts idle and moving, RSS and CPU during a turn, and the longest unattended run.
 - A hosted-model table (model, task, open weights yes/no, local swap path) for the voice, face and mood models the gateway serves.
 - The contract's reference parsers (`hal/board/device.py`, `hal/safety/policy.py`) sit inside GPL `hal/`, so the Apache-licensed CTS imports GPL code; moving them under `devices/contract/` is a wanted PR.
 - A plain setup page for browser setup without the phone app (today `/setup?debug=true&device_id=…`).

--- a/scripts/bench/latency.py
+++ b/scripts/bench/latency.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Measure what a turn costs on a real robot.
+
+Every timing claim about this OS has been a code comment. This reads the flow
+log the robot already writes — one JSONL line per stage of every turn, with a
+trace id and a duration — and prints p50/p95 per stage over real turns. No
+synthetic traffic, no instrumentation: talk to your robot for a while, then run
+this.
+
+    make latency TARGET=lamp-ac82.local PASSWORD=ac82
+    make latency TARGET=lamp-ac82.local PASSWORD=ac82 DATE=2026-08-15
+    python3 scripts/bench/latency.py --file flow_2026-08-16.jsonl   # offline
+
+Output is a markdown table you can paste into docs/benchmarks.md, plus the
+one-line summary the README wants: how long a fixed command takes (the local
+`intent_match` path, no model) and how long a turn through the brain takes.
+"""
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+
+# Stages worth reporting, in the order a turn walks them. The node names come
+# from flow.Start/End/Log call sites in system/ and runtimes/; a node not
+# listed here is still measured and printed after these, so a renamed stage is
+# never silently dropped.
+STAGE_ORDER = [
+    "sensing_input",         # a mic/camera/sensor event opened a turn
+    "chat_input",            # a text message opened a turn
+    "voice_pipeline_start",  # the realtime voice path took it
+    "intent_match",          # the local table answered it, no model
+    "agent_call",            # the brain answered it
+    "tool_call",
+    "hw_emotion",            # markers fired at HAL
+    "hw_servo",
+    "hw_led",
+    "hw_audio",
+    "tts_send",              # the words went out
+    "chat_send",
+]
+
+
+def login(host: str, password: str, timeout: float) -> str:
+    """POST /api/login with the device password, return the bearer token."""
+    req = urllib.request.Request(
+        f"http://{host}/api/login",
+        data=json.dumps({"password": password}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = json.load(resp)
+    token = (body.get("data") or {}).get("token")
+    if not token:
+        raise SystemExit("login succeeded but returned no token")
+    return token
+
+
+def fetch_flow(host: str, token: str, date: str, timeout: float) -> list:
+    """GET /api/agent/flow-logs — the day's JSONL, one flow event per line."""
+    url = f"http://{host}/api/agent/flow-logs"
+    if date:
+        url += f"?date={date}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            raise SystemExit(f"no flow log on {host} for {date or 'today'} — talk to the robot first")
+        raise
+    return parse_lines(raw.splitlines())
+
+
+def parse_lines(lines) -> list:
+    out = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def stage_durations(events: list) -> dict:
+    """node -> [duration_ms]. Prefers the emitted duration_ms on exit events;
+    falls back to exit.ts - enter.ts for the same node and trace."""
+    durations = defaultdict(list)
+    opened = {}
+    for e in events:
+        node = e.get("node") or "?"
+        kind = e.get("kind")
+        trace = e.get("trace_id") or ""
+        key = (trace, node)
+        if kind == "enter":
+            opened[key] = e.get("ts")
+        elif kind == "exit":
+            ms = e.get("duration_ms")
+            if not ms:
+                started = opened.pop(key, None)
+                if started and e.get("ts"):
+                    ms = (e["ts"] - started) * 1000.0
+            if ms:
+                durations[node].append(float(ms))
+    return durations
+
+
+def turn_durations(events: list) -> list:
+    """End-to-end per trace: last ts - first ts, in ms."""
+    spans = defaultdict(lambda: [None, None])
+    for e in events:
+        trace, ts = e.get("trace_id"), e.get("ts")
+        if not trace or not ts:
+            continue
+        span = spans[trace]
+        span[0] = ts if span[0] is None else min(span[0], ts)
+        span[1] = ts if span[1] is None else max(span[1], ts)
+    return [(hi - lo) * 1000.0 for lo, hi in spans.values() if lo is not None and hi > lo]
+
+
+def pct(values, p):
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    idx = min(len(ordered) - 1, max(0, round((p / 100) * (len(ordered) - 1))))
+    return ordered[idx]
+
+
+def fmt(ms: float) -> str:
+    return f"{ms:.0f} ms" if ms < 1000 else f"{ms / 1000:.2f} s"
+
+
+def report(events: list, host: str, date: str) -> int:
+    if not events:
+        raise SystemExit("no flow events found — talk to the robot, then run again")
+
+    durations = stage_durations(events)
+    turns = turn_durations(events)
+    ordered = [n for n in STAGE_ORDER if n in durations]
+    ordered += sorted(n for n in durations if n not in STAGE_ORDER)
+
+    print(f"# Turn latency — {host or 'file'}, {date or 'today'}")
+    print()
+    print(f"{len(events)} flow events, {len(turns)} turns.")
+    print()
+    print("| Stage | n | p50 | p95 | max |")
+    print("|---|---:|---:|---:|---:|")
+    for node in ordered:
+        vals = durations[node]
+        print(f"| `{node}` | {len(vals)} | {fmt(pct(vals, 50))} | {fmt(pct(vals, 95))} | {fmt(max(vals))} |")
+    if turns:
+        print(f"| **whole turn** | {len(turns)} | **{fmt(pct(turns, 50))}** | **{fmt(pct(turns, 95))}** | {fmt(max(turns))} |")
+    print()
+
+    intent = durations.get("intent_match") or []
+    agent = durations.get("agent_call") or []
+    if intent:
+        print(f"Fixed commands (`intent_match`, no model): p50 {fmt(pct(intent, 50))}, p95 {fmt(pct(intent, 95))}, n={len(intent)}.")
+    if agent:
+        print(f"Through the brain (`agent_call`): p50 {fmt(pct(agent, 50))}, p95 {fmt(pct(agent, 95))}, n={len(agent)}.")
+    if not intent and not agent:
+        print("Neither `intent_match` nor `agent_call` appeared — check the node names in system/ against STAGE_ORDER.")
+    print()
+    print("Measured from the robot's own flow log (`GET /api/agent/flow-logs`), "
+          "so these are real turns, not synthetic ones. Sample size is however "
+          "many turns that robot had.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--target", help="robot host, e.g. lamp-ac82.local")
+    ap.add_argument("--password", help="device password (the 4 characters in the Wi-Fi name)")
+    ap.add_argument("--token", help="bearer token, if you already have one")
+    ap.add_argument("--date", default="", help="YYYY-MM-DD (default: today on the robot)")
+    ap.add_argument("--file", help="read a downloaded flow JSONL instead of a robot")
+    ap.add_argument("--timeout", type=float, default=15.0)
+    args = ap.parse_args()
+
+    if args.file:
+        with open(args.file) as fh:
+            return report(parse_lines(fh), args.file, args.date)
+
+    if not args.target:
+        ap.error("--target or --file is required")
+    token = args.token
+    if not token:
+        if not args.password:
+            ap.error("--password (or --token) is required to read the flow log")
+        token = login(args.target, args.password, args.timeout)
+    return report(fetch_flow(args.target, token, args.date, args.timeout), args.target, args.date)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Every timing claim in this repo is a code comment, and two of them disagree: `system/intent/intent.go` says `~3-5s` through the agent in one place and `8s` time-to-first-token in another. A robot OS should be able to answer "how long is a turn" with a number.

## No instrumentation needed

Every turn already writes a flow log — one JSONL line per stage, with a trace id and a duration (`system/lib/flow/`, served by `GET /api/agent/flow-logs`). `scripts/bench/latency.py` logs in with the device password, pulls the day's log, and reports:

- p50 / p95 / max per stage (`sensing_input`, `intent_match`, `agent_call`, `hw_*`, `tts_send`, …) and for the whole turn
- the two summary lines: fixed commands on the local path, and a turn through the brain

```bash
make latency TARGET=lamp-ac82.local PASSWORD=ac82
make latency TARGET=lamp-ac82.local PASSWORD=ac82 DATE=2026-08-15
python3 scripts/bench/latency.py --file flow_2026-08-16.jsonl   # offline
```

These are **real turns**, not synthetic ones — the sample is whatever that robot actually did, and the report prints the count so nobody can quote a p95 built from three turns.

## Honest about state

`docs/benchmarks.md` ships with the method and **no numbers**, because none have been measured. It also names what this does not cover: time to first spoken word at the speaker (the log records when TTS was *sent*), watts idle and moving, RSS and CPU during a turn, and the longest unattended run.

Verified against synthetic flow logs in both shapes (`duration_ms` present, and enter/exit pairs only). Not yet run against a robot — that is one command for whoever has a Lamp on a desk.