### PR TITLE
hal: ground grid, DPR-aware canvas and hemisphere fill in the lamp simulator

### DIFF
--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -296,7 +296,10 @@ as HAL names them (`base_yaw`, `base_pitch`, `elbow_pitch`, `wrist_pitch`,
 `wrist_roll`) — driven by live joint values, plus recording playback and LED
 controls that call the same `/servo/*` and `/led/*` endpoints a skill calls.
 
-Drag to orbit, scroll to zoom, double-click to reset. The LED ring reads
+Drag to orbit, scroll to zoom, double-click to reset. The body stands on a
+700 mm ground grid (50 mm cells, brighter every 250 mm, fading to a circular
+edge) so pan and lean are readable against something; the canvas renders at the
+display's pixel ratio, capped at 2x. The LED ring reads
 `/simulator/pixels` (the strip buffer itself), not `/led/color`, because the
 latter reports an effect's static base colour and would render breathing, candle
 and rainbow as one dead colour.

--- a/docs/vi/simulator_vi.md
+++ b/docs/vi/simulator_vi.md
@@ -293,8 +293,10 @@ Một khung nhìn xoay được của mesh GLB có rig — năm joint node đặ
 điều khiển bởi giá trị khớp live, kèm replay recording và các nút LED gọi đúng
 `/servo/*`, `/led/*` mà một skill gọi.
 
-Kéo để xoay, lăn để zoom, double-click để reset. Vòng LED đọc `/simulator/pixels`
-(chính buffer của strip), không phải `/led/color`, vì endpoint đó trả màu base tĩnh
+Kéo để xoay, lăn để zoom, double-click để reset. Thân đèn đứng trên lưới sàn
+bán kính 700 mm (ô 50 mm, sáng hơn mỗi 250 mm, mờ dần ra mép tròn) để thấy rõ
+hướng quay và độ nghiêng; canvas render theo pixel ratio của màn hình, chặn ở 2x. Vòng LED đọc
+`/simulator/pixels` (chính buffer của strip), không phải `/led/color`, vì endpoint đó trả màu base tĩnh
 của effect và sẽ render breathing, candle, rainbow thành một màu chết.
 
 Tư thế render ra là **phản ứng thị giác** theo giá trị khớp live, **không phải**

--- a/hal/static/lamp-simulator.html
+++ b/hal/static/lamp-simulator.html
@@ -601,7 +601,13 @@
         // the light reads as coming out of the shade rather than painted on it.
         "float glow=m*LAMP_GAIN;" +
         "vec3 lamp=tint*glow+tint*glow*glow*0.35;" +
-        "vec3 body=color*(.18+.82*d)*(1.-.75*min(m,1.));" +
+                // A single directional light left every surface facing away from it
+        // sitting at a flat ambient floor, which is what made the body read as
+        // a cutout. Add the hemisphere term a real room has - cool light from
+        // above, warm bounce off the floor - at the same total as the constant
+        // it replaces, so nothing in the scene brightens.
+        "float sky=.5+.5*N.y;vec3 amb=mix(vec3(.15,.13,.11),vec3(.20,.22,.26),sky);" +
+        "vec3 body=color*(amb+.82*d)*(1.-.75*min(m,1.));" +
         "gl_FragColor=vec4(body+emit+rim*.10+lamp,1.);}";
       // A shader that fails to compile takes the whole program down with it and
       // every draw call then silently no-ops — an all-black canvas with nothing
@@ -1201,6 +1207,99 @@
         );
       }
 
