### PR TITLE
feat: refuse unsigned OTA after custody handoff

### DIFF
--- a/docs/bootstrap-ota.md
+++ b/docs/bootstrap-ota.md
@@ -293,10 +293,12 @@ release is not reinstalled on the next poll. Publishing a different version
 automatically resumes OTA for that component. Rollback itself does not need the
 metadata URL or network access.
 
-Devices without `signing_public_key` deliberately remain in legacy mode: they
-read the top-level entries and emit a warning rather than failing OTA. This is a
-compatibility bridge, not a trust guarantee; pin the public key to opt in to
-verified OTA.
+Devices without `signing_public_key` remain in legacy mode only when no
+custody handoff has closed leftover paths: they read the top-level entries and
+emit a warning rather than failing OTA. After handoff (`leftover_closed` in
+`/var/lib/lamp/custody.json`, or `ota_frozen`), unsigned metadata is refused.
+Pin the public key before F1 if the body should still receive vendor updates.
+This is a compatibility bridge, not a trust guarantee.
 
 **Wait-then-retry when unprovisioned**: if `metadata_url` is empty (device not
 set up yet), `Serve()` does not start the poll loop or healthcheck server. It logs

--- a/docs/vi/bootstrap-ota.md
+++ b/docs/vi/bootstrap-ota.md
@@ -290,9 +290,11 @@ bỏ qua đúng target đó nên release lỗi không bị cài lại ở lần 
 có version khác, OTA của component đó tự tiếp tục. Bản thân rollback không cần
 metadata URL hoặc mạng.
 
-Device không có `signing_public_key` chủ ý ở legacy mode: nó đọc component top
-level và chỉ log cảnh báo, không làm OTA lỗi. Đây là compatibility bridge, không
-phải bảo đảm trust; pin public key để bật verified OTA.
+Device không có `signing_public_key` chỉ còn legacy khi chưa handoff:
+đọc component top level và chỉ log cảnh báo. Sau handoff (`leftover_closed`
+trong `/var/lib/lamp/custody.json`, hoặc `ota_frozen`), metadata unsigned bị
+từ chối. Pin public key trước F1 nếu body vẫn cần nhận vendor update.
+Đây là compatibility bridge, không phải bảo đảm trust.
 
 **Đợi-rồi-retry khi chưa provisioning**: nếu `metadata_url` rỗng (device chưa
 setup), `Serve()` không khởi động poll loop lẫn healthcheck server. Nó log

