### PR TITLE
hal: frame the lamp simulator's camera from the model's own bounds

### DIFF
--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -296,8 +296,10 @@ as HAL names them (`base_yaw`, `base_pitch`, `elbow_pitch`, `wrist_pitch`,
 `wrist_roll`) — driven by live joint values, plus recording playback and LED
 controls that call the same `/servo/*` and `/led/*` endpoints a skill calls.
 
-Drag to orbit, scroll to zoom, double-click to reset. The body stands on a
-700 mm ground grid (50 mm cells, brighter every 250 mm, fading to a circular
+Drag to orbit, scroll to zoom, double-click to reset. Zoom spans 0.3x-4x of a 780 mm
+orbit (roughly 230 mm to 3.1 m) through a 38 deg lens, and elevation runs from
+level with the floor to just short of straight overhead. The body stands on a
+1.6 m ground grid (50 mm cells, brighter every 250 mm, fading to a circular
 edge) so pan and lean are readable against something; the canvas renders at the
 display's pixel ratio, capped at 2x. The LED ring reads
 `/simulator/pixels` (the strip buffer itself), not `/led/color`, because the

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -296,9 +296,11 @@ as HAL names them (`base_yaw`, `base_pitch`, `elbow_pitch`, `wrist_pitch`,
 `wrist_roll`) — driven by live joint values, plus recording playback and LED
 controls that call the same `/servo/*` and `/led/*` endpoints a skill calls.
 
-Drag to orbit, scroll to zoom, double-click to reset. Zoom spans 0.3x-4x of a 780 mm
-orbit (roughly 230 mm to 3.1 m) through a 38 deg lens, and elevation runs from
-level with the floor to just short of straight overhead. The body stands on a
+Drag to orbit, scroll to zoom, double-click to reset. The camera aims at the centre of
+whatever geometry loaded and backs off far enough to frame it, so the head does
+not run off the canvas on a wide window. Zoom spans 0.3x-4x of that distance
+through a 38 deg lens, and elevation runs from level with the floor to just
+short of straight overhead. The body stands on a
 1.6 m ground grid (50 mm cells, brighter every 250 mm, fading to a circular
 edge) so pan and lean are readable against something; the canvas renders at the
 display's pixel ratio, capped at 2x. The LED ring reads

--- a/docs/vi/simulator_vi.md
+++ b/docs/vi/simulator_vi.md
@@ -293,9 +293,11 @@ Một khung nhìn xoay được của mesh GLB có rig — năm joint node đặ
 điều khiển bởi giá trị khớp live, kèm replay recording và các nút LED gọi đúng
 `/servo/*`, `/led/*` mà một skill gọi.
 
-Kéo để xoay, lăn để zoom, double-click để reset. Thân đèn đứng trên lưới sàn
-bán kính 700 mm (ô 50 mm, sáng hơn mỗi 250 mm, mờ dần ra mép tròn) để thấy rõ
-hướng quay và độ nghiêng; canvas render theo pixel ratio của màn hình, chặn ở 2x. Vòng LED đọc
+Kéo để xoay, lăn để zoom, double-click để reset. Zoom chạy 0,3x-4x của quỹ đạo
+780 mm (khoảng 230 mm tới 3,1 m) qua ống kính 38 deg, độ cao camera từ ngang sàn
+tới gần thẳng đứng trên đỉnh. Thân đèn đứng trên lưới sàn bán kính 1,6 m (ô
+50 mm, sáng hơn mỗi 250 mm, mờ dần ra mép tròn) để thấy rõ hướng quay và độ
+nghiêng; canvas render theo pixel ratio của màn hình, chặn ở 2x. Vòng LED đọc
 `/simulator/pixels` (chính buffer của strip), không phải `/led/color`, vì endpoint đó trả màu base tĩnh
 của effect và sẽ render breathing, candle, rainbow thành một màu chết.
 

--- a/docs/vi/simulator_vi.md
+++ b/docs/vi/simulator_vi.md
@@ -293,9 +293,10 @@ Một khung nhìn xoay được của mesh GLB có rig — năm joint node đặ
 điều khiển bởi giá trị khớp live, kèm replay recording và các nút LED gọi đúng
 `/servo/*`, `/led/*` mà một skill gọi.
 
-Kéo để xoay, lăn để zoom, double-click để reset. Zoom chạy 0,3x-4x của quỹ đạo
-780 mm (khoảng 230 mm tới 3,1 m) qua ống kính 38 deg, độ cao camera từ ngang sàn
-tới gần thẳng đứng trên đỉnh. Thân đèn đứng trên lưới sàn bán kính 1,6 m (ô
+Kéo để xoay, lăn để zoom, double-click để reset. Camera ngắm vào tâm của hình học
+đang được nạp và lùi đủ xa để lọt hết khung, nên đầu đèn không bị cắt mất trên
+màn hình rộng. Zoom chạy 0,3x-4x của khoảng cách đó qua ống kính 38 deg, độ cao
+camera từ ngang sàn tới gần thẳng đứng trên đỉnh. Thân đèn đứng trên lưới sàn bán kính 1,6 m (ô
 50 mm, sáng hơn mỗi 250 mm, mờ dần ra mép tròn) để thấy rõ hướng quay và độ
 nghiêng; canvas render theo pixel ratio của màn hình, chặn ở 2x. Vòng LED đọc
 `/simulator/pixels` (chính buffer của strip), không phải `/led/color`, vì endpoint đó trả màu base tĩnh

--- a/hal/static/lamp-simulator.html
+++ b/hal/static/lamp-simulator.html
@@ -429,12 +429,25 @@
       // Perceptual (gamma) curve instead — hue and relative ordering are kept,
       // only the low end is lifted into the range a monitor can show.
       const displayLevel = (peak) => Math.pow(Math.min(1, peak / 255), 0.4);
+      // Camera framing. A 38 deg lens instead of the 45 this shipped with: the
+      // wider one splayed the base and read as a fisheye once the head leaned.
+      // ORBIT_R is the matching distance, so the default view frames the same
+      // body it always did. The zoom range used to run 0.65-1.55, barely half a
+      // step either way - you could not back off to see the lamp on its floor
+      // nor push in on the shade. It now spans a factor of ~13, which needs the
+      // far plane pushed out or the far end of it clips the grid away.
+      const CAM_FOV = 0.663,
+        CAM_EL = 0.34,
+        ORBIT_R = 780,
+        ZOOM_MIN = 0.3,
+        ZOOM_MAX = 4;
+
       let target = Object.fromEntries(joints.map((j) => [j, 0])),
         pose = { ...target },
         led = [0, 0, 0],
         ringPixels = [],
         az = -0.68,
-        el = 0.27,
+        el = CAM_EL,
         zoom = 1,
         drag,
         rawCAD = new URLSearchParams(location.search).has("raw"),
@@ -1213,25 +1226,30 @@
       // the fog a full scene graph would give us. Millimetres, like the rest of
       // the scene: the base is ~120 mm across.
       const GRID_STEP = 50,
-        GRID_RADIUS = 700,
+        GRID_RADIUS = 1600,
         GRID_MAJOR = 250;
+      // Segments are bucketed by brightness and emitted in bucket order, so the
+      // whole floor is GRID_BUCKETS draw calls no matter how large the grid is.
+      // Sorting matters: laid out geometrically, the buckets interleave and the
+      // same floor cost 163 calls a frame.
+      const GRID_BUCKETS = 6;
       function gridBuffer() {
-        const v = [],
-          n = [],
-          shade = [];
+        const buckets = Array.from({ length: GRID_BUCKETS }, () => []);
         const push = (x0, z0, x1, z1, major) => {
-          for (const [x, z] of [
+          const ends = [
             [x0, z0],
             [x1, z1],
-          ]) {
-            v.push(x, 0, z);
-            n.push(0, 1, 0);
-            // One brightness per vertex would need an extra attribute; the fade
-            // is baked per segment instead, which is why the lines are split at
-            // every step rather than drawn edge to edge.
-            const f = 1 - Math.hypot(x, z) / GRID_RADIUS;
-            shade.push(Math.max(0, f) * (major ? 1 : 0.45));
-          }
+          ];
+          const shade =
+            ends.reduce(
+              (a, [x, z]) => a + Math.max(0, 1 - Math.hypot(x, z) / GRID_RADIUS),
+              0,
+            ) / 2;
+          const level = Math.min(
+            GRID_BUCKETS - 1,
+            Math.floor(shade * (major ? 1 : 0.45) * GRID_BUCKETS),
+          );
+          for (const [x, z] of ends) buckets[level].push(x, 0, z);
         };
         for (let a = -GRID_RADIUS; a <= GRID_RADIUS; a += GRID_STEP) {
           const major = Math.abs(a) % GRID_MAJOR === 0;
@@ -1243,7 +1261,16 @@
             push(b, a, b1, a, major);
           }
         }
-        return { v, n, shade, count: v.length / 3 };
+        const v = [],
+          ranges = [];
+        buckets.forEach((pts, level) => {
+          if (!pts.length) return;
+          ranges.push({ level, first: v.length / 3, count: pts.length / 3 });
+          v.push(...pts);
+        });
+        // The lines are flat on the floor, so every normal is straight up - the
+        // shader needs the attribute, not a real surface.
+        return { v, n: v.map((_, i) => (i % 3 === 1 ? 1 : 0)), ranges };
       }
       const gridData = gridBuffer(),
         gridPos = gl.createBuffer(),
@@ -1254,22 +1281,6 @@
       ]) {
         gl.bindBuffer(gl.ARRAY_BUFFER, buf);
         gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(data), gl.STATIC_DRAW);
