### PR TITLE
Keep a working realtime turn alive instead of killing it on the silent-turn watchdog

### DIFF
--- a/docs/realtime-voice.md
+++ b/docs/realtime-voice.md
@@ -786,6 +786,18 @@ queue-based contract:
   `OutputBase` until a `TurnDoneEvent`, or until no event arrives within
   `HAL_REALTIME_RECV_QUEUE_TIMEOUT_S` — default 8 s — which ends the turn quietly
   so a silent/no-response turn falls back to the main agent without long dead-air).
+  That gap window alone cannot tell a model that chose not to answer from one
+  that is **working**: a turn grounded with Google Search emits no output at all
+  until the search returns, and ending it there throws away an answer the model
+  was about to give, hands the turn to the far slower main agent, and still pays
+  for the abandoned search (whose chunks land in the session context and are
+  re-billed on every later turn). The two are not alike on the wire, though — a
+  working turn keeps sending messages that never reach the queue (thought parts,
+  grounding metadata, usage-only frames), while an abandoned one goes completely
+  quiet. Providers call `note_server_activity()` on every inbound message, and
+  `receive()` keeps the turn alive past the gap window while those keep arriving,
+  up to `HAL_REALTIME_TURN_MAX_SILENCE_S` (default 20 s) for the whole turn.
+  A turn with no inbound traffic at all still ends on the first gap window.
 - `available` ⇔ the websocket/session is connected (`_connected`).
 
 ### OpenAI connection safety
@@ -1231,6 +1243,7 @@ is a top-level `config.json` flag:
 | `HAL_REALTIME_PROVIDER` | `gemini` | `none` \| `gemini` \| `openai` \| `qwen` |
 | `HAL_REALTIME_TURN_DETECTION` | `off` | `server_vad` \| `semantic_vad` \| `off` (Gemini: off = manual activity detection) |
 | `HAL_REALTIME_RECV_QUEUE_TIMEOUT_S` | `8.0` | Max seconds `receive()` waits for the next output event before ending a silent turn (fallback to main agent) |
+| `HAL_REALTIME_TURN_MAX_SILENCE_S` | `20.0` | Ceiling on how long one turn may stay silent while the server keeps sending messages. `receive()` extends a turn past `HAL_REALTIME_RECV_QUEUE_TIMEOUT_S` only while inbound traffic proves the model is still working (a grounded search emits nothing until it returns); this stops a server that chatters without ever producing output from hanging the turn. `0` disables the keep-alive and restores the plain gap watchdog. |
 | `HAL_REALTIME_LOOK_RECV_TIMEOUT_S` | `20.0` | Silent-turn watchdog used instead of the default for turns where a `look` fired (per-turn, via `extend_recv_timeout()`). Gemini's forced thinking over a text-dense frame can stay silent >8 s right before the answer — the default watchdog was killing those turns. Raising it delays the look-frame handoff, so keep `HAL_GEMINI_VISION_HANDOFF_MAX_AGE_S` above it |
 | `HAL_REALTIME_REQUIRE_TRANSCRIPT` | `true` | Never commit an empty-STT turn to the model. A final transcript containing only punctuation or symbols (for example `.`) is normalized to empty before gaze, speaker-ID, realtime, dispatch, or follow-up refresh; it cannot create a `voice_followup`. Real speech that nova-3 missed (short utterances) is voiced and passes the VAD/Silero guards, so committing its raw audio makes the model invent a reply to silence (a generic greeting, often with a name nobody said). When `true`, any empty-STT turn is dropped regardless of duration/voicing — silence beats a wrong reply. Set `false` to fall back to the Silero-gated audio-only path below. |
 | `HAL_REALTIME_AI_REJECT_FILTER` | `true` | Registers `reject_turn` and enables the isolated `should_drop_realtime_rejection()` policy gate. An explicit tool call drops a transcript before OS dispatch; a silent model completion, timeout, or error still falls back to the main agent. The separate deterministic noise guard is also terminal for audio it already classified as non-speech. Set `false` to disable this experimental AI filter without changing the rest of realtime routing. |

--- a/docs/vi/realtime-voice_vi.md
+++ b/docs/vi/realtime-voice_vi.md
@@ -752,6 +752,17 @@ trên queue:
   `OutputBase` đến khi gặp `TurnDoneEvent`, hoặc khi không có event nào trong
   `HAL_REALTIME_RECV_QUEUE_TIMEOUT_S` — mặc định 8 s — để kết thúc lượt im lặng
   và fallback sang main agent mà không bị dead-air dài).
