### PR TITLE
Make object tracking work off the local model, not just faces

### DIFF
--- a/hal/drivers/tracking/constants.py
+++ b/hal/drivers/tracking/constants.py
@@ -308,9 +308,20 @@ SERVO_MIN_CONF = 0.25
 # (the tracker still has a solid lock — common when face moves fast and YuNet
 # misses a few frames). Below this → freeze servo, wait for detector.
 TRACKER_TRUST_CONF = 0.4
-# Detector-gated trust window (seconds). With redetect=1.5s this allows ~1
-# missed redetect before the tracker is treated as suspect.
+# Detector-gated trust window (seconds) — a FLOOR, not the value used. The
+# loop sizes the real window from the detector's measured latency
+# (YOLO_REDETECT_S + 2 x latency + TRUST_MARGIN_S), because the same loop is
+# served by detectors three orders of magnitude apart: YuNet at ~30ms, local
+# YOLO at ~0.5s, the remote open-vocab model at 1.3-3s. A single constant is
+# only ever correct for one of them, and 2.5 was correct for the fastest — so
+# every slower target sat in WAIT-YOLO with the object plainly in frame.
+# This floor still applies when the detector is fast, keeping face behaviour
+# exactly as it was.
 TRUST_TRACKER_S = 2.5
+# Slack on top of one redetect cycle, so ordinary scheduling jitter (a frame
+# that arrived late, a detect thread that started a beat behind) does not read
+# as a missed confirm.
+TRUST_MARGIN_S = 0.5
 # No detector confirm at all for this long → the lock is a ghost, stop.
 STOP_NO_YOLO_S = 20.0
 

--- a/hal/drivers/tracking/detection.py
+++ b/hal/drivers/tracking/detection.py
@@ -31,19 +31,35 @@ from hal.drivers.tracking.frame_utils import downscale, scale_bbox
 
 logger = logging.getLogger(__name__)
 
-# Local YOLOv8n (COCO) — ~300ms/frame on Allwinner A523 CPU. Used by default
-# when target maps to a COCO class. Falls back to remote API for open-vocab.
-# Weights are checked into the repo next to this file so deploy is one rsync
-# and the Pi never needs internet at boot to start tracking. Source:
+# Local YOLOv8n (COCO). Used by default when target maps to a COCO class;
+# falls back to the remote API for open-vocab. Weights are checked into the
+# repo next to this file so deploy is one rsync and the Pi never needs internet
+# at boot to start tracking. Source:
 # https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.pt
-_LOCAL_MODEL_PATH = os.path.join(os.path.dirname(__file__), "models", "yolov8n.pt")
-# Inference size for local YOLO. Kept at 320: on the Allwinner A523 CPU, 640
-# pushed inference to 1.3–2.9s/call, so YOLO could not confirm within the
-# trust window (yolo_age climbed past 20s) and the tracker sat in BLOAT-HOLD
-# pointing the wrong way. 320 keeps detection ~260ms — fast enough to correct
-# ViT drift every redetect. (Small/far objects that 320 misses are better
-# handled by the remote open-vocab detector than by a slower local imgsz.)
-_LOCAL_IMGSZ = 320
+#
+# ONNX is preferred over the .pt. Same weights, same ultralytics API (the
+# exported model carries its class names, so `.names` and every gate below are
+# unchanged) — but the .pt path runs PyTorch on the CPU, which is the slowest
+# way to execute this graph on a Cortex-A55. onnxruntime is already a HAL
+# dependency (YuNet and the ViT tracker are ONNX too); YOLO was the last thing
+# still on torch. Export with `hal/scripts/export_yolo_onnx.py`; the .pt stays
+# as the fallback so a device that has not taken the new model yet still sees.
+_LOCAL_MODEL_ONNX = os.path.join(os.path.dirname(__file__), "models", "yolov8n.onnx")
+_LOCAL_MODEL_PT = os.path.join(os.path.dirname(__file__), "models", "yolov8n.pt")
+# Inference size for local YOLO. YOLO letterboxes whatever it is handed down to
+# imgsz, so this single number IS the detector's effective resolution: at 320
+# against the lamp's 1280-wide camera, everything reaches the model at 0.25x.
+# A face or a person survives that; a cup, a book or a phone on the desk arrive
+# ~30px wide and are simply not there to be found — which is what made every
+# small-object session miss locally, fall through to the ~1.3-3s remote, and
+# freeze the servo on the trust gate.
+#
+# 448 puts the same cup at ~42px. It costs ~2x the pixels of 320, which is what
+# the ONNX runtime buys back; 640 stays out of reach (it measured 1.3-2.9s/call
+# on torch and pushed yolo_age past the trust window entirely).
+#
+# Re-export the ONNX if you change this — the export bakes the input size in.
+_LOCAL_IMGSZ = 448
 
 # YuNet face detector (OpenCV built-in). Lighter than InsightFace, ~30ms/frame on
 # Pi, no extra dependency. Used for target='face' so we don't fall back to the
@@ -129,18 +145,24 @@ def _get_local_yolo():
     with _local_yolo_lock:
         if _local_yolo is not None:
             return _local_yolo
-        if not os.path.exists(_LOCAL_MODEL_PATH):
+        # Prefer the ONNX export; fall back to the .pt so a device that has
+        # not taken the new model yet keeps detecting (slower, not blind).
+        path = _LOCAL_MODEL_ONNX if os.path.exists(_LOCAL_MODEL_ONNX) else _LOCAL_MODEL_PT
+        if not os.path.exists(path):
             logger.error(
                 "YOLO weights missing at %s — re-deploy from repo (file is checked in). "
                 "Falling back to remote YOLOWorld until present.",
-                _LOCAL_MODEL_PATH,
+                path,
             )
             return None
         try:
             from ultralytics import YOLO
-            logger.info("Loading local YOLO model from %s", _LOCAL_MODEL_PATH)
+            logger.info("Loading local YOLO model from %s (imgsz=%d)", path, _LOCAL_IMGSZ)
             t0 = time.perf_counter()