-      }
-      // Segments sorted into brightness buckets so the whole floor is a handful
-      // of draw calls instead of one per line.
-      const GRID_BUCKETS = 6;
-      const gridRanges = [];
-      for (let s = 0; s < gridData.count; s += 2) {
-        const level = Math.min(
-          GRID_BUCKETS - 1,
-          Math.floor(
-            ((gridData.shade[s] + gridData.shade[s + 1]) / 2) * GRID_BUCKETS,
-          ),
-        );
-        const last = gridRanges[gridRanges.length - 1];
-        if (last && last.level === level && last.first + last.count === s)
-          last.count += 2;
-        else gridRanges.push({ level, first: s, count: 2 });
       }
       function drawGrid() {
         gl.uniform1f(L.skinned, 0);
@@ -1293,7 +1304,7 @@
           gl.disableVertexAttribArray(loc);
           gl.vertexAttrib4f(loc, 0, 0, 0, 0);
         }
-        for (const r of gridRanges) {
+        for (const r of gridData.ranges) {
           const f = ((r.level + 0.5) / GRID_BUCKETS) * 0.34;
           gl.uniform3fv(L.emit, [f * 0.72, f * 0.82, f]);
           gl.drawArrays(gl.LINES, r.first, r.count);
@@ -1440,7 +1451,7 @@
         // to carry it, so nothing moves there either.
         const previewAz = az,
           previewEl = el,
-          r = 660 * zoom,
+          r = ORBIT_R * zoom,
           t = [0, 205, 0],
           eye = [
             r * Math.sin(previewAz) * Math.cos(previewEl),
@@ -1451,7 +1462,7 @@
         gl.uniformMatrix4fv(
           L.proj,
           false,
-          M.pers(0.78, canvas.width / canvas.height, 10, 1800),
+          M.pers(CAM_FOV, canvas.width / canvas.height, 5, 9000),
         );
         drawGrid();
         // Rig first: it is the only view that is both the real geometry and
@@ -1765,9 +1776,13 @@
       canvas.addEventListener("pointermove", (e) => {
         if (!drag) return;
         az += (e.clientX - drag[0]) * 0.011;
+        // Elevation ran -24..43 deg, which could neither get level with the
+        // desk nor look down on the base. Stop just short of straight overhead:
+        // at exactly 90 the eye lands on the up vector and the view matrix goes
+        // singular.
         el = Math.max(
-          -0.42,
-          Math.min(0.75, el + (e.clientY - drag[1]) * 0.009),
+          -0.06,
+          Math.min(1.45, el + (e.clientY - drag[1]) * 0.009),
         );
         drag = [e.clientX, e.clientY];
       });
@@ -1778,15 +1793,15 @@
         (e) => {
           e.preventDefault();
           zoom = Math.max(
-            0.65,
-            Math.min(1.55, zoom * (e.deltaY > 0 ? 1.08 : 0.92)),
+            ZOOM_MIN,
+            Math.min(ZOOM_MAX, zoom * (e.deltaY > 0 ? 1.08 : 0.92)),
           );
         },
         { passive: false },
       );
       canvas.addEventListener("dblclick", () => {
         az = -0.68;
-        el = 0.27;
+        el = CAM_EL;
         zoom = 1;
       });
       // Ring pixels on the same fast timer as motion. /led/color reports an

--- a/hal/static/lamp-simulator.html
+++ b/hal/static/lamp-simulator.html
@@ -440,7 +440,43 @@
         CAM_EL = 0.34,
         ORBIT_R = 780,
         ZOOM_MIN = 0.3,
-        ZOOM_MAX = 4;
+        ZOOM_MAX = 4,
+        // How much room to leave around the body at zoom 1. The bounding box is
+        // measured at the rest pose; a raised head reaches past it, so the fit
+        // has to carry more margin than a static model would need.
+        CAM_MARGIN = 1.18;
+      // A bounding sphere for whatever geometry is on screen, in scene
+      // millimetres. The camera used to sit at a hard-coded distance aiming at a
+      // hard-coded height, which framed the body it was tuned against and
+      // clipped everything else - the head ran off the top of the canvas on a
+      // wide window.
+      function growBox(box, positions) {
+        for (let i = 0; i < positions.length; i += 3)
+          for (let k = 0; k < 3; k++) {
+            const c = positions[i + k];
+            if (c < box.lo[k]) box.lo[k] = c;
+            if (c > box.hi[k]) box.hi[k] = c;
+          }
+        return positions;
+      }
+      const emptyBox = () => ({
+        lo: [Infinity, Infinity, Infinity],
+        hi: [-Infinity, -Infinity, -Infinity],
+      });
+      function boundsOf(box, scale) {
+        if (!box.lo.every(isFinite) || !box.hi.every(isFinite)) return null;
+        const lo = box.lo.map((c) => c * scale),
+          hi = box.hi.map((c) => c * scale);
+        return {
+          center: lo.map((c, k) => (c + hi[k]) / 2),
+          radius: Math.hypot(...hi.map((c, k) => (c - lo[k]) / 2)),
+        };
+      }
+      // Distance at which a sphere of `radius` fills the frame vertically. The
+      // canvas is never taller than it is wide here, so the vertical field is
+      // always the tighter of the two.
+      const fitDistance = (radius) =>
+        (radius / Math.tan(CAM_FOV / 2)) * CAM_MARGIN;
 
       let target = Object.fromEntries(joints.map((j) => [j, 0])),
         pose = { ...target },
@@ -1122,6 +1158,9 @@
           ibm = readAccessor(skin.inverseBindMatrices),
           jointNodes = skin.joints;
         const parts = [];
+        // Every mesh in the file contributes to the frame, so the box is grown
+        // primitive by primitive rather than measured from one of them.
+        const rigBox = emptyBox();
         for (const node of gltf.nodes) {
           if (node.mesh === undefined) continue;
           const skinned = node.skin !== undefined;
@@ -1146,7 +1185,7 @@
                   : gl.UNSIGNED_SHORT,
               index: buffer(indices, gl.ELEMENT_ARRAY_BUFFER),
               position: buffer(
-                readAccessor(prim.attributes.POSITION),
+                growBox(rigBox, readAccessor(prim.attributes.POSITION)),
                 gl.ARRAY_BUFFER,
               ),
               normal: buffer(
@@ -1172,6 +1211,7 @@
           gl.getExtension("OES_element_index_uint");
 
         rig = {
+          bounds: boundsOf(rigBox, RIG_SCALE),
           nodes: gltf.nodes,
           jointNodes,
           ibm,
@@ -1389,7 +1429,10 @@
             }
           }
           const positions = source.subarray(0, out);
-          cadMesh = { count: out / 3 };
+          cadMesh = {
+            count: out / 3,
+            bounds: boundsOf(growBox(emptyBox(), positions), 1),
+          };
           for (const [k, data] of Object.entries({
             p: positions,
             n: n.subarray(0, out),
@@ -1449,10 +1492,14 @@
         // The camera stays where the user put it. In the jointed preview the
         // body itself carries the pose; the static CAD assembly has no joints
         // to carry it, so nothing moves there either.
+        const shown = rawCAD ? cadMesh : rig,
+          bounds = shown && shown.bounds;
         const previewAz = az,
           previewEl = el,
-          r = ORBIT_R * zoom,
-          t = [0, 205, 0],
+          // No bounds yet (still loading, or the box stand-in): fall back to the
+          // distance and aim this page shipped with.
+          r = (bounds ? fitDistance(bounds.radius) : ORBIT_R) * zoom,
+          t = bounds ? bounds.center : [0, 205, 0],
           eye = [
             r * Math.sin(previewAz) * Math.cos(previewEl),
             t[1] + r * Math.sin(previewEl),


### PR DESCRIPTION
Follow-up to #295, which landed the grid and the canvas fixes. These two commits are the camera itself. Both were pushed to that branch after it had already been merged, so they never reached `main`; this PR carries them.

### Zoom range and lens (`38416e90`)

| | animacy | here (before) | now |
|---|---|---|---|
| Zoom | 0.08–6 m (~75x) | 0.65–1.55x (~2.4x) | 0.3–4x (~13x) |
| Lens | 38° | 44.7° | 38° |
| Elevation | level → overhead | −24°…43° | −3°…83° |
| Far plane | 50 m | 1.8 m | 9 m |

`0.65–1.55` is barely half a step either way — you could neither back off to see the lamp standing on its floor nor push in on the shade. The 45° lens was the other half: it splayed the base and read as a fisheye once the head leaned.

Also fixes something from #295: at a 3.2 m grid the brightness buckets interleave geometrically and the floor cost **163 draw calls a frame**. Segments are now sorted into bucket order before upload — **6 calls**, independent of grid size.

### Auto-framing (`726dfa9f`)

Predates all of this: the camera aimed at a hard-coded `y = 205 mm` from a hard-coded distance, so it only ever showed a ±270 mm band around that height. The body is ~450 mm tall and the shade fell outside it — visible as the head running off the top of the canvas on a wide window. The lens change above deliberately preserved the old framing, so it preserved this too.

animacy's `viewer.js` hard-codes neither: `frame()` measures the bounding box and derives the distance from it, aiming at the box centre. Ported:

- the box is grown primitive by primitive while parsing the GLB, and from the STL on the CAD path
- the camera aims at the box centre at `radius / tan(fov/2) * 1.18` — a wider margin than theirs because the box is measured at the rest pose and a raised head reaches past it
- `zoom` is a multiple of that fitted distance rather than of a constant
- the old distance stays as the fallback for the frames before the model has loaded

For a ~0.15 × 0.45 × 0.15 m body: centre y = 225 mm, radius 249 mm, distance 853 mm, half-frame 293 mm > 249.

### Verification

- `python3 -m unittest hal.test.test_lamp_simulator_page` — 3 passed
- `node --check` on the page's inline script — clean
- `growBox` / `boundsOf` / `fitDistance` extracted from the page and run against a synthetic box: centre correct, frame wider than the body, an empty box yields `null`
- grid self-check: 6288 segments, 6 draw calls, no vertex outside the radius, every vertex at y=0

Not verified visually here (no browser access from this sandbox). The framing numbers above are arithmetic, not a screenshot.

Docs updated in the same commits: `docs/simulator.md` + `docs/vi/simulator_vi.md`.