### PR TITLE
hal: adopt an equal turn sequence from a newer run

### DIFF
--- a/docs/realtime-voice.md
+++ b/docs/realtime-voice.md
@@ -203,9 +203,14 @@ crash restarts the count at 1 while HAL still holds the old high-water mark, so
 every turn of the new session looks like a late arrival and is dropped —
 measured 03/09/2026: `seq=1` against `latest_seq=40` silenced the wake greeting
 (its LED and servo still ran) and would have silenced the next 39 turns. The run
-id carries its creation time (`device-chat-<n>-<unix-ms>`), so when a LOWER
-sequence arrives from a run created LATER than the one holding the speaker, HAL
-treats the counter as restarted and adopts the new sequence. Ids without a stamp
+id carries its creation time (`device-chat-<n>-<unix-ms>`), so when a LOWER OR
+EQUAL sequence arrives from a run created LATER than the one holding the speaker,
+HAL treats the counter as restarted and adopts the new sequence. Equal counts
+because a restart resets to 1, so the new run only falls BELOW the old mark when
+that mark is high — with a low mark (two restarts in a row, or a restart early in
+a session) the sequences collide instead. Measured 04/09/2026: `seq=2` met an
+unrelated `seq=2` from before the restart and the wake greeting was dropped, the
+same silent-device symptom one comparison away. Ids without a stamp
 (`tg-<messageID>`) keep the plain sequence rule: with nothing to compare, a
 genuinely stale POST must not be able to take the speaker back.
 

--- a/docs/vi/realtime-voice_vi.md
+++ b/docs/vi/realtime-voice_vi.md
@@ -191,8 +191,13 @@ HAL, và hai bên restart độc lập. Deploy, OTA hay crash làm bộ đếm b
 trong khi HAL vẫn giữ mốc cũ, nên mọi turn của phiên mới trông như đến muộn và bị
 vứt — đo ngày 03/09/2026: `seq=1` gặp `latest_seq=40` làm câm lời chào lúc thức
 (LED và servo vẫn chạy) và sẽ câm tiếp 39 turn sau đó. Run id có mang thời điểm
-tạo (`device-chat-<n>-<unix-ms>`), nên khi một sequence THẤP HƠN đến từ run được
-tạo MUỘN HƠN run đang giữ loa, HAL coi như bộ đếm đã restart và nhận sequence mới.
+tạo (`device-chat-<n>-<unix-ms>`), nên khi một sequence THẤP HƠN HOẶC BẰNG đến từ
+run được tạo MUỘN HƠN run đang giữ loa, HAL coi như bộ đếm đã restart và nhận
+sequence mới. Phải tính cả ca BẰNG NHAU vì restart đưa bộ đếm về 1, nên run mới chỉ
+rơi xuống DƯỚI mốc cũ khi mốc đó đang cao — mốc thấp (restart hai lần liên tiếp,
+hoặc restart sớm trong phiên) thì hai sequence đụng nhau chứ không thấp hơn. Đo ngày
+04/09/2026: `seq=2` gặp một `seq=2` không liên quan từ trước restart và lời chào lúc
+thức bị vứt — đúng triệu chứng câm tiếng đó, chỉ cách một phép so sánh.
 Id không có dấu thời gian (`tg-<messageID>`) vẫn theo luật sequence thuần: không có
 gì để so thì một POST cũ thật sự không được phép giành lại loa.
 ### Hai đồng hồ im lặng (kết thúc lượt)

--- a/hal/drivers/voice/tts/service.py
+++ b/hal/drivers/voice/tts/service.py
@@ -735,14 +735,24 @@ class TTSService:
         return int(m.group(1)) if m else None
 
     def _counter_restarted(self, turn_id: str, turn_seq: int) -> bool:
-        """True when a lower sequence belongs to a NEWER turn than the one
-        holding the speaker — i.e. os-server restarted and began counting again.
+        """True when a lower-or-equal sequence belongs to a NEWER turn than the
+        one holding the speaker — i.e. os-server restarted and began counting
+        again.
 
         Both ids must carry a creation stamp: without one there is nothing to
         compare, and guessing would let a genuinely stale POST take the speaker
         back from the turn that superseded it.