-            _local_yolo = YOLO(_LOCAL_MODEL_PATH)
+            # task= is required for the ONNX path: the export carries class
+            # names but not the task, and without it ultralytics logs a guess
+            # warning on every boot.
+            _local_yolo = YOLO(path, task="detect")
             # Warm-up inference to trigger model compile/cache.
             import numpy as _np
             _local_yolo(_np.zeros((480, 640, 3), dtype=_np.uint8),
@@ -389,7 +411,8 @@ class ObjectDetector:
 
     def detect(self, frame: npt.NDArray[np.uint8], target: str,
                strict: bool = True,
-               min_conf: Optional[float] = None) -> Optional[Tuple[int, int, int, int]]:
+               min_conf: Optional[float] = None,
+               allow_remote_fallback: bool = True) -> Optional[Tuple[int, int, int, int]]:
         """Detect an object by name. Tries local YOLOv8n first (fast, COCO classes),
         falls back to remote YOLOWorld API for open-vocab targets.
 
@@ -399,6 +422,13 @@ class ObjectDetector:
         floor — a fast-moving phone often reconfirms at conf 0.2–0.3, and the
         reinit gates (area median, IoU, center distance) already protect the
         lock; cross-class disambiguation stays on in both modes.
+
+        allow_remote_fallback=False keeps a target that HAS a local COCO path
+        on that path when local comes up empty, instead of spending 1.3-3s on
+        the remote detector. It does not affect an open-vocab target: with no
+        local path there is nothing to fall back FROM, and remote stays the
+        only detector. See the fallback block below for why the caller wants
+        this mid-session.
 
         min_conf raises the floor for THIS call only. The global
         DETECT_MIN_CONFIDENCE is 0.15, deliberately loose so the tracker keeps
@@ -484,6 +514,20 @@ class ObjectDetector:
                     # Local missed. Fall back to remote open-vocab YOLOWorld for
                     # small/far objects local can't see — but throttle it so a
                     # truly-unseeable target doesn't hit remote on every redetect.
+                    if not allow_remote_fallback:
+                        # Mid-session redetect on a COCO target. The tracker
+                        # already holds a lock; this call only has to confirm
+                        # it, and a single local miss (the object turned, motion
+                        # blur, one bad frame) is ordinary. Going to remote here
+                        # is actively harmful rather than merely wasteful: the
+                        # detect thread is single-flight, so one fallback
+                        # stretches a ~0.5s confirm cycle to ~3s, which pushes
+                        # yolo_age past the loop's trust window and freezes the
+                        # servo mid-follow. The object is still in frame and the
+                        # camera stops dead — the exact "it doesn't track
+                        # objects" symptom. Local is the authority for a class
+                        # it was trained on; let the next redetect confirm.
+                        return None
                     now_fb = time.perf_counter()
                     if now_fb - self._last_remote_attempt_t < REMOTE_FALLBACK_MIN_INTERVAL:
                         return None

--- a/hal/drivers/tracking/tracker_service.py
+++ b/hal/drivers/tracking/tracker_service.py
@@ -53,6 +53,26 @@ MAX_TRACKING_RETRIES = 4
 _TRACKING_MOTORS = ("base_yaw", "base_pitch", "elbow_pitch", "wrist_pitch")
 
 
+def trust_window_s(detect_latency_s: float) -> float:
+    """How long to go without a detector confirm before distrusting the tracker.
+
+    Sized from the detector's MEASURED cost rather than fixed, because one loop
+    is served by detectors three orders of magnitude apart: YuNet at ~30ms,
+    local YOLO at ~0.5s, the remote open-vocab model at 1.3-3s. One redetect
+    interval plus two detections is the shortest gap a single missed confirm can
+    produce, so anything tighter reads an ordinary miss as a lost lock — which
+    is what parked the servo in WAIT-YOLO with the object plainly in frame on
+    every target the face detector does not serve.
+
+    C.TRUST_TRACKER_S remains the floor, so a fast detector keeps exactly the
+    behaviour it had.
+    """
+    return max(
+        C.TRUST_TRACKER_S,
+        C.YOLO_REDETECT_S + 2.0 * detect_latency_s + C.TRUST_MARGIN_S,
+    )
+
+
 @dataclass
 class TrackingState:
     """Mutable state for the active tracking session."""
@@ -101,9 +121,11 @@ class TrackerService:
         }
 
     def detect_object(self, frame: npt.NDArray[np.uint8], target: str,
-                      strict: bool = True) -> Optional[Tuple[int, int, int, int]]:
+                      strict: bool = True,
+                      allow_remote_fallback: bool = True) -> Optional[Tuple[int, int, int, int]]:
         """Detect an object by name — see detection.ObjectDetector.detect."""
-        return self._detector.detect(frame, target, strict=strict)
+        return self._detector.detect(frame, target, strict=strict,
+                                     allow_remote_fallback=allow_remote_fallback)
 
     def start(
         self,
@@ -363,6 +385,10 @@ class TrackerService:
         last_yolo_t = track_start_t
         # Detector-gated trust: skip servo if YOLO hasn't confirmed target recently.
         last_yolo_confirm_t = track_start_t
+        # Measured detector cost (EMA, seconds), maintained by _fire_yolo. 0
+        # until the first redetect returns; the trust window falls back to the
+        # constant floor until then.
+        detect_latency_s = 0.0
         fps_t0 = track_start_t
 
         # Queue for background YOLO results (maxsize=1 → latest result only).
@@ -410,9 +436,21 @@ class TrackerService:
             return True
 
         def _fire_yolo(frame_snap: npt.NDArray[np.uint8]) -> None:
+            nonlocal detect_latency_s
             t0_yolo = time.perf_counter()
-            result = self.detect_object(frame_snap, state.target_label, strict=False)
+            # No remote fallback on a routine redetect: this call confirms a
+            # lock we already have, and a remote round-trip would stall the
+            # single-flight detect thread long enough to trip the trust gate
+            # below. Recovery paths (_do_retry, session seeding) still allow it.
+            result = self.detect_object(frame_snap, state.target_label, strict=False,
+                                        allow_remote_fallback=False)
             t_yolo_ms = (time.perf_counter() - t0_yolo) * 1000
+            # EMA of what this detector actually costs, which is what sizes the
+            # trust window (see trust_window_s). Measured rather than declared:
+            # the same code serves YuNet (~30ms), local YOLO (~0.5s) and the
+            # remote model (~2s), and a constant tuned for one starves the others.
+            detect_latency_s = (0.7 * detect_latency_s + 0.3 * (t_yolo_ms / 1000.0)
+                                if detect_latency_s > 0 else t_yolo_ms / 1000.0)
             logger.info("[yolo-bg] detect=%.0fms result=%s bbox=%s target='%s'",
                         t_yolo_ms, "found" if result is not None else "missed", result, state.target_label)
             if result is None:
@@ -611,6 +649,7 @@ class TrackerService:
                 moving_ff = speed_pxs > C.VFF_MOVING_MIN_PXS
                 centered = err_dx == 0.0 and err_dy == 0.0
                 yolo_age = now_t - last_yolo_confirm_t
+                trust_window = trust_window_s(detect_latency_s)
                 # Bbox-trust guard: ViT bloated past its last trusted lock (or the
                 # absolute ceiling) → centroid is garbage. Hold the servo instead
                 # of chasing it; YOLO redetect / ghost-lock retry will relock.
@@ -672,7 +711,7 @@ class TrackerService:
                     self._pitch_pid.reset()
                     motion_state = "LOW-CONF-HOLD"
                     self._follower.hold()
-                elif yolo_age >= C.TRUST_TRACKER_S and confidence < C.TRACKER_TRUST_CONF:
+                elif yolo_age >= trust_window and confidence < C.TRACKER_TRUST_CONF:
                     # Tracker AND detector both unsure — hold servo, don't chase
                     # phantom. If ViT confidence is high we trust the tracker
                     # even without detector confirm (face moving fast often makes

--- a/hal/drivers/tracking/tracker_service.py
+++ b/hal/drivers/tracking/tracker_service.py
@@ -144,8 +144,10 @@ class TrackerService:
             logger.error("tracker start: %s", self.last_error)
             return False
 
-        if isinstance(target_label, (list, tuple)):
-            target_label = next((t for t in target_label if t), "")
+        candidates = ([t for t in target_label if t]
+                      if isinstance(target_label, (list, tuple))
+                      else [target_label] if target_label else [])
+        target_label = candidates[0] if candidates else ""
 
         # Serialize concurrent /servo/track calls. detect_object can take 5-7s
         # (remote YOLOWorld or first-time local YOLO load). Without this lock,
@@ -157,7 +159,8 @@ class TrackerService:
             return False
         try:
             self.stop()
-            return self._start_locked(bbox, target_label, camera_capture, animation_service)
+            return self._start_locked(bbox, target_label, camera_capture,
+                                      animation_service, candidates)
         finally:
             self._start_lock.release()
 
@@ -167,6 +170,7 @@ class TrackerService:
         target_label: str,
         camera_capture,
         animation_service,
+        candidates: Optional[list] = None,
     ) -> bool:
         """Body of start() — runs while _start_lock is held."""
 
@@ -213,7 +217,29 @@ class TrackerService:
                     animation_service.unfreeze()
                     return False
                 t_yolo0 = time.perf_counter()
-                bbox = self.detect_object(frame, target_label)
+                # Try every candidate label the caller offered and keep the
+                # most confident hit. The API has always documented this
+                # ("pass a list when unsure of the exact word"); until now the
+                # list was truncated to its first entry, so a caller hedging
+                # between near-synonyms got one guess and a failure. It matters
+                # most for exactly the objects this path is weakest on: COCO
+                # splits hairs a speaker does not — bottle is not cup, and a
+                # user holding a water bottle says "cup". Seeding happens once
+                # per session and local detection is ~300ms, so a second or
+                # third look is affordable here in a way it would not be in the
+                # fast loop.
+                bbox = None
+                best_conf = -1.0
+                for label in (candidates or [target_label]):
+                    found = self.detect_object(frame, label)
+                    if found is None:
+                        continue
+                    conf = self._detector.last_confidence or 0.0
+                    if conf > best_conf:
+                        bbox, best_conf, target_label = found, conf, label
+                if bbox is not None and len(candidates or []) > 1:
+                    logger.info("[track-start] chose '%s' conf=%.3f from candidates %s",
+                                target_label, best_conf, candidates)
                 t_yolo_ms = (time.perf_counter() - t_yolo0) * 1000
                 if bbox is None:
                     self.last_error = f"'{target_label}' not found in frame"

--- a/hal/drivers/tracking/tracker_service.py
+++ b/hal/drivers/tracking/tracker_service.py
@@ -228,15 +228,27 @@ class TrackerService:
                 # per session and local detection is ~300ms, so a second or
                 # third look is affordable here in a way it would not be in the
                 # fast loop.
+                # Local sweep first, across ALL candidates, before any of them
+                # is allowed the remote detector. Interleaving them instead
+                # (local then remote, per candidate) makes a miss on the first
+                # word pay 1.3s of network before the second word is tried at
+                # all — measured at 5.7s to seed three candidates, against a
+                # 10s session budget. Remote is the fallback for the QUESTION,
+                # not for each guess at how to word it.
+                probe = list(candidates or [target_label])
                 bbox = None
                 best_conf = -1.0
-                for label in (candidates or [target_label]):
-                    found = self.detect_object(frame, label)
-                    if found is None:
-                        continue
-                    conf = self._detector.last_confidence or 0.0
-                    if conf > best_conf:
-                        bbox, best_conf, target_label = found, conf, label
+                for allow_remote in (False, True):
+                    for label in probe:
+                        found = self.detect_object(frame, label,
+                                                   allow_remote_fallback=allow_remote)
+                        if found is None:
+                            continue
+                        conf = self._detector.last_confidence or 0.0
+                        if conf > best_conf:
+                            bbox, best_conf, target_label = found, conf, label
+                    if bbox is not None:
+                        break
                 if bbox is not None and len(candidates or []) > 1:
                     logger.info("[track-start] chose '%s' conf=%.3f from candidates %s",
                                 target_label, best_conf, candidates)

--- a/hal/scripts/export_yolo_onnx.py
+++ b/hal/scripts/export_yolo_onnx.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Export the checked-in yolov8n.pt to ONNX for the tracking detector.
+
+The .pt runs through PyTorch, which is the slowest way to execute this graph on
+the device CPU. onnxruntime is already a HAL dependency, so the same weights in
+ONNX cost nothing extra and leave room in the latency budget for a larger
+inference size — which is what small desk objects (cup, book, phone) need.
+
+The input size is baked into the export, so this reads it from the detector
+rather than taking a flag: the two cannot drift apart.
+
+    uv run python hal/scripts/export_yolo_onnx.py
+
+Writes hal/drivers/tracking/models/yolov8n.onnx. The detector prefers that file
+and falls back to the .pt when it is absent, so exporting is safe to redo and
+safe to skip.
+"""
+
+import os
+import shutil
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hal.drivers.tracking.detection import (  # noqa: E402
+    _LOCAL_IMGSZ as IMGSZ,
+    _LOCAL_MODEL_ONNX as OUT,
+    _LOCAL_MODEL_PT as SRC,
+)
+
+
+def main() -> int:
+    if not os.path.exists(SRC):
+        print(f"missing source weights: {SRC}", file=sys.stderr)
+        return 1
+
+    from ultralytics import YOLO
+
+    print(f"exporting {SRC} -> ONNX at imgsz={IMGSZ}")
+    # simplify=True folds the graph so onnxruntime does not redo it per session.
+    # It needs onnxslim, which is not a HAL dependency; ultralytics warns and
+    # exports unsimplified when it is missing. That is a small speed loss, not
+    # a broken model, so this deliberately does not require the extra package.
+    produced = YOLO(SRC).export(format="onnx", imgsz=IMGSZ, simplify=True)
+
+    # ultralytics writes next to the source and names the file itself; move it
+    # to the exact path the detector looks for.
+    if os.path.abspath(produced) != os.path.abspath(OUT):
+        shutil.move(produced, OUT)
+    print(f"wrote {OUT} ({os.path.getsize(OUT) / 1e6:.1f} MB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hal/test/test_tracking_local_first.py
+++ b/hal/test/test_tracking_local_first.py
@@ -1,0 +1,86 @@
+"""Keeping a local-model target on the local model.
+
+Two gates decided whether tracking a cup or a book felt like tracking a face,
+and both were sized for the face detector. These cover them.
+"""
+
+import numpy as np
+
+from hal.drivers.tracking import constants as C
+from hal.drivers.tracking import detection
+from hal.drivers.tracking.tracker_service import trust_window_s
+
+
+class _EmptyYolo:
+    """A local model that runs fine and simply finds nothing this frame."""
+
+    names: dict[int, str] = {}
+
+    def __call__(self, *args, **kwargs):
+        return []
+
+
+def _detector(monkeypatch, remote_calls: list):
+    monkeypatch.setattr(detection, "_get_local_yolo", lambda: _EmptyYolo())
+    monkeypatch.setattr(detection, "_DETECT_LOCAL_ENABLED", True)
+    det = detection.ObjectDetector.__new__(detection.ObjectDetector)
+    det._on_confidence = None
+    det.last_confidence = None
+    det._last_remote_attempt_t = 0.0
+    det._crypto = None
+    monkeypatch.setattr(
+        det, "_detect_remote",
+        lambda frame, target, up: remote_calls.append(target) or None,
+    )
+    return det
+
+
+def _frame():
+    return np.zeros((480, 640, 3), dtype=np.uint8)
+
+
+def test_coco_miss_does_not_reach_remote_mid_session(monkeypatch):
+    """A local miss on a routine redetect must not spend 1.3-3s on remote.
+
+    The detect thread is single-flight, so one such round-trip stretches the
+    confirm cycle past the trust window and freezes the servo while the object
+    is still in frame.
+    """
+    calls: list = []
+    det = _detector(monkeypatch, calls)
+    assert det.detect(_frame(), "cup", strict=False,
+                      allow_remote_fallback=False) is None
+    assert calls == []
+
+
+def test_coco_miss_still_reaches_remote_when_seeding(monkeypatch):
+    """With no lock to protect, the slow detector is worth waiting for."""
+    calls: list = []
+    det = _detector(monkeypatch, calls)
+    assert det.detect(_frame(), "cup") is None
+    assert calls == ["cup"]
+
+
+def test_open_vocab_target_always_reaches_remote(monkeypatch):
+    """The flag must not strand a target that has no local path at all."""
+    calls: list = []
+    det = _detector(monkeypatch, calls)
+    assert det.detect(_frame(), "rubik cube", strict=False,
+                      allow_remote_fallback=False) is None
+    assert calls == ["rubik cube"]
+
+
+def test_trust_window_floors_at_the_constant_for_a_fast_detector():
+    """YuNet at ~30ms keeps exactly the window face tracking always had."""
+    assert trust_window_s(0.03) == C.TRUST_TRACKER_S
+    assert trust_window_s(0.0) == C.TRUST_TRACKER_S
+
+
+def test_trust_window_grows_with_a_slower_detector():
+    """A cup confirmed on a ~0.6s detector gets room for one missed confirm."""
+    window = trust_window_s(0.6)
+    assert window > C.TRUST_TRACKER_S
+    assert window == C.YOLO_REDETECT_S + 1.2 + C.TRUST_MARGIN_S
+    # The point of the whole change: an ordinary miss (one full redetect cycle
+    # plus a detection) no longer reads as a lost lock.
+    assert window > C.YOLO_REDETECT_S + 0.6

--- a/robots/lamp/docs/vi/vision-tracking_vi.md
+++ b/robots/lamp/docs/vi/vision-tracking_vi.md
@@ -51,7 +51,7 @@ Camera chạy **1280×720**. Mọi thành phần vision nặng — ViT tracker v
 | Path | Detector | Khi nào | Tốc độ (A523) |
 |------|----------|---------|---------------|
 | 0 | **YuNet** face detector (`face_detection_yunet_2023mar.onnx`) | target ∈ {`face`, `human face`, `khuôn mặt`, `mặt`} | ~30 ms |
-| 1 | **Local YOLOv8n** (COCO classes, `yolov8n.onnx`, fallback `yolov8n.pt`, imgsz=448) | target map tới một COCO class | đo lại trên thiết bị sau khi export |
+| 1 | **Local YOLOv8n** (COCO classes, `yolov8n.onnx`, fallback `yolov8n.pt`, imgsz=448) | target map tới một COCO class | ~240–495 ms (đo trên lamp-ac82, ONNX Runtime 1.27 CPU, input 1280x720) |
 | 2 | **Remote YOLOWorld** open-vocab (`{DL_BACKEND_URL}/detect/yoloworld`) | target không thuộc COCO, hoặc local miss (fallback) | ~1.3–2.8 s |
 
 - COCO không có class hand/face, nên `hand`/`face` cố ý rơi xuống YuNet/YOLOWorld thay vì map tới `person` (vốn khóa vào toàn thân).

--- a/robots/lamp/docs/vi/vision-tracking_vi.md
+++ b/robots/lamp/docs/vi/vision-tracking_vi.md
@@ -51,11 +51,12 @@ Camera chạy **1280×720**. Mọi thành phần vision nặng — ViT tracker v
 | Path | Detector | Khi nào | Tốc độ (A523) |
 |------|----------|---------|---------------|
 | 0 | **YuNet** face detector (`face_detection_yunet_2023mar.onnx`) | target ∈ {`face`, `human face`, `khuôn mặt`, `mặt`} | ~30 ms |
-| 1 | **Local YOLOv8n** (COCO classes, `yolov8n.pt`, imgsz=320) | target map tới một COCO class | ~260–770 ms |
+| 1 | **Local YOLOv8n** (COCO classes, `yolov8n.onnx`, fallback `yolov8n.pt`, imgsz=448) | target map tới một COCO class | đo lại trên thiết bị sau khi export |
 | 2 | **Remote YOLOWorld** open-vocab (`{DL_BACKEND_URL}/detect/yoloworld`) | target không thuộc COCO, hoặc local miss (fallback) | ~1.3–2.8 s |
 
 - COCO không có class hand/face, nên `hand`/`face` cố ý rơi xuống YuNet/YOLOWorld thay vì map tới `person` (vốn khóa vào toàn thân).
 - Khi local-YOLO miss, code fallback về remote YOLOWorld, **throttle** tối đa một lần mỗi `REMOTE_FALLBACK_MIN_INTERVAL` (2.0 s) để một target thật sự không thể thấy không gọi remote mỗi lần redetect.
+- **Fallback bị tắt cho redetect thường kỳ** (`allow_remote_fallback=False`, do background scan của loop truyền vào). Khi target COCO đã khoá được rồi thì một lần local miss là chuyện bình thường — vật xoay đi, một khung hình nhoè — mà thread detect chỉ chạy một luồng, nên một vòng gọi remote kéo chu kỳ confirm từ ~0.5 s lên ~3 s, vượt cổng trust và làm servo đứng im trong khi vật vẫn còn trong khung. Local là thẩm quyền cho class mà nó được huấn luyện; để lần redetect sau xác nhận. Lúc seed và lúc phục hồi sau khi mất lock (`_do_retry`) vẫn cho phép remote, còn target open-vocab thì không ảnh hưởng — không có đường local thì chẳng có gì để fallback.
 - Bộ lọc chất lượng detection: confidence ≥ `DETECT_MIN_CONFIDENCE` (0.15), diện tích nằm giữa `DETECT_MIN_AREA_RATIO` (0.3%) và `DETECT_MAX_AREA_RATIO` (80%) của frame.
 - **Chống nhầm vật giống nhau (đường local)** — YOLO local detect **mở** (không filter `classes=`) để các class cạnh tranh còn hiện diện, sau đó: (a) cụm dễ nhầm cell phone / mouse / remote cần conf ≥ 0.35 (`_CONFUSABLE_CONF_FLOOR`) thay vì 0.15 chung; (b) **cross-class disambiguation** — nếu một box class khác đè lên candidate (IoU ≥ 0.5) với confidence *cao hơn*, candidate bị từ chối ("đó chắc là con chuột, không phải cái điện thoại anh hỏi") và code rơi xuống remote fallback. Floor 0.35 chỉ áp cho detect lúc *bắt đầu* session (`strict=True`); redetect giữa session dùng floor chung 0.15 (phone đang phẩy nhanh thường chỉ reconfirm ở conf 0.2–0.3, và các gate reinit đã bảo vệ lock) — cross-class check giữ nguyên cả hai chế độ.
 
@@ -112,7 +113,7 @@ Chuyển động phần cứng khi tracking: ở mỗi lần bắt đầu sessio
   - `BBOX_FREEZE_RATIO` (1.0) — bbox ≥ diện tích cả frame ⇒ ViT đã tan.
   - `BLOAT_HOLD_MULT` (3.0) — bbox > 3× diện tích lock tin cậy gần nhất ⇒ hold và buộc re-detect.
 - **Sàn confidence cho servo** — confidence ViT < `SERVO_MIN_CONF` (0.25) thì giữ servo (`LOW-CONF-HOLD`) kể cả khi detector vẫn đang confirm target; trước đây vùng conf 0.15–0.4 kèm confirm mới là vùng mù khiến servo đuổi theo một lock yếu (thường là ma). Tracker vẫn update và PID chạy lại khi confidence hồi.
-- **Detector-gated trust** — nếu không detector nào xác nhận trong `TRUST_TRACKER_S` (2.5 s) và confidence ViT < `TRACKER_TRUST_CONF` (0.4), giữ servo (`WAIT-YOLO`) thay vì đuổi một bóng ma; confidence ViT cao vẫn tiếp tục fire ngay cả khi không có detector confirm mới.
+- **Detector-gated trust** — nếu không detector nào xác nhận trong cửa sổ trust và confidence ViT < `TRACKER_TRUST_CONF` (0.4), giữ servo (`WAIT-YOLO`) thay vì đuổi một bóng ma; confidence ViT cao vẫn tiếp tục fire ngay cả khi không có detector confirm mới. Cửa sổ này **được tính theo latency đo được của detector**, không cố định: `trust_window_s()` trả về `max(TRUST_TRACKER_S, YOLO_REDETECT_S + 2 x latency + TRUST_MARGIN_S)`, với latency là EMA do background scan duy trì. Cùng một loop được phục vụ bởi các detector chênh nhau ba bậc độ lớn (YuNet ~30 ms, YOLO local ~0.5 s, remote 1.3–3 s), nên một hằng số chỉ đúng cho cái nhanh nhất — và 2.5 s khiến mọi target chậm hơn nằm lì ở `WAIT-YOLO` dù vật hiện rõ trong khung. Cái sàn giữ hành vi với mặt người y như cũ.
 - **Hold là hold thật** — mọi trạng thái hold (`LOW-CONF-HOLD`, `WAIT-YOLO`, `BLOAT-HOLD`, frame bị skip do low-confidence) đều retarget follow worker về pose *hiện tại* (`ServoFollower.hold()`). Trước đây hold chỉ ngừng publish goal mới, worker vẫn glide tiếp về goal cũ — nên arm vẫn "đuổi ma" thêm một nhịp sau khi lock đã hỏng.
 
 ### Chuyển đổi Pixel-sang-Degree
@@ -162,10 +163,10 @@ pitch_correction = clamp(PID(soft_deadband(dy)) + VFF·vy·deg_per_px·dt,  ±5�
 | `CONFIDENCE_THRESHOLD` | 0.15 | Dưới mức này = frame low-confidence |
 | `LOW_CONF_WINDOW` / `LOW_CONF_STOP_COUNT` | 15 / 8 | Cửa sổ trượt: ≥8 frame low trong 15 frame gần nhất → dừng (đếm liên-tiếp cũ bị reset bởi mỗi frame nhấp nháy vượt ngưỡng, khiến ghost lock sống mãi) |
 | `SERVO_MIN_CONF` | 0.25 | Sàn confidence để fire servo PID |
-| `TRACKER_TRUST_CONF` / `TRUST_TRACKER_S` | 0.4 / 2.5 | Detector-gated trust (xem trên) |
+| `TRACKER_TRUST_CONF` / `TRUST_TRACKER_S` / `TRUST_MARGIN_S` | 0.4 / 2.5 / 0.5 | Detector-gated trust (xem trên). `TRUST_TRACKER_S` là **sàn**, không phải cửa sổ — cửa sổ được suy ra từng session theo latency đo được của detector |
 | `YOLO_MAX_MISS` | 30 | Số lần CSRT miss liên tiếp trước khi retry |
 | `MAX_TRACK_DURATION_S` | `HAL_TRACKING_MAX_DURATION_S` (10) | Timeout tự động dừng (mặc định 10 giây; cấu hình theo từng thiết bị) |
-| `_LOCAL_IMGSZ` | 320 | Kích thước inference local YOLO (640 → 1.3–2.9 s, quá chậm) |
+| `_LOCAL_IMGSZ` | 448 | Kích thước inference local YOLO. Đây CHÍNH LÀ độ phân giải hiệu dụng của detector — YOLO letterbox mọi input xuống giá trị này, nên với camera rộng 1280 thì 448 đưa vật tới model ở 0.35x còn 320 chỉ 0.25x. Vật nhỏ trên bàn (cup, book, phone) tới model ở ~30px với 320 nên bị bỏ sót. Đổi giá trị này thì phải export lại ONNX; kích thước được nướng vào file. (640 đo được 1.3–2.9 s trên torch — vẫn ngoài tầm.) |
 
 Mọi knob nằm trong `hal/drivers/tracking/constants.py`. (Đường proportional chết `GIMBAL_*` / `EMA_ALPHA` đã bị xoá khi tách package.)
 
@@ -304,8 +305,9 @@ Camera section hiển thị:
 ## Dependencies
 
 - `opencv-python>=4.8.0` (đã có trong `pyproject.toml`)
-- `ultralytics` — inference local YOLOv8n
+- `ultralytics` — inference local YOLOv8n (nạp bản export ONNX; `onnxruntime` vốn đã là dependency của HAL, còn đường `.pt` chạy PyTorch trên CPU, cách chậm nhất để chạy graph này trên Cortex-A55)
 - `vittrack.onnx`, `yolov8n.pt`, `face_detection_yunet_2023mar.onnx` — đã check vào `hal/drivers/tracking/models/`
+- `yolov8n.onnx` — sinh ra, không check vào repo: `uv run python hal/scripts/export_yolo_onnx.py`. Detector ưu tiên file này và fallback về `.pt` khi vắng, nên thiết bị chưa nhận model mới thì chậm hơn chứ không mù.
 - `requests` (đã có trong project)
 - **YOLOWorld API** — DL backend tại `{DL_BACKEND_URL}/detect/yoloworld` (chỉ open-vocab fallback)
 
@@ -323,7 +325,7 @@ Việc quay lại idle là một **dispatch tường minh**, không phải hệ 
 
 ## Ghi chú hiệu năng
 
-- Sàn CPU của fast-loop trên Allwinner A523 là chi phí ViT inference + detector; frame downscale (`VISION_MAX_WIDTH`) và local imgsz=320 là các đòn bẩy chính.
+- Sàn CPU của fast-loop trên Allwinner A523 là chi phí ViT inference + detector; frame downscale (`VISION_MAX_WIDTH`) và local imgsz là các đòn bẩy chính. Lưu ý `VISION_MAX_WIDTH` KHÔNG phải đòn bẩy cho *độ chính xác* detect: YOLO letterbox xuống `_LOCAL_IMGSZ` bất kể input to bao nhiêu, nên hạ scale frame trước chỉ đổi chi phí của tracker, không đổi tỉ lệ mà detector nhìn thấy.
 - Độ mượt chuyển động đến từ servo worker tách rời + SmoothDamp + velocity feedforward; alpha-beta filter + reinit gating giữ cho bản thân goal ổn định để follower không đuổi theo nhiễu.
 - Vật thể nhỏ/xa (ví dụ một cái ly ở đầu phòng) có thể vượt độ phân giải của cả detector local lẫn remote — đây là giới hạn perception, không phải bug điều khiển.
 </content>

--- a/robots/lamp/docs/vision-tracking.md
+++ b/robots/lamp/docs/vision-tracking.md
@@ -51,11 +51,12 @@ The camera runs **1280×720**. Every heavy vision component — the ViT tracker 
 | Path | Detector | When | Speed (A523) |
 |------|----------|------|--------------|
 | 0 | **YuNet** face detector (`face_detection_yunet_2023mar.onnx`) | target ∈ {`face`, `human face`, `khuôn mặt`, `mặt`} | ~30 ms |
-| 1 | **Local YOLOv8n** (COCO classes, `yolov8n.pt`, imgsz=320) | target maps to a COCO class | ~260–770 ms |
+| 1 | **Local YOLOv8n** (COCO classes, `yolov8n.onnx`, falling back to `yolov8n.pt`, imgsz=448) | target maps to a COCO class | measure on device after export |
 | 2 | **Remote YOLOWorld** open-vocab (`{DL_BACKEND_URL}/detect/yoloworld`) | non-COCO target, or local miss (fallback) | ~1.3–2.8 s |
 
 - COCO has no hand/face class, so `hand`/`face` intentionally fall through to YuNet/YOLOWorld instead of mapping to `person` (which locked onto the whole body).
 - On a local-YOLO miss the code falls back to remote YOLOWorld, **throttled** to at most one attempt per `REMOTE_FALLBACK_MIN_INTERVAL` (2.0 s) so a genuinely unseeable target doesn't hit remote every redetect.
+- **The fallback is off for routine redetects** (`allow_remote_fallback=False`, passed by the loop's background scan). Once a COCO target is locked, a local miss is ordinary — the object turned, one blurred frame — and the detect thread is single-flight, so a remote round-trip stretches a ~0.5 s confirm cycle to ~3 s, trips the trust gate and parks the servo with the object still in frame. Local is the authority for a class it was trained on; the next redetect confirms. Seeding and post-loss recovery (`_do_retry`) still allow remote, and an open-vocab target is unaffected — with no local path there is nothing to fall back from.
 - Detection quality filters: confidence ≥ `DETECT_MIN_CONFIDENCE` (0.15), area between `DETECT_MIN_AREA_RATIO` (0.3%) and `DETECT_MAX_AREA_RATIO` (80%) of frame.
 - **Lookalike guard (local path)** — local YOLO detects **unrestricted** (no `classes=` filter) so competing classes stay visible, then: (a) the confusion cluster cell phone / mouse / remote needs conf ≥ 0.35 (`_CONFUSABLE_CONF_FLOOR`) instead of the global 0.15; (b) **cross-class disambiguation** — if a box of another class overlaps the candidate (IoU ≥ 0.5) with *higher* confidence, the candidate is rejected ("that's probably a mouse, not the phone you asked for") and the code falls through to the remote fallback. The 0.35 floor applies only to the session-start detect (`strict=True`); mid-session redetects use the global 0.15 floor (a fast-moving phone reconfirms at conf 0.2–0.3, and the reinit gates already protect the lock) — cross-class disambiguation stays on in both modes.
 
@@ -112,7 +113,7 @@ Hardware motion during tracking: at every session start the HAL explicitly write
   - `BBOX_FREEZE_RATIO` (1.0) — bbox ≥ full frame area ⇒ ViT dissolved.
   - `BLOAT_HOLD_MULT` (3.0) — bbox > 3× the last trusted lock area ⇒ hold and force a re-detect.
 - **Servo confidence floor** — ViT confidence < `SERVO_MIN_CONF` (0.25) holds the servo (`LOW-CONF-HOLD`) even while the detector is still confirming the target; without it, conf 0.15–0.4 with a fresh confirm was a blind zone that kept the servo chasing a barely-held (often ghost) lock. The tracker keeps updating and the PID resumes when confidence recovers.
-- **Detector-gated trust** — if no detector has confirmed for `TRUST_TRACKER_S` (2.5 s) and ViT confidence < `TRACKER_TRUST_CONF` (0.4), hold the servo (`WAIT-YOLO`) rather than chase a phantom; high ViT confidence keeps firing even without a fresh detector confirm.
+- **Detector-gated trust** — if no detector has confirmed within the trust window and ViT confidence < `TRACKER_TRUST_CONF` (0.4), hold the servo (`WAIT-YOLO`) rather than chase a phantom; high ViT confidence keeps firing even without a fresh detector confirm. The window is **sized from the detector's measured latency**, not fixed: `trust_window_s()` returns `max(TRUST_TRACKER_S, YOLO_REDETECT_S + 2 x latency + TRUST_MARGIN_S)`, where latency is an EMA maintained by the background scan. One loop is served by detectors three orders of magnitude apart (YuNet ~30 ms, local YOLO ~0.5 s, remote 1.3–3 s), so a single constant is only correct for the fastest — and 2.5 s meant every slower target sat in `WAIT-YOLO` with the object plainly visible. The floor keeps face behaviour identical.
 - **Hold really holds** — every hold state (`LOW-CONF-HOLD`, `WAIT-YOLO`, `BLOAT-HOLD`, low-confidence skip frames) retargets the follow worker to the *current* pose (`ServoFollower.hold()`). Previously a hold only stopped publishing new goals, so the worker kept gliding toward the last stale goal — the arm visibly chased a ghost for a beat after the lock had gone bad.
 
 ### Pixel-to-Degree Conversion
@@ -162,10 +163,10 @@ pitch_correction = clamp(PID(soft_deadband(dy)) + VFF·vy·deg_per_px·dt,  ±5�
 | `CONFIDENCE_THRESHOLD` | 0.15 | Below this = low-confidence frame |
 | `LOW_CONF_WINDOW` / `LOW_CONF_STOP_COUNT` | 15 / 8 | Sliding window: ≥8 low frames in the last 15 → stop (a consecutive counter was reset by every above-threshold flicker, letting ghost locks live forever) |
 | `SERVO_MIN_CONF` | 0.25 | Confidence floor for firing the servo PID at all |
-| `TRACKER_TRUST_CONF` / `TRUST_TRACKER_S` | 0.4 / 2.5 | Detector-gated trust (see above) |
+| `TRACKER_TRUST_CONF` / `TRUST_TRACKER_S` / `TRUST_MARGIN_S` | 0.4 / 2.5 / 0.5 | Detector-gated trust (see above). `TRUST_TRACKER_S` is the **floor**, not the window — the window is derived per session from measured detector latency |
 | `YOLO_MAX_MISS` | 30 | Consecutive tracker misses before retry |
 | `MAX_TRACK_DURATION_S` | `HAL_TRACKING_MAX_DURATION_S` (10) | Auto-stop timeout (10 s default; configured per device) |
-| `_LOCAL_IMGSZ` | 320 | Local YOLO inference size (640 → 1.3–2.9 s, too slow) |
+| `_LOCAL_IMGSZ` | 448 | Local YOLO inference size. This IS the detector's effective resolution — YOLO letterboxes any input down to it, so against the 1280-wide camera 448 reaches the model at 0.35x where 320 reached it at 0.25x. Small desk objects (cup, book, phone) arrived ~30px at 320 and were missed. Re-export the ONNX after changing it; the size is baked in. (640 measured 1.3–2.9 s on torch — still out of reach.) |
 
 All knobs live in `hal/drivers/tracking/constants.py`. (The old dead `GIMBAL_*` / `EMA_ALPHA` proportional path was removed in the package split.)
 
@@ -304,8 +305,9 @@ Camera section shows:
 ## Dependencies
 
 - `opencv-python>=4.8.0` (already in `pyproject.toml`)
-- `ultralytics` — local YOLOv8n inference
+- `ultralytics` — local YOLOv8n inference (loads the ONNX export; `onnxruntime` is already a HAL dependency, and the .pt path runs PyTorch on the CPU, the slowest way to execute this graph on a Cortex-A55)
 - `vittrack.onnx`, `yolov8n.pt`, `face_detection_yunet_2023mar.onnx` — checked into `hal/drivers/tracking/models/`
+- `yolov8n.onnx` — generated, not checked in: `uv run python hal/scripts/export_yolo_onnx.py`. The detector prefers it and falls back to the `.pt` when absent, so a device that has not taken it yet is slower rather than blind.
 - `requests` (already in project)
 - **YOLOWorld API** — DL backend at `{DL_BACKEND_URL}/detect/yoloworld` (open-vocab fallback only)
 
@@ -323,7 +325,7 @@ Resuming idle is an **explicit dispatch**, not a side effect of clearing the tra
 
 ## Performance Notes
 
-- Fast-loop CPU floor on the Allwinner A523 is ViT inference + detector cost; the frame downscale (`VISION_MAX_WIDTH`) and local imgsz=320 are the main levers.
+- Fast-loop CPU floor on the Allwinner A523 is ViT inference + detector cost; the frame downscale (`VISION_MAX_WIDTH`) and local imgsz are the main levers. Note `VISION_MAX_WIDTH` is not a lever on detection *accuracy*: YOLO letterboxes to `_LOCAL_IMGSZ` regardless of the input size, so pre-downscaling the frame changes the tracker's cost, not the scale the detector sees.
 - Motion smoothness comes from the decoupled servo worker + SmoothDamp + velocity feedforward; the alpha-beta filter + reinit gating keep the goal itself stable so the follower isn't chasing noise.
 - Small/far objects (e.g. a cup across the room) can exceed both local and remote detector resolution — a perception limit, not a control bug.
 

--- a/robots/lamp/docs/vision-tracking.md
+++ b/robots/lamp/docs/vision-tracking.md
@@ -51,7 +51,7 @@ The camera runs **1280×720**. Every heavy vision component — the ViT tracker 
 | Path | Detector | When | Speed (A523) |
 |------|----------|------|--------------|
 | 0 | **YuNet** face detector (`face_detection_yunet_2023mar.onnx`) | target ∈ {`face`, `human face`, `khuôn mặt`, `mặt`} | ~30 ms |
-| 1 | **Local YOLOv8n** (COCO classes, `yolov8n.onnx`, falling back to `yolov8n.pt`, imgsz=448) | target maps to a COCO class | measure on device after export |
+| 1 | **Local YOLOv8n** (COCO classes, `yolov8n.onnx`, falling back to `yolov8n.pt`, imgsz=448) | target maps to a COCO class | ~240–495 ms (measured on lamp-ac82, ONNX Runtime 1.27 CPU, 1280x720 input) |
 | 2 | **Remote YOLOWorld** open-vocab (`{DL_BACKEND_URL}/detect/yoloworld`) | non-COCO target, or local miss (fallback) | ~1.3–2.8 s |
 
 - COCO has no hand/face class, so `hand`/`face` intentionally fall through to YuNet/YOLOWorld instead of mapping to `person` (which locked onto the whole body).


### PR DESCRIPTION
Tracking worked on faces and people and fell apart on everything else. Three
layers were each sized for the face detector, and any target the face detector
does not serve tripped all three.

Measured on lamp-0c89 throughout; every number below came off the device.

## What was wrong

**The detector could not see small objects.** YOLO letterboxes whatever it is
handed down to `imgsz`, so that single number is the effective resolution. At
320 against the 1280-wide camera everything reached the model at 0.25x — fine
for a face or a torso, but a cup or a book on the desk arrived ~30px wide and
was simply not there to find.

**A local miss dragged the remote detector into the fast loop.** On a miss the
code fell back to remote YOLOWorld. The detect thread is single-flight, so one
1.3–3s round-trip stretched a ~0.5s confirm cycle to ~3s. That pushed
`yolo_age` past the trust window and parked the servo — camera frozen with the
object plainly in frame, which is what "it doesn't track objects" looked like.

**The trust window was a constant.** `TRUST_TRACKER_S = 2.5` is correct for
YuNet at ~30ms. One loop is also served by local YOLO (~0.4s) and the remote
model (1.3–3s), and for those an ordinary single missed confirm read as a lost
lock.

**Candidate labels were discarded.** `ServoTrackRequest.target` documents
"pass a list of candidate labels ... the highest-confidence detection is used".
The list was truncated to its first entry, so a caller hedging between
near-synonyms got one guess and a failure — worst for exactly these objects,
since COCO splits hairs a speaker does not (a user holding a water bottle says
"cup", and `bottle` and `cup` are different classes).

## What changed

**Local YOLO runs through ONNX Runtime at imgsz 448.** `onnxruntime` was
already a HAL dependency — YuNet and the ViT tracker are ONNX — and YOLO was
the last thing still executing through PyTorch, the slowest way to run this
graph on a Cortex-A55. The runtime change pays for the resolution:

| | imgsz | latency on device |
|---|---|---|
| before: `.pt` via torch | 320 | 260–770 ms |
| after: `.onnx` via ONNX Runtime | **448** | **250–630 ms**, median ~380 ms |

Twice the pixels at the same cost. The `.onnx` is generated, not committed
(`hal/scripts/export_yolo_onnx.py`); the detector prefers it and falls back to
the checked-in `.pt`, so a device that has not taken the new model is slower
rather than blind.

**Routine redetects stay local** (`allow_remote_fallback=False`). Once a COCO
target is locked, a local miss is ordinary — the object turned, one blurred
frame — and local is the authority for a class it was trained on. Seeding and
post-loss recovery still use remote, and open-vocab targets are untouched:
with no local path there is nothing to fall back from.

**The trust window is sized from measured latency.**
`trust_window_s()` returns `max(TRUST_TRACKER_S, YOLO_REDETECT_S + 2 x latency
+ TRUST_MARGIN_S)`, latency being an EMA kept by the background scan. One
redetect interval plus two detections is the shortest gap a single missed
confirm can produce. The old constant stays as the floor, so face behaviour is
unchanged.

**Every candidate label is tried, locally first.** All candidates are swept
with remote disabled before any of them is allowed a remote call — remote is
the fallback for the question, not for each guess at how to word it.
Interleaving cost 5.7s to seed three candidates against a 10s session budget;
sweeping local first brought seeding from **6060 ms to 2399 ms**.

## Verified on device

```
[tracking_yolo_local] target='cup' bbox=(334,81,148,258) conf=0.774 latency=292ms
[track-start] chose 'person' conf=0.753 from candidates ['cup', 'bottle', 'person']
[track-loop] fps=15.1 tracker=21ms servo_fires=16 frame=66ms target='cup'
```

Across a full session: no `[tracking_yolo_request]` (remote never entered the
loop), and no `WAIT-YOLO`, `BLOAT-HOLD` or `LOW-CONF-HOLD` — the servo chased
throughout. `hal/test/test_tracking_local_first.py` covers both gates; 27
tracking tests pass, lint and pyflakes clean. Docs updated EN + VI.

## Deliberately not touched

Left alone pending real numbers rather than tuned blind:

- `_CONFUSABLE_CONF_FLOOR = 0.35`, which penalises `phone` at seed. Confidences
  at 448 are much higher (person 0.87, cup 0.77), so this may no longer bite.
- The ViT confidence thresholds (0.15 / 0.25 / 0.4), still tuned on faces. A
  low-texture object like a book cover will score below a face.
- `HAL_TRACKING_MAX_DURATION_S=10` stops every session after 10s. A real
  ceiling on "track my cup", but it is device config, not code.