+  Riêng cửa sổ đó không phân biệt được model *quyết định không trả lời* với model
+  *đang làm việc*: một lượt có Google Search grounding không phát ra output nào
+  cho tới khi search về, và cắt ở đó là vứt đi câu trả lời model sắp nói, đẩy
+  lượt xuống main agent chậm hơn nhiều, mà vẫn phải trả tiền cho cái search bị bỏ
+  (chunk của nó rơi vào context session và bị tính lại ở mọi lượt sau). Nhưng
+  trên đường truyền thì hai ca này khác nhau: lượt đang làm việc vẫn liên tục gửi
+  message không bao giờ vào queue (thought part, grounding metadata, frame chỉ có
+  usage), còn lượt bị bỏ thì im hoàn toàn. Provider gọi `note_server_activity()`
+  ở mọi message nhận được, và `receive()` giữ lượt sống quá cửa sổ gap chừng nào
+  còn message về, tối đa `HAL_REALTIME_TURN_MAX_SILENCE_S` (mặc định 20 s) cho cả
+  lượt. Lượt không có message nào về vẫn kết thúc ngay ở cửa sổ gap đầu tiên.
 - `available` ⇔ websocket/session đã connect (`_connected`).
 
 ### An toàn connection của OpenAI
@@ -1176,6 +1187,7 @@ trong `config.json`:
 | `HAL_REALTIME_PROVIDER` | `gemini` | `none` \| `gemini` \| `openai` \| `qwen` |
 | `HAL_REALTIME_TURN_DETECTION` | `off` | `server_vad` \| `semantic_vad` \| `off` (Gemini: off = activity detection thủ công) |
 | `HAL_REALTIME_RECV_QUEUE_TIMEOUT_S` | `8.0` | Số giây tối đa `receive()` chờ output event kế tiếp trước khi kết thúc lượt im lặng (fallback sang main agent) |
+| `HAL_REALTIME_TURN_MAX_SILENCE_S` | `20.0` | Trần thời gian một lượt được im lặng khi server vẫn còn gửi message. `receive()` chỉ kéo dài quá `HAL_REALTIME_RECV_QUEUE_TIMEOUT_S` khi lưu lượng vào chứng minh model còn đang làm việc (search grounding không phát output tới khi xong); trần này chặn trường hợp server nói liên tục mà không bao giờ ra output. `0` tắt cơ chế giữ lượt, quay về watchdog gap thuần. |
 | `HAL_REALTIME_LOOK_RECV_TIMEOUT_S` | `20.0` | Watchdog im-lặng dùng thay mặc định cho turn có `look` (theo từng turn, qua `extend_recv_timeout()`). Gemini bị ép thinking trên frame dày chữ có thể im >8 s ngay trước khi trả lời — watchdog mặc định giết nhầm mấy turn đó. Nâng nó lên là hoãn luôn handoff frame `look`, nên phải giữ `HAL_GEMINI_VISION_HANDOFF_MAX_AGE_S` cao hơn |
 | `HAL_REALTIME_REQUIRE_TRANSCRIPT` | `true` | Không bao giờ commit turn empty-STT lên model. Final transcript chỉ có dấu câu/ký hiệu (ví dụ `.`) được chuẩn hoá thành empty trước gaze, speaker-ID, realtime, dispatch hay refresh follow-up; nó không thể tạo `voice_followup`. Giọng thật mà nova-3 miss (câu ngắn) vẫn là voiced nên qua hết guard VAD/Silero, commit audio thô khiến model bịa câu trả lời cho khoảng im lặng (lời chào chung chung, thường kèm tên không ai nói). Khi `true`, mọi turn empty-STT bị bỏ bất kể duration/voicing — im còn hơn trả lời sai. Đặt `false` để quay về đường audio-only gated bằng Silero bên dưới. |
 | `HAL_REALTIME_AI_REJECT_FILTER` | `true` | Đăng ký `reject_turn` và bật policy gate tách riêng `should_drop_realtime_rejection()`. Tool call rõ ràng sẽ bỏ transcript trước OS dispatch; model im lặng, timeout hay lỗi vẫn fallback sang main agent. Noise guard deterministic riêng cũng terminal cho audio mà nó đã phân loại là không phải tiếng nói. Đặt `false` để tắt filter AI thử nghiệm này mà không đổi phần routing realtime còn lại. |