+
+        Equal sequences count. A restart resets the counter to 1, so the new
+        run COLLIDES with the old high-water mark instead of falling under it
+        whenever that mark is itself low — two restarts in a row, or a restart
+        early in a session. Device-observed 04/09/2026: seq=2 met an unrelated
+        seq=2 from before the restart and the wake greeting was dropped, the
+        same silent-device symptom this guard exists to prevent. Wall clock
+        settles it either way; only a same-millisecond tie falls through to the
+        conflict rule below.
         """
-        if turn_seq >= self._latest_queue_turn_seq:
+        if turn_seq > self._latest_queue_turn_seq:
             return False
         incoming = self._run_id_stamp(turn_id)
         holding = self._run_id_stamp(self._latest_queue_turn_id)
@@ -800,7 +810,7 @@ class TTSService:
                 # than the one holding the speaker is newer, whatever its seq.
                 if self._counter_restarted(turn_id, turn_seq):
                     logger.warning(
-                        "TTS turn counter restarted (turn_id=%s seq=%d < latest_id=%s "
+                        "TTS turn counter restarted (turn_id=%s seq=%d <= latest_id=%s "
                         "latest_seq=%d, but newer) -- adopting the new sequence",
                         turn_id, turn_seq, self._latest_queue_turn_id,
                         self._latest_queue_turn_seq,

--- a/hal/test/test_tts_turn_queue.py
+++ b/hal/test/test_tts_turn_queue.py
@@ -195,3 +195,39 @@ def test_an_id_without_a_stamp_keeps_the_sequence_rule():
 
     assert service.speak_queue("late", turn_id="tg-990", turn_seq=1) is True
     assert service._latest_queue_turn_seq == 40
+
+
+# A restart resets the counter to 1, so the new run does not always land BELOW
+# the old high-water mark — when that mark is itself low (two restarts in a row,
+# or a restart early in a session) the sequences collide instead. Device-observed
+# 04/09/2026: seq=2 met an unrelated seq=2 from before the restart and the wake
+# greeting was dropped — LED and servo ran, no sound, the same symptom as the
+# 03/09 case one comparison away.
+def test_an_equal_sequence_from_a_newer_run_is_adopted_not_dropped(monkeypatch, tmp_path):
+    service = _queue_service()
+    service._latest_queue_turn_id = "device-chat-2-1788500426762"
+    service._latest_queue_turn_seq = 2
+    service._tts_cache_path = lambda _: tmp_path / "missing.wav"
+    played = []
+    service._speak_sync = played.append
+    monkeypatch.setattr(tts_service_module.threading, "Thread", _InlineThread)
+
+    assert service.speak_queue(
+        "Hey — morning light to you", turn_id="device-chat-2-1788500830940", turn_seq=2
+    ) is True
+
+    assert played == ["Hey — morning light to you"]
+    assert service._latest_queue_turn_id == "device-chat-2-1788500830940"
+    assert service._latest_queue_turn_seq == 2
+
+
+def test_an_equal_sequence_from_an_older_run_is_still_dropped():
+    service = _queue_service()
+    service._latest_queue_turn_id = "device-chat-2-1788500830940"
+    service._latest_queue_turn_seq = 2
+
+    # Same seq, created EARLIER: a late POST from the run that was superseded.
+    assert service.speak_queue(
+        "late old reply", turn_id="device-chat-2-1788500426762", turn_seq=2
+    ) is True
+    assert service._latest_queue_turn_id == "device-chat-2-1788500830940"


### PR DESCRIPTION
## Problem

The wake greeting was silent again — LED and servo ran, no sound (lamp-0c89, 12:47:16 on 2026-09-04):

```
TTS queued speech dropped -- conflicting turn sequence
  (turn_id=device-chat-2-1788500830940 seq=2 latest_id=device-chat-2-1788500426762)
```

Same symptom `27ef9868` ("hal: adopt the new turn sequence when os-server restarts its counter", 03/09) was written to prevent, one comparison away.

`_counter_restarted` bails out at `turn_seq >= self._latest_queue_turn_seq`, so it only ever fires when the new run's sequence lands *below* the old high-water mark. That covers the case it was measured against (`seq=1` vs `latest_seq=40`), but a restart resets the counter to 1 — so the new run only falls below when the old mark is high. When that mark is itself low (two restarts in a row, or a restart early in a session) the sequences **collide** instead, and the request falls through to the equal-sequence conflict rule and is dropped.

That conflict rule (`70f816a6`, "fix: prioritize latest TTS turn", 21/08) predates restart-awareness by two weeks. Within one os-server run sequences are monotonic, so two different ids at the same seq genuinely are ambiguous and keeping the turn that holds the speaker is right. It was never meant to arbitrate across a restart.

The intent is already stated in `27ef9868`'s own comment — *"a turn created LATER than the one holding the speaker is newer, whatever its seq"* — but the code is narrower than the rule it declares.

## Change

`_counter_restarted` bails at `>` instead of `>=`, so wall clock also settles equal sequences. Everything else is untouched: both ids must still carry a creation stamp, and the conflict rule still handles what remains genuinely ambiguous — stampless ids (`tg-<messageID>`), and an incoming turn that really is older.

## Verification

- New tests: `test_an_equal_sequence_from_a_newer_run_is_adopted_not_dropped` (the exact ids from the 04/09 log) and `test_an_equal_sequence_from_an_older_run_is_still_dropped`.
- `test_tts_turn_queue.py`: 11/11 pass, including the three cases from `27ef9868` and the pre-existing equal-sequence conflict test, which stays green because its ids carry no stamp.
- Full `hal/test/`: 980 passed, 2 skipped, 1 failed — `test_lamp_sim_server.py::test_center_is_the_aim_that_recenters_yaw`, a socket TimeoutError in the simulator harness, unrelated to this change and untouched by it.
- Deployed to lamp-0c89 and reproduced end to end with the two turn ids from the incident: the log now reads `TTS turn counter restarted (... seq=2 <= ... latest_seq=2, but newer) -- adopting the new sequence` and the speaker plays.

## Docs

`docs/realtime-voice.md` + `docs/vi/realtime-voice_vi.md` — the turn-counter paragraph now covers the equal-sequence case and carries the 04/09 measurement.