--- a/system/bootstrap/bootstrap.go
+++ b/system/bootstrap/bootstrap.go
@@ -550,7 +550,13 @@ func (b *Bootstrap) fetchMetadataPayload(ctx context.Context) ([]byte, bool, err
 	if err != nil {
 		return nil, false, fmt.Errorf("read metadata: %w", err)
 	}
-	if strings.TrimSpace(b.cfg.SigningPublicKey) == "" {
+	cust := loadVendorCustody(b.custodyFile())
+	frozen := cust.OtaFrozen || (b.cfg != nil && b.cfg.OtaFrozen)
+	signedKey := b.cfg != nil && strings.TrimSpace(b.cfg.SigningPublicKey) != ""
+	if ok, reason := allowVendorApply(signedKey, frozen, cust.LeftoverClosed); !ok {
+		return nil, false, fmt.Errorf("vendor ota refused: %s", reason)
+	}
+	if !signedKey {
 		slog.Warn("OTA signature verification disabled: signing_public_key is not provisioned", "component", "bootstrap")
 		return data, false, nil
 	}

--- a/system/bootstrap/config/config.go
+++ b/system/bootstrap/config/config.go
@@ -28,6 +28,12 @@ type Config struct {
 	// authorizes OTA metadata for this deployment. It is provisioned locally and
 	// is never accepted from the metadata feed itself.
 	SigningPublicKey string `json:"signing_public_key" yaml:"signingPublicKey"`
+	// OtaFrozen is a local operator freeze. The owner-facing freeze also lives
+	// on the custody record (ota_frozen); either one refuses apply.
+	OtaFrozen bool `json:"ota_frozen,omitempty" yaml:"otaFrozen"`
+	// CustodyFile is the ABP custody record. After handoff leftover_closed
+	// requires a signature; ota_frozen refuses apply. Missing file is legacy.
+	CustodyFile string `json:"custody_file,omitempty" yaml:"custodyFile"`
 	// RollbackVersions records release versions explicitly rolled back by the
 	// local updater. Bootstrap skips only an exact matching target, allowing a
 	// later metadata version to resume automatic OTA without operator cleanup.
@@ -45,6 +51,7 @@ func Default() Config {
 		MetadataURL:  "",
 		PollInterval: "5m",
 		StateFile:    "/root/bootstrap/state.json",
+		CustodyFile:  "/var/lib/lamp/custody.json",
 	}
 }
 

--- a/system/bootstrap/vendor.go
+++ b/system/bootstrap/vendor.go
@@ -1,0 +1,49 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+const defaultCustodyFile = "/var/lib/lamp/custody.json"
+
+// vendorCustody is the ABP custody record fields this worker honors.
+// Other fields are ignored. After handoff leftover_closed is true; the owner
+// may freeze updates with ota_frozen.
+type vendorCustody struct {
+	LeftoverClosed bool `json:"leftover_closed"`
+	OtaFrozen      bool `json:"ota_frozen"`
+}
+
+func allowVendorApply(signed, frozen, leftoverClosed bool) (bool, string) {
+	if frozen {
+		return false, "frozen"
+	}
+	if leftoverClosed && !signed {
+		return false, "unsigned"
+	}
+	return true, ""
+}
+
+func loadVendorCustody(path string) vendorCustody {
+	if strings.TrimSpace(path) == "" {
+		path = defaultCustodyFile
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return vendorCustody{}
+	}
+	var rec vendorCustody
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return vendorCustody{}
+	}
+	return rec
+}
+
+func (b *Bootstrap) custodyFile() string {
+	if b != nil && b.cfg != nil && strings.TrimSpace(b.cfg.CustodyFile) != "" {
+		return b.cfg.CustodyFile
+	}
+	return defaultCustodyFile
+}

--- a/system/bootstrap/vendor_test.go
+++ b/system/bootstrap/vendor_test.go
@@ -1,0 +1,48 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAllowVendorApply(t *testing.T) {
+	cases := []struct {
+		name                     string
+		signed, frozen, leftover bool
+		ok                       bool
+		reason                   string
+	}{
+		{"lab unsigned before handoff", false, false, false, true, ""},
+		{"signed after handoff", true, false, true, true, ""},
+		{"unsigned after handoff", false, false, true, false, "unsigned"},
+		{"frozen signed", true, true, true, false, "frozen"},
+		{"frozen unsigned", false, true, false, false, "frozen"},
+	}
+	for _, c := range cases {
+		ok, reason := allowVendorApply(c.signed, c.frozen, c.leftover)
+		if ok != c.ok || reason != c.reason {
+			t.Fatalf("%s: got (%v, %q) want (%v, %q)", c.name, ok, reason, c.ok, c.reason)
+		}
+	}
+}
+
+func TestLoadVendorCustodyReadsABPRecord(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custody.json")
+	body := []byte(`{"owner":"Pat Demo","leftover_closed":true,"ota_frozen":true,"bindable_faces":["pat-face"]}`)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rec := loadVendorCustody(path)
+	if !rec.LeftoverClosed || !rec.OtaFrozen {
+		t.Fatalf("did not honor ABP custody flags: %+v", rec)
+	}
+}
+
+func TestLoadVendorCustodyMissingIsOpen(t *testing.T) {
+	rec := loadVendorCustody(filepath.Join(t.TempDir(), "missing.json"))
+	if rec.LeftoverClosed || rec.OtaFrozen {
+		t.Fatalf("missing custody file must stay legacy-open: %+v", rec)
+	}
+}


### PR DESCRIPTION
"""Sealed vendor OTA after custody handoff.

After leftover_closed, unsigned metadata is refused. Owner freeze
(ota_frozen on the custody record or bootstrap.json) refuses even a
signed key. Lab devices with no custody file stay on the unsigned
bridge. Vendor cannot pull camera.

## Test plan
- [x] `go test ./system/bootstrap/` in golang:1.24
- [ ] Live lamp: leftover_closed + no signing key → OTA refuses
- [ ] Live lamp: leftover_closed + pinned key → signed apply, leftover stays dead
"""
