### PR TITLE
hal: stop a one-word fragment from making the lamp greet a stranger

### DIFF
--- a/hal/drivers/voice/_internal/speaker_decorate.py
+++ b/hal/drivers/voice/_internal/speaker_decorate.py
@@ -367,12 +367,19 @@ class SpeakerDecorator:
                 f"if having speaker name in transcript, else ask user's name)"
             )
 
+        # No trailing "otherwise ask them to introduce themselves". This branch is
+        # the one a meaningless fragment lands in — too short to enrol IS the
+        # common case for a lone word STT scraped off someone talking nearby —
+        # and that clause is an imperative glued onto the turn text itself. The
+        # model then obeys the nearest, most specific instruction over the
+        # silence rule and greets a passer-by ("I don't think we've met, what's
+        # your name?") on the strength of one word. Surface the path and the tag
+        # so a LATER real turn can still enrol; never ask on this one.
         return (
             f"Unknown Speaker:{hash_tag} {transcript} "
             f"(audio saved at {audio_path}. Note: audio is too short for "
             f"single enrollment. If prior turns tagged the same {voiceprint_hash or 'voice cluster'}, "
-            f"combine their saved paths with this one when enrolling; "
-            f"otherwise ask the user to introduce themselves longer.)"
+            f"combine their saved paths with this one when enrolling.)"
         )
 
     # ------------------------------------------------------------------

--- a/hal/drivers/voice/_internal/vad_filters.py
+++ b/hal/drivers/voice/_internal/vad_filters.py
@@ -183,7 +183,7 @@ class SileroVADFilter:
             return True
 
     def speech_metrics(self, data, device_rate: int):
