### PR TITLE
hal: open the lamp simulator on the lamp's face, not behind its head

### DIFF
--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -296,8 +296,9 @@ as HAL names them (`base_yaw`, `base_pitch`, `elbow_pitch`, `wrist_pitch`,
 `wrist_roll`) — driven by live joint values, plus recording playback and LED
 controls that call the same `/servo/*` and `/led/*` endpoints a skill calls.
 
-Drag to orbit, scroll to zoom, double-click to reset. The camera aims at the centre of
-whatever geometry loaded and backs off far enough to frame it, so the head does
+Drag to orbit, scroll to zoom, double-click to reset. The camera opens on the lamp's face,
+three quarters round from dead-on, aims at the centre of whatever geometry
+loaded and backs off far enough to frame it, so the head does
 not run off the canvas on a wide window. Zoom spans 0.3x-4x of that distance
 through a 38 deg lens, and elevation runs from level with the floor to just
 short of straight overhead. The body stands on a

--- a/docs/vi/simulator_vi.md
+++ b/docs/vi/simulator_vi.md
@@ -293,8 +293,9 @@ Một khung nhìn xoay được của mesh GLB có rig — năm joint node đặ
 điều khiển bởi giá trị khớp live, kèm replay recording và các nút LED gọi đúng
 `/servo/*`, `/led/*` mà một skill gọi.
 
-Kéo để xoay, lăn để zoom, double-click để reset. Camera ngắm vào tâm của hình học
-đang được nạp và lùi đủ xa để lọt hết khung, nên đầu đèn không bị cắt mất trên
+Kéo để xoay, lăn để zoom, double-click để reset. Camera mở ra ở mặt trước đèn, lệch 3/4
+so với chính diện, ngắm vào tâm của hình học đang được nạp và lùi đủ xa để lọt
+hết khung, nên đầu đèn không bị cắt mất trên
 màn hình rộng. Zoom chạy 0,3x-4x của khoảng cách đó qua ống kính 38 deg, độ cao
 camera từ ngang sàn tới gần thẳng đứng trên đỉnh. Thân đèn đứng trên lưới sàn bán kính 1,6 m (ô
 50 mm, sáng hơn mỗi 250 mm, mờ dần ra mép tròn) để thấy rõ hướng quay và độ

--- a/hal/static/lamp-simulator.html
+++ b/hal/static/lamp-simulator.html
@@ -436,7 +436,12 @@
       // step either way - you could not back off to see the lamp on its floor
       // nor push in on the shade. It now spans a factor of ~13, which needs the
       // far plane pushed out or the far end of it clips the grid away.
+      // Which way the lamp faces. The rig's rest pose aims the shade at az 2.46,
+      // so the old default sat behind its head; this is that heading swung 3/4
+      // round, the same off-axis framing animacy opens with. Dead-on (2.46) puts
+      // the arm edge-on and unlit, which reads flat.
       const CAM_FOV = 0.663,
+        CAM_AZ = 1.2,
         CAM_EL = 0.34,
         ORBIT_R = 780,
         ZOOM_MIN = 0.3,
@@ -482,7 +487,7 @@
         pose = { ...target },
         led = [0, 0, 0],
         ringPixels = [],
-        az = -0.68,
+        az = CAM_AZ,
         el = CAM_EL,
         zoom = 1,
         drag,
@@ -1847,7 +1852,7 @@
         { passive: false },
       );
       canvas.addEventListener("dblclick", () => {
-        az = -0.68;
+        az = CAM_AZ;
         el = CAM_EL;
         zoom = 1;
       });


### PR DESCRIPTION
The default view opened behind the lamp's head. The rest pose aims the shade at azimuth 2.46 and the default sat at −0.68 — very nearly 180° off, so the page loaded looking at the back of the shade.

`CAM_AZ = 1.2`: that heading swung three quarters round.

### How the angle was picked

HAL was running locally (`make sim`), so this one is measured rather than reasoned. The page temporarily accepted an `?az=` override and four azimuths were rendered through headless Chrome (`--headless=new --enable-unsafe-swiftshader`, which does render the page's WebGL):

- **2.46** — dead-on. Confirms where the rig actually faces.
- **1.675** — 45° off, animacy's own framing. Still too frontal here: the arm goes edge-on and falls in shadow, and the whole body reads flat.
- **1.2** — face toward the viewer, arm in three-quarter and catching the key light. Picked.
- **−2.2** — the mirror side, no better than 1.2.

The `?az=` override is gone; only the constant remains.

### Verification

- Rendered the final default through headless Chrome against live HAL — the lamp faces the viewer, whole body inside the frame, grid reading to the edge
- `python3 -m unittest hal.test.test_lamp_simulator_page` — 3 passed
- `node --check` on the page's inline script — clean

Docs updated in the same commit: `docs/simulator.md` + `docs/vi/simulator_vi.md`.