--- a/hal/config.py
+++ b/hal/config.py
@@ -727,6 +727,23 @@ REALTIME_RECV_QUEUE_TIMEOUT_S: float = float(
 # watchdog gives up: keep REALTIME_GEMINI_VISION_HANDOFF_MAX_AGE_S comfortably
 # above it, or the frame expires before it can be handed off (that regression
 # ran from 2026-07-06 to 2026-08-24 — see that setting's comment).
+# Ceiling on how long ONE turn may stay silent while the server is still
+# talking to us. The gap watchdog above ends a turn that produces no output,
+# which is right for a model that chose not to answer and wrong for one that is
+# busy — a Google Search grounding emits nothing until the search returns, and
+# ending the turn there hands a question the model was about to answer to the
+# main agent instead (minutes, not seconds), while the abandoned search is
+# billed anyway and its chunks still land in the session context.
+#
+# receive() therefore keeps a turn alive past the gap window as long as inbound
+# messages keep arriving (see note_server_activity) — this is the hard stop on
+# that, so a server that chatters without ever producing output still cannot
+# hang the turn forever. Must stay above the slowest grounded turn worth
+# waiting for; measured on lamp-0c89 04/09/2026 a search landed 9.5s into the
+# turn. 0 disables the keep-alive entirely (back to the plain gap watchdog).
+REALTIME_TURN_MAX_SILENCE_S: float = float(
+    os.environ.get("HAL_REALTIME_TURN_MAX_SILENCE_S", "20.0")
+)
 REALTIME_LOOK_RECV_TIMEOUT_S: float = float(
     os.environ.get("HAL_REALTIME_LOOK_RECV_TIMEOUT_S", "20.0")
 )

--- a/hal/realtime/voice_agent/base.py
+++ b/hal/realtime/voice_agent/base.py
@@ -3,6 +3,7 @@
 import logging
 import queue
 import threading
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Generator
 from typing import Any
@@ -55,6 +56,9 @@ class VoiceAgentBase(ABC):
         # (device-observed 2026-07-06 — watchdog killed the turn seconds
         # after express_emotion fired). Cleared when receive() exits.
         self._recv_timeout_override_s: float | None = None
+        # monotonic() of the last message the SERVER sent us, whatever it was.
+        # Liveness, not output — see note_server_activity / receive().
+        self._last_server_msg_at: float = 0.0
 
     @property
     def available(self) -> bool:
@@ -179,6 +183,20 @@ class VoiceAgentBase(ABC):
         """
         self._skip_stale_turn_done = True
 
+    def note_server_activity(self) -> None:
+        """Record that the server just sent us something, output or not.
+
+        The silent-turn watchdog in receive() cannot tell a model that decided
+        not to answer from one that is busy — grounding a search, thinking —
+        because both look identical from the queue: nothing arrives. They are
+        NOT identical on the wire, though. A working turn keeps producing
+        messages we deliberately drop before the queue (thought parts, grounding
+        metadata, usage-only frames), while a turn the model abandoned goes
+        completely quiet. Providers call this on every inbound message so the
+        watchdog can use that difference instead of guessing.
+        """
+        self._last_server_msg_at = time.monotonic()
+
     def extend_recv_timeout(self, seconds: float) -> None:
         """Raise the silent-turn watchdog for the CURRENT turn only.
 
@@ -200,6 +218,7 @@ class VoiceAgentBase(ABC):
         # (GeneratorExit) — the extended watchdog must survive into the
         # replayed turn, so only a normal end clears the override.
         turn_ended = False
+        turn_started: float = time.monotonic()
         try:
             while True:
                 recv_timeout: float = (
@@ -209,12 +228,38 @@ class VoiceAgentBase(ABC):
                 try:
                     event = self._recv_queue.get(timeout=recv_timeout)
                 except queue.Empty:
-                    # No output within the gap window — almost always the model
-                    # staying silent on a noise / non-directed turn (correct), not an
-                    # error. End the turn quietly so it can fall back to the main agent.
+                    # No OUTPUT within the gap window. Usually the model staying
+                    # silent on a noise / non-directed turn, which is correct —
+                    # end quietly and let the main agent have it.
+                    #
+                    # But a turn can also be silent because it is WORKING: a
+                    # Google Search grounding produces no output until the search
+                    # returns, and killing it here throws away an answer the
+                    # model was about to give and forwards the turn to the main
+                    # agent, which is far slower (and the abandoned search is
+                    # still billed, and its chunks still land in the session
+                    # context). Tell the two apart by liveness on the wire: a
+                    # working turn keeps sending messages we drop before the
+                    # queue, a silent one sends nothing at all.
+                    since_msg: float = time.monotonic() - self._last_server_msg_at
+                    waited: float = time.monotonic() - turn_started
+                    if (
+                        self._last_server_msg_at > 0
+                        and since_msg < recv_timeout
+                        and waited < app_config.REALTIME_TURN_MAX_SILENCE_S
+                    ):
+                        logger.info(
+                            "receive() no output for %.1fs but the server is still "
+                            "talking (last message %.1fs ago, %.1fs into the turn) "
+                            "— keeping the turn alive",
+                            recv_timeout, since_msg, waited,
+                        )
+                        continue
                     logger.info(
-                        "receive() got no output within %.1fs — ending turn (model stayed silent)",
+                        "receive() got no output within %.1fs — ending turn "
+                        "(model stayed silent; last server message %.1fs ago)",
                         recv_timeout,
+                        since_msg if self._last_server_msg_at > 0 else -1.0,
                     )
                     turn_ended = True
                     break

--- a/hal/realtime/voice_agent/gemini_live.py
+++ b/hal/realtime/voice_agent/gemini_live.py
@@ -492,6 +492,12 @@ class GeminiLiveAgent(VoiceAgentBase):
         self._first_audio_received = False
 
         async for message in self._session.receive():
+            # Liveness for the silent-turn watchdog: most of what arrives here
+            # never reaches _recv_queue (thought parts, grounding metadata,
+            # usage-only frames), and without this a turn that is busy grounding
+            # is indistinguishable from one the model abandoned. See
+            # RealtimeVoiceAgent.note_server_activity.
+            self.note_server_activity()
             if message.usage_metadata:
                 # Per-turn token bill. prompt_token_count is the input CONTEXT
                 # billed this turn — it grows as a long-lived session accumulates

--- a/hal/test/test_recv_liveness.py
+++ b/hal/test/test_recv_liveness.py
@@ -1,0 +1,76 @@
+"""Silent-turn watchdog: a turn that is still working must not be killed.
+
+A grounded turn produces no output until its search returns, which is
+indistinguishable from a model that chose not to answer — unless you look at
+whether the server is still sending anything at all.
+"""
+
+import threading
+import time
+
+from hal import config as app_config
+from hal.realtime.models import OutputEvent, TextOutput
+from hal.realtime.voice_agent.base import VoiceAgentBase
+
+
+class _Agent(VoiceAgentBase):
+    """Minimal concrete agent — receive() is all this exercises."""
+
+    @property
+    def sample_rate(self) -> int:
+        return 16000
+
+    def _do_connect(self): ...
+    def _do_disconnect(self): ...
+    def _send_loop(self): ...
+    def _recv_loop(self): ...
+
+
+def _fast_watchdog(monkeypatch, gap=0.15, cap=5.0):
+    monkeypatch.setattr(app_config, "REALTIME_RECV_QUEUE_TIMEOUT_S", gap)
+    monkeypatch.setattr(app_config, "REALTIME_TURN_MAX_SILENCE_S", cap)
+
+
+def test_a_fully_silent_turn_still_ends(monkeypatch):
+    _fast_watchdog(monkeypatch)
+    agent = _Agent()
+    assert list(agent.receive()) == []
+
+
+def test_a_server_still_sending_keeps_the_turn_alive(monkeypatch):
+    """No output for several gap windows, but messages keep arriving."""
+    _fast_watchdog(monkeypatch)
+    agent = _Agent()
+
+    def busy():
+        for _ in range(6):
+            time.sleep(0.05)
+            agent.note_server_activity()
+        agent._recv_queue.put(OutputEvent(output=TextOutput(text="grounded answer")))
+
+    threading.Thread(target=busy, daemon=True).start()
+    assert [o.text for o in agent.receive()] == ["grounded answer"]
+
+
+def test_the_cap_stops_a_server_that_never_produces_output(monkeypatch):
+    _fast_watchdog(monkeypatch, gap=0.1, cap=0.4)
+    agent = _Agent()
+    stop = threading.Event()
+
+    def chatter():
+        while not stop.is_set():
+            agent.note_server_activity()
+            time.sleep(0.02)
+
+    threading.Thread(target=chatter, daemon=True).start()
+    started = time.monotonic()
+    assert list(agent.receive()) == []
+    stop.set()
+    assert time.monotonic() - started < 3.0
+
+
+def test_zero_cap_restores_the_plain_gap_watchdog(monkeypatch):
+    _fast_watchdog(monkeypatch, gap=0.1, cap=0.0)
+    agent = _Agent()
+    agent.note_server_activity()
+    assert list(agent.receive()) == []


### PR DESCRIPTION
## The bug

`receive()` ends a turn when no output arrives within `HAL_REALTIME_RECV_QUEUE_TIMEOUT_S` (8s) and lets it fall back to the main agent. That is right for a model that decided not to answer, and wrong for one that is **working**: a turn grounded with Google Search produces no output at all until the search returns.

When that fires on a grounded turn we lose three ways at once:

- the answer the model was about to give is thrown away,
- the question goes to the main agent instead, which is far slower (a delegated turn measured minutes, against seconds for a realtime one),
- the abandoned search is billed anyway, and its grounding chunks still land in the session context, where they are re-billed as input on every later turn of that session.

## Why it could not tell them apart

The two cases look identical **from the queue** — nothing arrives — but they are not identical **on the wire**. A working turn keeps sending messages that we deliberately drop before the queue: thought parts (`part.thought`), grounding metadata, usage-only frames. A turn the model abandoned sends nothing at all.

The watchdog only ever saw the queue, so the evidence that separates the two cases was being discarded one layer below it.

## The fix

`VoiceAgentBase.note_server_activity()` records the arrival of **any** inbound message, output or not; `gemini_live._async_receive_turn()` calls it at the top of its receive loop. On a gap timeout `receive()` now checks that liveness: if the server is still talking, the turn is kept alive, bounded by `HAL_REALTIME_TURN_MAX_SILENCE_S` (default 20s) for the whole turn so a server that chatters without ever producing output still cannot hang it. A turn with no inbound traffic at all still ends on the first gap window, so the fast fallback for a genuinely silent or dead session is unchanged.

This is the automatic version of the pattern `look` already uses via `extend_recv_timeout()` — that one has to know in advance that a slow turn is coming; this one reads it off the wire.

`HAL_REALTIME_TURN_MAX_SILENCE_S=0` disables the keep-alive and restores the plain gap watchdog.

## Verification

Unit tests (`hal/test/test_recv_liveness.py`), run against the HAL venv on lamp-0c89 — the device image ships no `pytest`, so the assertions were driven directly; 4/4 pass:

- a fully silent turn still ends,
- a server that keeps sending keeps the turn alive and its output is delivered,
- the cap stops a server that chatters without ever producing output,
- `0` restores the old behaviour.

On the device, with `HAL_REALTIME_RECV_QUEUE_TIMEOUT_S` temporarily lowered to 2s so any grounded turn crosses the window (a grounded turn on this device answers at ~4s, under the real 8s window, so it would not otherwise be observable), two real voice turns:

```
10:03:30.106  Entering realtime flow — committing audio
10:03:32.142  receive() no output for 2.0s but the server is still talking
              (last message 1.9s ago, 2.0s into the turn) — keeping the turn alive
10:03:33.718  first output +3.58s after commit
10:03:33.961  First sentence -> speak (+3.82s): "I've got some highlights!"
10:03:39.848  route=realtime_handled -> realtime (main agent stays silent)
```

Under the old code this turn died at `10:03:32.142` and went to the main agent. The second turn reproduced it (`last message 0.0s ago`, answered at +3.76s). This also settles the open question behind the design: Gemini **does** keep sending messages while it works — roughly one every 2s here — so the liveness signal is real and no blunt timeout raise is needed.

The test override was reverted afterwards (`.env` restored from backup, backup deleted, HAL restarted, `RECV_QUEUE_TIMEOUT` back to the 8.0 default).

## Not in this PR

The same traces show the model speaking 3–6s *before* its grounding metadata arrives, with `chunks=0` on 2 of 3 grounded turns — so the spoken answer is not actually grounded in the search. That is a prompt-policy question (make the model wait for the search before it speaks), not a transport one, and it is left alone here.