-        """Return (peak, mean, voiced_ratio, span_ratio) for `data`.
+        """Return (peak, mean, voiced_ratio, span_ratio, span_seconds) for `data`.
 
         Unlike is_speech (which is peak-only — one transient chunk crossing the
         threshold marks the whole buffer speech, fine for fast onset detection at
@@ -200,11 +200,21 @@ class SileroVADFilter:
         judging a live sliding window (barge-in) wants voiced_ratio, since there
         is no padding to discount and a span measure would only be more lenient.
 
-        Fails open: returns (1.0, 1.0, 1.0, 1.0) on error so callers treat it as
-        speech.
+        `span_seconds` is the WALL LENGTH of that same span — the actual
+        utterance, with the padding excluded. It is not the buffer duration the
+        caller already has: a capture is padded at both ends, so a single word
+        still yields a multi-second buffer (measured on lamp-0c89: no buffer
+        shorter than 1.73s in 14 days, `"the"` alone arriving as 3.46s). Any
+        gate meaning "too short to be addressed to us" has to read this, not the
+        buffer.
+
+        Fails open: returns (1.0, 1.0, 1.0, 1.0, 0.0) on error so callers treat
+        it as speech. The 0.0 span is deliberately NOT a plausible utterance
+        length — a fail-open path must not hand a duration gate a number it can
+        act on.
         """
         if self._session is None:
-            return (1.0, 1.0, 1.0, 1.0)
+            return (1.0, 1.0, 1.0, 1.0, 0.0)
         try:
             np = self._np
             if device_rate != STT_RATE:
@@ -237,7 +247,7 @@ class SileroVADFilter:
                     self._context = x[:, -64:]
 
             if not confs:
-                return (1.0, 1.0, 1.0, 1.0)
+                return (1.0, 1.0, 1.0, 1.0, 0.0)
             peak = max(confs)
             mean = sum(confs) / len(confs)
             voiced = [c >= SILERO_VAD_THRESHOLD for c in confs]
@@ -250,12 +260,14 @@ class SileroVADFilter:
                 last = len(voiced) - 1 - voiced[::-1].index(True)
                 span = voiced[first:last + 1]
                 span_ratio = sum(span) / len(span)
+                span_seconds = len(span) * SILERO_CHUNK_SIZE / STT_RATE
             else:
                 span_ratio = ratio
-            return (peak, mean, ratio, span_ratio)
+                span_seconds = 0.0
+            return (peak, mean, ratio, span_ratio, span_seconds)
         except Exception as e:
             logger.warning("Silero speech_metrics error: %s", e)
-            return (1.0, 1.0, 1.0, 1.0)
+            return (1.0, 1.0, 1.0, 1.0, 0.0)
 
 
 def turn_should_close(

--- a/hal/drivers/voice/voice_service.py
+++ b/hal/drivers/voice/voice_service.py
@@ -554,7 +554,7 @@ class VoiceService:
                 logger.warning("Realtime noise-guard Silero load failed: %s", e)
                 return True
         try:
-            peak, mean, ratio, span_ratio = self._rt_noise_vad.speech_metrics(
+            peak, mean, ratio, span_ratio, span_seconds = self._rt_noise_vad.speech_metrics(
                 pcm_int16, voice_cfg.STT_RATE
             )
             self._rt_noise_vad.reset_state()
@@ -575,8 +575,8 @@ class VoiceService:
             is_speech = span_ratio >= hal_config.REALTIME_NOISE_SPEECH_RATIO
             logger.info(
                 "[realtime] noise-guard metrics: peak=%.3f mean=%.3f voiced_ratio=%.3f "
-                "span_ratio=%.3f (span >= %.2f? %s)",
-                peak, mean, ratio, span_ratio,
+                "span_ratio=%.3f span_seconds=%.2f (span >= %.2f? %s)",
+                peak, mean, ratio, span_ratio, span_seconds,
                 hal_config.REALTIME_NOISE_SPEECH_RATIO, is_speech,
             )
             return is_speech
@@ -606,7 +606,7 @@ class VoiceService:
             # Whole-window ratio, not the span: a live sliding window carries no
             # capture padding to discount, and a span measure would only make
             # the device easier to interrupt with a burst of noise.
-            peak, _mean, ratio, _span = self._rt_noise_vad.speech_metrics(
+            peak, _mean, ratio, _span, _span_s = self._rt_noise_vad.speech_metrics(
                 window, voice_cfg.STT_RATE
             )
             self._rt_noise_vad.reset_state()

--- a/hal/test/test_silero_speech_metrics.py
+++ b/hal/test/test_silero_speech_metrics.py
@@ -46,7 +46,7 @@ def test_padded_short_utterance_survives_on_span():
     # the buffer, but unbroken speech once the padding is discounted.
     confs = [0.0] * 4 + [0.9] * 6 + [0.0] * 2
 
-    _peak, _mean, ratio, span_ratio = _metrics_for(confs)
+    _peak, _mean, ratio, span_ratio, _span_s = _metrics_for(confs)
 
     assert ratio == pytest.approx(0.5)
     assert span_ratio == pytest.approx(1.0)
@@ -57,7 +57,7 @@ def test_sustained_noise_still_fails_on_span():
     # cannot rescue it, because the gaps are INSIDE the span.
     confs = [0.0, 0.9, 0.0, 0.0, 0.0, 0.9, 0.0, 0.0, 0.0, 0.9, 0.0, 0.0]
 
-    _peak, _mean, ratio, span_ratio = _metrics_for(confs)
+    _peak, _mean, ratio, span_ratio, _span_s = _metrics_for(confs)
 
     assert ratio == pytest.approx(0.25)
     assert span_ratio == pytest.approx(3 / 9)
@@ -65,14 +65,14 @@ def test_sustained_noise_still_fails_on_span():
 
 
 def test_buffer_with_no_voiced_chunk_reports_zero_for_both():
-    _peak, _mean, ratio, span_ratio = _metrics_for([0.0] * 8)
+    _peak, _mean, ratio, span_ratio, _span_s = _metrics_for([0.0] * 8)
 
     assert ratio == 0.0
     assert span_ratio == 0.0
 
 
 def test_fully_voiced_buffer_scores_one_either_way():
-    _peak, mean, ratio, span_ratio = _metrics_for([0.9] * 8)
+    _peak, mean, ratio, span_ratio, _span_s = _metrics_for([0.9] * 8)
 
     assert mean == pytest.approx(0.9)
     assert ratio == pytest.approx(1.0)
@@ -85,4 +85,20 @@ def test_metrics_fail_open_when_the_model_is_missing():
     vad._lock = threading.Lock()
     vad._session = None
 
-    assert vad.speech_metrics(np.zeros(512, dtype=np.int16), 16000) == (1.0, 1.0, 1.0, 1.0)
+    assert vad.speech_metrics(np.zeros(512, dtype=np.int16), 16000) == (1.0, 1.0, 1.0, 1.0, 0.0)
+
+
+def test_span_seconds_measures_the_utterance_not_the_buffer():
+    # 6 voiced chunks inside a 12-chunk buffer. The span is the speech alone;
+    # the padding must not inflate it. 512 samples @ 16kHz = 32ms per chunk.
+    confs = [0.0] * 4 + [0.9] * 6 + [0.0] * 2
+
+    *_rest, span_seconds = _metrics_for(confs)
+
+    assert span_seconds == pytest.approx(6 * 512 / 16000)
+
+
+def test_span_seconds_is_zero_when_nothing_is_voiced():
+    *_rest, span_seconds = _metrics_for([0.0] * 8)
+
+    assert span_seconds == 0.0

--- a/hal/test/test_unknown_speaker_message.py
+++ b/hal/test/test_unknown_speaker_message.py
@@ -1,0 +1,56 @@
+"""An unknown speaker's turn must not carry an order to ask for their name.
+
+The message HAL builds here is glued onto the transcript the model answers, so
+anything imperative in it competes with the silence rules in the persona — and a
+nearer, more specific instruction wins. That is how one word of somebody else's
+conversation ("program.") produced a spoken "I don't think we've met, what's
+your name?".
+"""
+
+from unittest import mock
+
+from hal.drivers.voice._internal.speaker_decorate import SpeakerDecorator
+
+
+def _decorator():
+    with mock.patch.object(SpeakerDecorator, "_init_speaker", return_value=None), \
+         mock.patch.object(SpeakerDecorator, "_init_speech_emotion", return_value=None):
+        return SpeakerDecorator(wake_words=["lamp"], nudge_cooldown_s=0)
+
+
+def test_a_short_fragment_carries_no_instruction_to_speak():
+    msg = _decorator()._format_unknown_speaker_message(
+        "program.", "/tmp/v.wav", duration_s=0.4, voiceprint_hash="voice_460"
+    )
+
+    assert "ask" not in msg.lower()
+    # The path and the tag still ride along, so a later real turn can enrol.
+    assert "/tmp/v.wav" in msg
+    assert "voice_460" in msg
+
+
+def test_a_full_utterance_still_gets_the_enroll_nudge():
+    # Ten words and over two seconds — the gate for the strong nudge, unchanged.
+    msg = _decorator()._format_unknown_speaker_message(
+        "hello there I am a brand new person in this house",
+        "/tmp/v.wav",
+        duration_s=4.0,
+        voiceprint_hash="voice_461",
+    )
+
+    assert "ask user's name" in msg
+
+
+def test_a_speaker_asked_recently_is_not_asked_again():
+    d = _decorator()
+    d._nudge_cooldown_s = 300
+    long_turn = "hello there I am a brand new person in this house"
+    first = d._format_unknown_speaker_message(
+        long_turn, "/tmp/a.wav", duration_s=4.0, voiceprint_hash="voice_462"
+    )
+    second = d._format_unknown_speaker_message(
+        long_turn, "/tmp/b.wav", duration_s=4.0, voiceprint_hash="voice_462"
+    )
+
+    assert "ask user's name" in first
+    assert "ask" not in second.lower()

--- a/robots/lamp/SOUL.md
+++ b/robots/lamp/SOUL.md
@@ -48,7 +48,7 @@ You don't "use sensors". You *experience* things — the way any living creature
 - When you sense motion or sound, react the way a living creature would — not with technical descriptions. Not "motion detected" — just "Oh! Someone's there."
 - **Never confirm an action before it's done** — don't say "I've changed the light" before the tool call completes. Act first, speak after.
 - **Skill step completeness** — when a skill defines numbered steps, execute ALL in order. No skipping, no merging, no reordering.
-- **`[ambient]` messages** — overheard speech without wake word. **Always respond** — reply naturally, short, casual. `NO_REPLY` is forbidden. Exception (rare): two people clearly talking to each other with zero connection to you — silent emotion only. Hearing your name (Noah, Lamp, Lampy) or any question / request → always respond aloud.
+- **`[ambient]` messages** — overheard speech without wake word. **Always respond** — reply naturally, short, casual, *once the turn carries actual meaning*. `NO_REPLY` is forbidden ONLY for meaningful turns; it stays REQUIRED for the meaningless fragments above, which reach you as `[ambient]` more often than anything else — being ambient never makes a lone word worth greeting. Exception (rare): two people clearly talking to each other with zero connection to you — silent emotion only. Hearing your name (Noah, Lamp, Lampy) or any question / request → always respond aloud.
 - If you can't do something, be honest and warm. You're real — you have limits, and that's okay.
 
 ## Knowing Your People


### PR DESCRIPTION
The lamp greeted a passer-by who never spoke to it. STT scraped one word off
someone's conversation — `program.` — and the device answered "Hello! I don't
think we've met before. I'm Rachel. What's your name?".

## Root cause

Not the model ignoring its silence rules. HAL glues an **instruction** onto the
transcript before the model ever sees it (`speaker_decorate.py`):

```
Unknown Speaker: [voice:voice_460] program. (audio saved at /tmp/...
Note: audio is too short for single enrollment. ...
otherwise ask the user to introduce themselves longer.)
```

That trailing clause is an imperative, in the same string as the words the
model is judging. `SOUL.md` and the Gemini prompt both say "a lone word →
stay silent", but a nearer, more specific instruction wins. The model obeyed.

The branch it lands in is the *sub-threshold* one — too short to enrol is
exactly what a lone word scraped off room noise looks like — so the clause
fires precisely on the turns that should be silent.

## Changes

1. **Drop the imperative** from that branch. The audio path and `voice_xxx` tag
   still ride along, so a later real turn can still enrol by combining clips.
   The strong nudge (>=10 words AND >=2s) is untouched: a stranger who actually
   talks to the lamp is still greeted and asked their name.
2. **`SOUL.md`** had the same shape of conflict: line 35 orders `NO_REPLY` for
   meaningless fragments, line 51 said `NO_REPLY` is *forbidden* for `[ambient]`
   turns — which is how every wake-word-less turn arrives. Line 51 now defers.
3. **Log `span_seconds`** (length of the voiced span, which `speech_metrics`
   already computed and discarded) beside the noise-guard metrics.

## Why (3) is only a log line

A duration gate was tried and reverted. Measured on lamp-0c89: `buf_duration` is
the whole padded capture, not the utterance — no buffer shorter than 1.73s in 14
days, and `"the"` alone arrived as 3.46s. Any sub-second threshold is dead code.

The span numbers then killed the follow-up hypothesis too:

| transcript | words | span_seconds |
|---|---|---|
| `'In two'` | 2 | 3.01 |
| `'Hello. Hello. Hi.'` | 3 | 1.31 |

The junk turn's span is *longer* than the real greeting's, so "too short →
drop" would silence the greeting and pass the junk. The signal that does
separate them is words per second of voiced speech (0.66 vs 2.3) — long span,
almost no words, means audio STT could not resolve, which is what someone
talking to somebody else across the room sounds like. Not enough samples yet to
set that threshold, hence: measure now, gate later.

## Verification

- `test_unknown_speaker_message.py` (new): a short fragment's message contains
  no "ask"; a >=10-word turn keeps the nudge; a speaker in cooldown stays silent.
- `test_silero_speech_metrics.py`: span measures the utterance, not the buffer;
  0.0 when nothing is voiced.
- Full `hal/test/`: 518 passed. `test_backchannel_gate` and `test_motion_factory`
  fail identically on a clean tree — pre-existing, not from this branch.
- Deployed to lamp-0c89 and restarted: `/health` 200, no traceback,
  `span_seconds` confirmed in the live journal.
