### PR TITLE
hal: bound recorded animation playback by declared motion.max_speed

### DIFF
--- a/docs/safety.md
+++ b/docs/safety.md
@@ -179,9 +179,20 @@ to the declared `motion.max_speed` at the single place the profile is chosen
 Lamp (`max_speed: 120`) nothing is clamped today; a body declaring a lower
 ceiling is what the gate is for.
 
-**Still not gated:** recorded animations. They replay stored frames at a fixed
-fps, so bounding their speed means changing how an animation looks, not
-stretching a number — an open question rather than a missing line of code.
+Recorded animations are gated at load time rather than per frame. A recording
+is resampled onto the playback loop's own fps grid, and any segment demanding
+more than the ceiling is *stretched in time* — the same degradation the route
+gate uses, applied per segment so a recording slows down exactly where it was
+impossible and nowhere else (`hal/drivers/motors/recording_timing.py`, shared by
+the physical and mock drivers so the simulator plays what the body plays). The
+ceiling is the lower of the servo's measured limit (`SERVO_MAX_DPS`, 250 deg/s)
+and the declared `motion.max_speed`.
+
+**Still not gated:** recorded moves on the Reachy SDK path. `ReachyMotionService`
+hands a trajectory to `mini.play_move()` and the Pollen daemon streams it, so HAL
+bounds only the ramp into frame 0 (`_ramp_for`, via `min_move_duration`) and not
+the body of the move. This is what a `HAL_REACHY_MOVES` list of community moves
+from the Hub (#207) would need answered first.
 
 ### Learned-policy interface (dry run)
 

--- a/docs/vi/safety_vi.md
+++ b/docs/vi/safety_vi.md
@@ -170,9 +170,19 @@ chính vòng lặp (55 / 100 deg/s, `hal/drivers/tracking/constants.py`) xuống
 trên Lamp (`max_speed: 120`) hôm nay không có gì bị kẹp; gate này dành cho thân nào
 khai trần thấp hơn.
 
-**Vẫn CHƯA gate:** recorded animation. Chúng phát lại frame đã lưu ở fps cố định,
-nên bound tốc độ nghĩa là đổi cách animation trông ra sao, không phải kéo dài một
-con số — đây là câu hỏi mở chứ không phải thiếu một dòng code.
+Recorded animation được gate lúc load chứ không phải từng frame. Recording được
+resample lên đúng lưới fps của vòng phát, và đoạn nào đòi hơn trần thì bị *giãn
+theo thời gian* — cùng kiểu suy giảm mà gate ở route dùng, áp theo từng đoạn nên
+recording chỉ chậm lại đúng chỗ bất khả thi, không chỗ nào khác
+(`hal/drivers/motors/recording_timing.py`, dùng chung cho driver thật và mock để
+simulator phát đúng thứ body phát). Trần là giá trị nhỏ hơn giữa giới hạn đo được
+của servo (`SERVO_MAX_DPS`, 250 deg/s) và `motion.max_speed` đã khai.
+
+**Vẫn CHƯA gate:** recorded move trên đường SDK của Reachy. `ReachyMotionService`
+giao trajectory cho `mini.play_move()` rồi daemon Pollen stream nó, nên HAL chỉ
+bound được đoạn ramp vào frame 0 (`_ramp_for`, qua `min_move_duration`), không
+bound được thân move. Đây là thứ phải trả lời trước nếu muốn có danh sách
+`HAL_REACHY_MOVES` nạp community move từ Hub (#207).
 
 ### Interface learned-policy (dry run)
 

--- a/hal/drivers/motors/animation_service.py
+++ b/hal/drivers/motors/animation_service.py
@@ -82,13 +82,17 @@ def _motor_positions_from_bus(robot: LeLampFollower) -> Dict[str, float]:
 
 
 class AnimationService:
-    def __init__(self, port: str, lamp_id: str, fps: int = 30, duration: float = 5.0, idle_recording: str = SERVO_IDLE, hold_s: float = 0.0):
+    def __init__(self, port: str, lamp_id: str, fps: int = 30, duration: float = 5.0, idle_recording: str = SERVO_IDLE, hold_s: float = 0.0, safety_policy=None):
         self.port = port
         self.lamp_id = lamp_id
         self.fps = fps
         self.duration = duration
         self.idle_recording = idle_recording
         self.hold_s = hold_s
+        # SAFETY.md motion.max_speed, applied to recording playback at load
+        # time (see _load_recording). aim/nudge take theirs per call from the
+        # route; playback has no route to carry it, so the service holds it.
+        self._safety_policy = safety_policy
         self._hold_until: float = 0.0  # timestamp until which to hold pose before returning to idle
         self._no_idle_recordings = NO_IDLE_RECORDINGS
         # disable_torque_on_disconnect=False: dropping torque is what `release()`
@@ -761,7 +765,8 @@ class AnimationService:
         """Load a recording from cache or file, resampled for playback.
 
         Frames are returned on the event loop's 1/fps grid with over-speed
-        segments stretched — see recording_timing.resample_recording. Playback stays a
+        segments stretched — over-speed against the servo's own limit and the
+        declared motion.max_speed, whichever is lower — see recording_timing.resample_recording. Playback stays a
         plain frame-per-tick walk.
         """
         # Check cache first
@@ -798,7 +803,11 @@ class AnimationService:
                 self._recording_cache[recording_name] = actions
                 return actions
 
-            actions = resample_recording(times, actions, recording_name, self.fps)
+            # Cached per name, which is safe: the policy is read once at boot
+            # and never changes for the life of the process.
+            actions = resample_recording(
+                times, actions, recording_name, self.fps, self._safety_policy
+            )
 
             # Cache the recording
             self._recording_cache[recording_name] = actions

--- a/hal/drivers/motors/mock_service.py
+++ b/hal/drivers/motors/mock_service.py
@@ -463,7 +463,9 @@ class MockMotionService:
         if len(frames) < 2 or len(times) != len(frames):
             # No usable time axis: play what was authored rather than invent timing.
             return [(index * step, positions) for index, positions in enumerate(frames)]
-        resampled = resample_recording(times, frames, name, PLAYBACK_FPS)
+        resampled = resample_recording(
+            times, frames, name, PLAYBACK_FPS, self._safety_policy
+        )
         return [(index * step, positions) for index, positions in enumerate(resampled)]
 
     def _record(self, name: str, *args: Any) -> None:

--- a/hal/drivers/motors/recording_timing.py
+++ b/hal/drivers/motors/recording_timing.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("hal.motion.timing")
 
@@ -24,6 +24,21 @@ logger = logging.getLogger("hal.motion.timing")
 # stretching and play recordings at their authored speed.
 SERVO_MAX_DPS = float(os.environ.get("HAL_SERVO_MAX_DPS", "250"))
 
+def effective_max_dps(policy: Any = None) -> float:
+    """The speed ceiling a replay must respect: hardware limit, then policy.
+
+    ``SERVO_MAX_DPS`` is what the servo can physically deliver; SAFETY.md's
+    ``motion.max_speed`` is what the body promises it will not exceed. A replay
+    is bound by whichever is lower, so a declared ceiling covers recordings the
+    same way it already covers move/aim/nudge (#219).
+    """
+    if SERVO_MAX_DPS <= 0 or policy is None:
+        return SERVO_MAX_DPS
+    from hal.safety.policy import cap_speed_dps
+
+    return cap_speed_dps(policy, SERVO_MAX_DPS)
+
+
 # Recordings are authored at ~20 Hz but a playback loop steps one frame per
 # tick at its own fps, so raw frames play at the wrong wall-clock speed. Frames
 # are resampled onto that grid at load time; this is the CSV column that
@@ -31,14 +46,17 @@ SERVO_MAX_DPS = float(os.environ.get("HAL_SERVO_MAX_DPS", "250"))
 RECORDING_TIME_COLUMN = "timestamp"
 
 
-def stretch_timeline(times: List[float], frames: List[Dict[str, float]]) -> List[float]:
+def stretch_timeline(
+    times: List[float], frames: List[Dict[str, float]], policy: Any = None
+) -> List[float]:
     """Widen the gaps that demand more joint speed than the servo can deliver.
 
     Returns a new, still-monotonic time axis. Only over-speed segments grow;
     everything else keeps its authored timing, so a recording slows down
     exactly where it was impossible and nowhere else.
     """
-    if SERVO_MAX_DPS <= 0:
+    max_dps = effective_max_dps(policy)
+    if max_dps <= 0:
         return times
 
     out = [times[0]]
@@ -48,20 +66,24 @@ def stretch_timeline(times: List[float], frames: List[Dict[str, float]]) -> List
             (abs(frames[i][j] - frames[i - 1][j]) for j in frames[i]),
             default=0.0,
         )
-        needed_dt = peak_delta / SERVO_MAX_DPS
+        needed_dt = peak_delta / max_dps
         out.append(out[-1] + max(authored_dt, needed_dt))
     return out
 
 
 def resample_recording(
-    times: List[float], frames: List[Dict[str, float]], name: str, fps: float
+    times: List[float],
+    frames: List[Dict[str, float]],
+    name: str,
+    fps: float,
+    policy: Any = None,
 ) -> List[Dict[str, float]]:
     """Put frames on a playback loop's own 1/fps grid.
 
     The loop steps exactly one frame per tick, so a list sampled at fps plays at
     real time by construction — no timing logic in the hot path.
     """
-    stretched = stretch_timeline(times, frames)
+    stretched = stretch_timeline(times, frames, policy)
     duration = stretched[-1] - stretched[0]
     if duration <= 0:
         return frames
@@ -84,9 +106,10 @@ def resample_recording(
         out.append({j: a[j] + (b[j] - a[j]) * p for j in joints})
 
     authored = times[-1] - times[0]
-    if SERVO_MAX_DPS > 0 and duration > authored * 1.01:
+    max_dps = effective_max_dps(policy)
+    if max_dps > 0 and duration > authored * 1.01:
         logger.info(
             "recording %r stretched %.2fs -> %.2fs to stay under %.0f deg/s",
-            name, authored, duration, SERVO_MAX_DPS,
+            name, authored, duration, max_dps,
         )
     return out

--- a/hal/server.py
+++ b/hal/server.py
@@ -395,6 +395,7 @@ async def lifespan(app: FastAPI):
                 svc = AnimationService(
                     port=SERVO_PORT, lamp_id=DEVICE_ID, fps=SERVO_FPS,
                     duration=SERVO_PLAY_RAMP_S, hold_s=SERVO_HOLD_S,
+                    safety_policy=_safety,
                 )
             else:
                 # SDK backends carry the safety policy themselves: their play

--- a/hal/test/test_recording_timing_policy.py
+++ b/hal/test/test_recording_timing_policy.py
@@ -1,0 +1,31 @@
+"""Recording playback respects SAFETY.md motion.max_speed (#219)."""
+from hal.drivers.motors.recording_timing import stretch_timeline
+from hal.safety.policy import MotionBounds, SafetyPolicy
+
+
+def _policy(max_speed):
+    return SafetyPolicy(schema="v1", motion=MotionBounds(max_speed=max_speed, stop_always=True))
+
+
+# One 30 deg step in 0.1s = 300 deg/s: over the servo limit and over any policy.
+TIMES = [0.0, 0.1]
+FRAMES = [{"base_yaw": 0.0}, {"base_yaw": 30.0}]
+
+
+def test_no_policy_uses_servo_limit():
+    # 30/250 = 0.12s
+    assert round(stretch_timeline(TIMES, FRAMES)[-1], 3) == 0.12
+
+
+def test_declared_ceiling_stretches_further():
+    # 30/120 = 0.25s — the declared bound is lower, so it wins.
+    assert round(stretch_timeline(TIMES, FRAMES, _policy(120))[-1], 3) == 0.25
+
+
+def test_ceiling_above_hardware_does_not_loosen():
+    assert round(stretch_timeline(TIMES, FRAMES, _policy(400))[-1], 3) == 0.12
+
+
+def test_slow_segment_untouched():
+    times, frames = [0.0, 1.0], [{"base_yaw": 0.0}, {"base_yaw": 10.0}]
+    assert stretch_timeline(times, frames, _policy(120)) == times

--- a/robots/lamp/docs/motion-playback.md
+++ b/robots/lamp/docs/motion-playback.md
@@ -11,7 +11,7 @@ Recordings in `hal/recordings/` are teleop captures authored at **20 Hz** (`time
 Resampling does two things:
 
 - **Honors the authored `timestamp`**, so a recording lasts as long as it was recorded to last. Stepping 20 Hz frames at 30 Hz previously played every animation 1.5× too fast.
-- **Stretches segments that exceed `SERVO_MAX_DPS`** (250 deg/s, `HAL_SERVO_MAX_DPS`; set to 0 to disable). The STS3215 tops out around 270 deg/s, and several recordings were authored well past that.
+- **Stretches segments that exceed the speed ceiling** — the lower of `SERVO_MAX_DPS` (250 deg/s, `HAL_SERVO_MAX_DPS`; set to 0 to disable) and the body's declared `motion.max_speed`. The STS3215 tops out around 270 deg/s, and several recordings were authored well past that; on Lamp the declared 120 deg/s is the binding one, and it stretches `laugh` (+20%), `playful`, `headshake` and `acknowledge`. No `music_*` recording is affected, so grooves keep their timing.
 
 The cap is not cosmetic. Measured on lamp-0c89 by sampling `Present_Position` while playing `greeting`: commanding 554 deg/s left the servo **55° behind its goal** — it saturates, lags, then snaps, which is the audible grinding. Stretching is surgical, applied only to the segments that were impossible:
 

--- a/robots/lamp/docs/vi/motion-playback_vi.md
+++ b/robots/lamp/docs/vi/motion-playback_vi.md
@@ -11,7 +11,7 @@ Recording trong `hal/recordings/` là bản ghi teleop ở **20 Hz** (cột `tim
 Resample làm hai việc:
 
 - **Tôn trọng `timestamp` gốc**, để recording dài đúng bằng lúc ghi. Trước đây bước frame 20 Hz ở nhịp 30 Hz làm mọi animation phát nhanh gấp 1.5×.
-- **Giãn những đoạn vượt `SERVO_MAX_DPS`** (250 deg/s, `HAL_SERVO_MAX_DPS`; đặt 0 để tắt). STS3215 chỉ đạt tối đa khoảng 270 deg/s, trong khi nhiều recording được ghi vượt xa mức đó.
+- **Giãn những đoạn vượt trần tốc độ** — lấy giá trị nhỏ hơn giữa `SERVO_MAX_DPS` (250 deg/s, `HAL_SERVO_MAX_DPS`; đặt 0 để tắt) và `motion.max_speed` mà body khai báo. STS3215 chỉ đạt tối đa khoảng 270 deg/s, trong khi nhiều recording được ghi vượt xa mức đó; trên Lamp thì mức khai báo 120 deg/s mới là mức có hiệu lực, và nó giãn `laugh` (+20%), `playful`, `headshake`, `acknowledge`. Không recording `music_*` nào bị ảnh hưởng nên các đoạn groove giữ nguyên nhịp.
 
 Ngưỡng này không phải để làm đẹp. Đo trên lamp-0c89 bằng cách đọc `Present_Position` trong lúc phát `greeting`: khi lệnh đòi 554 deg/s, servo bị bỏ lại **55° so với mục tiêu** — nó bão hòa, lết, rồi giật, và đó chính là tiếng ồn nghe được. Việc giãn rất chọn lọc, chỉ chạm vào những đoạn bất khả thi:
 


### PR DESCRIPTION
Closes the feetech half of #219.

`motion.max_speed` was enforced on `/servo/move`, `aim`, `nudge` and the vision-tracking loop, but not on the path a body actually moves by most: recorded animation playback. That path stretched only against `SERVO_MAX_DPS` (250 deg/s — the STS3215's *measured* limit), so Lamp's declared 120 deg/s ceiling was a promise nothing kept.

The mechanism the issue asked design for already exists: `recording_timing.stretch_timeline()` widens exactly the segments that are too fast and leaves the rest alone. This just gives it the right number — `min(SERVO_MAX_DPS, motion.max_speed)`, reusing the existing `cap_speed_dps` helper.

## Measured impact on Lamp (`max_speed: 120`)

4 of 29 recordings change duration at all:

| recording | authored | now (250) | capped at 120 | vs now |
|---|---|---|---|---|
| `laugh` | 3.95s | 3.96s | 4.75s | **+20%** |
| `playful` | 11.95s | 11.95s | 12.79s | +7.0% |
| `headshake` | 4.95s | 4.97s | 5.16s | +3.9% |
| `acknowledge` | 5.00s | 5.00s | 5.06s | +1.2% |

The other 25 are untouched, **including every `music_*`** — grooves keep their timing, which was the main worry in the issue.

## Still open, deliberately

Reachy's SDK path is not covered and cannot be by this change: `ReachyMotionService` hands the trajectory to `mini.play_move()` and the Pollen daemon streams it, so HAL bounds only the ramp into frame 0 (`_ramp_for`). That is the part #207 needs, and it gets its own issue rather than being smuggled in here. Both `docs/safety.md` and the VI version now say so explicitly instead of claiming recorded animations are ungated.

## Verification

- `make hal-lint` — clean, 309 files.
- `hal/.venv/bin/python -m pytest test/` — 985 passed, 2 skipped.
- New `hal/test/test_recording_timing_policy.py`: no policy → servo limit; declared 120 → stretches further; declared 400 → does **not** loosen past the hardware limit; slow segment untouched.