+      // Ground grid. The body used to float in an empty void, which made it hard
+      // to read how far the head had panned or leaned. Lines are cut to a circle
+      // so the floor has no hard square edge, and fade with radius in place of
+      // the fog a full scene graph would give us. Millimetres, like the rest of
+      // the scene: the base is ~120 mm across.
+      const GRID_STEP = 50,
+        GRID_RADIUS = 700,
+        GRID_MAJOR = 250;
+      function gridBuffer() {
+        const v = [],
+          n = [],
+          shade = [];
+        const push = (x0, z0, x1, z1, major) => {
+          for (const [x, z] of [
+            [x0, z0],
+            [x1, z1],
+          ]) {
+            v.push(x, 0, z);
+            n.push(0, 1, 0);
+            // One brightness per vertex would need an extra attribute; the fade
+            // is baked per segment instead, which is why the lines are split at
+            // every step rather than drawn edge to edge.
+            const f = 1 - Math.hypot(x, z) / GRID_RADIUS;
+            shade.push(Math.max(0, f) * (major ? 1 : 0.45));
+          }
+        };
+        for (let a = -GRID_RADIUS; a <= GRID_RADIUS; a += GRID_STEP) {
+          const major = Math.abs(a) % GRID_MAJOR === 0;
+          for (let b = -GRID_RADIUS; b < GRID_RADIUS; b += GRID_STEP) {
+            const b1 = b + GRID_STEP;
+            if (Math.hypot(a, b) > GRID_RADIUS || Math.hypot(a, b1) > GRID_RADIUS)
+              continue;
+            push(a, b, a, b1, major);
+            push(b, a, b1, a, major);
+          }
+        }
+        return { v, n, shade, count: v.length / 3 };
+      }
+      const gridData = gridBuffer(),
+        gridPos = gl.createBuffer(),
+        gridNrm = gl.createBuffer();
+      for (const [buf, data] of [
+        [gridPos, gridData.v],
+        [gridNrm, gridData.n],
+      ]) {
+        gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+        gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(data), gl.STATIC_DRAW);
+      }
+      // Segments sorted into brightness buckets so the whole floor is a handful
+      // of draw calls instead of one per line.
+      const GRID_BUCKETS = 6;
+      const gridRanges = [];
+      for (let s = 0; s < gridData.count; s += 2) {
+        const level = Math.min(
+          GRID_BUCKETS - 1,
+          Math.floor(
+            ((gridData.shade[s] + gridData.shade[s + 1]) / 2) * GRID_BUCKETS,
+          ),
+        );
+        const last = gridRanges[gridRanges.length - 1];
+        if (last && last.level === level && last.first + last.count === s)
+          last.count += 2;
+        else gridRanges.push({ level, first: s, count: 2 });
+      }
+      function drawGrid() {
+        gl.uniform1f(L.skinned, 0);
+        gl.uniform1f(L.lampMask, 0);
+        gl.uniform1f(L.lampHeight, 0);
+        gl.uniform1f(L.ringLit, 0);
+        gl.uniform1f(L.ledLevel, 0);
+        gl.uniformMatrix4fv(L.model, false, M.id());
+        gl.uniformMatrix3fv(L.normal, false, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
+        gl.uniform3fv(L.color, [0, 0, 0]);
+        for (const [loc, buf] of [
+          [L.p, gridPos],
+          [L.n, gridNrm],
+        ]) {
+          gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+          gl.enableVertexAttribArray(loc);
+          gl.vertexAttribPointer(loc, 3, gl.FLOAT, false, 0, 0);
+        }
+        for (const loc of [L.joint, L.weight]) {
+          if (loc < 0) continue;
+          gl.disableVertexAttribArray(loc);
+          gl.vertexAttrib4f(loc, 0, 0, 0, 0);
+        }
+        for (const r of gridRanges) {
+          const f = ((r.level + 0.5) / GRID_BUCKETS) * 0.34;
+          gl.uniform3fv(L.emit, [f * 0.72, f * 0.82, f]);
+          gl.drawArrays(gl.LINES, r.first, r.count);
+        }
+      }
+
       function drawRig() {
         if (!rig) return;
         const joints = rigJointMatrices(),
@@ -1320,6 +1419,18 @@
         // here invented a trajectory the body never made — slower to start,
         // never quite arriving. The only smoothing left is HAL's own.
         for (const j of joints) pose[j] = target[j];
+        // The backbuffer used to be a fixed 960x720 stretched to whatever width
+        // the layout gave it, so every edge on a wide or retina screen was
+        // resampled - the single biggest reason this read as lower quality than
+        // it is. Track the CSS box instead, capped at 2x like any renderer does
+        // (3x on a phone costs 2.25x the fill for no visible gain).
+        const dpr = Math.min(window.devicePixelRatio || 1, 2),
+          w = Math.round(canvas.clientWidth * dpr) || canvas.width,
+          h = Math.round(canvas.clientHeight * dpr) || canvas.height;
+        if (canvas.width !== w || canvas.height !== h) {
+          canvas.width = w;
+          canvas.height = h;
+        }
         gl.viewport(0, 0, canvas.width, canvas.height);
         gl.enable(gl.DEPTH_TEST);
         gl.clearColor(0.045, 0.052, 0.05, 0);
@@ -1342,6 +1453,7 @@
           false,
           M.pers(0.78, canvas.width / canvas.height, 10, 1800),
         );
+        drawGrid();
         // Rig first: it is the only view that is both the real geometry and
         // jointed. drawPreview is the stand-in for when the GLB is missing.
         if (rawCAD) drawCAD();

--- a/hal/test/test_lamp_simulator_page.py
+++ b/hal/test/test_lamp_simulator_page.py
@@ -1,0 +1,50 @@
+"""Static checks on the simulator page's inline GLSL.
+
+The shaders are built by concatenating string literals. Dropping the `+` between
+two of them is not a JavaScript error - the rest of the shader parses as its own
+expression statement and is silently thrown away - so the page still loads and
+renders an untextured body with no explanation. Catch that here instead.
+"""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+PAGE = Path(__file__).resolve().parents[1] / "static" / "lamp-simulator.html"
+
+
+def shader_block(name: str) -> str:
+    source = PAGE.read_text(encoding="utf-8")
+    match = re.search(rf"\n      const {name} =\n(.*?;)\n", source, re.S)
+    assert match, f"const {name} not found in {PAGE}"
+    return match.group(1)
+
+
+class TestSimulatorShaders(unittest.TestCase):
+    def test_shader_literals_stay_concatenated(self):
+        for name in ("vs", "fs"):
+            block = shader_block(name)
+            pieces = [
+                line.strip()
+                for line in block.splitlines()
+                if line.strip().startswith('"')
+            ]
+            for piece in pieces[:-1]:
+                self.assertTrue(
+                    piece.endswith("+"),
+                    f"{name}: literal is not joined to the next one: {piece[:60]}…",
+                )
+            self.assertTrue(pieces[-1].endswith(";"), f"{name}: block does not end")
+
+    def test_fragment_shader_reaches_its_output(self):
+        self.assertIn("gl_FragColor", shader_block("fs"))
+
+    def test_ground_grid_is_drawn(self):
+        source = PAGE.read_text(encoding="utf-8")
+        self.assertIn("drawGrid();", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three things borrowed from the [animacy](https://github.com/Hcoder10/animacy) browser viewer (Apache-2.0), applied to `hal/static/lamp-simulator.html`.

**Ground grid.** 700 mm radius, 50 mm cells, brighter every 250 mm, cut to a circle and faded with radius — standing in for the fog a full scene graph gives you for free. Drawn with `gl.LINES` and bucketed by brightness, so the whole floor is ~6 draw calls. The body used to float in an empty void, which made it hard to read how far the head had panned or leaned.

**DPR-aware canvas.** The backbuffer was a fixed 960x720 stretched to whatever width the layout gave it, so every edge on a wide or retina screen was resampled. Now it tracks the CSS box at the display's pixel ratio, capped at 2x.

**Hemisphere fill.** A single directional light left every surface facing away from it at a flat ambient floor, which is what made the body read as a cutout. Replaced that constant with a hemisphere term at the same total, so nothing in the scene brightens. The LED path (`LAMP_GAIN`, `ringLit`, the per-pixel ring sampling) is untouched.

Not taken: their ACES tone mapping (it would undo the deliberate clipping the LED glow is tuned around) and URDF + `urdf-loader` (a rewrite, and it would cost the emissive shade driven by the 32 real ring pixels).

### Tests

`hal/test/test_lamp_simulator_page.py` — the shaders are built by concatenating string literals, and dropping the `+` between two of them is **not** a JavaScript error: the rest parses as its own expression statement and is silently discarded, so the page still loads and renders a body with no shading and no console output. This happened while writing the change. The test asserts every literal in `vs`/`fs` is joined to the next and that `fs` reaches `gl_FragColor`; removing a `+` fails it, restoring it passes.

### Verification

- `python3 -m unittest hal.test.test_lamp_simulator_page` — 3 passed
- `node --check` on the page's inline script — clean
- Grid geometry self-check: 1168 segments, no vertex outside the 700 mm radius

**Not verified visually.** The sandbox blocks both localhost and `file://` in the browser, and `hal/.venv` is not built here, so HAL could not be brought up. Worth an eyeball at `http://127.0.0.1:5001/simulator` under `make sim` before merging.

Docs updated in the same pass: `docs/simulator.md` + `docs/vi/simulator_vi.md`.