### PR TITLE
fix(harness): preserve web delivery for legacy events

### DIFF
--- a/system/server/device/delivery/mqtt/chat_stream.go
+++ b/system/server/device/delivery/mqtt/chat_stream.go
@@ -15,6 +15,14 @@ import (
 	"go.autonomous.ai/os/system/server/config"
 )
 
+func isHarnessHandoff(evt domain.MonitorEvent) bool {
+	if evt.Type != "chat_response" {
+		return false
+	}
+	s := strings.ToLower(evt.Summary)
+	return strings.Contains(s, "sent to") && (strings.Contains(s, "agent") || strings.Contains(s, "harness"))
+}
+
 // Streaming an agent turn back to the backend over MQTT.
 //
 // The web chat renders a turn from the monitor bus (GET /api/agent/events):
@@ -208,7 +216,7 @@ func (s *ChatStream) handle(evt domain.MonitorEvent) {
 	flushed := s.takePending(run)
 	sessionID := run.sessionID
 	terminal := isTerminalChatEvent(evt)
-	if terminal {
+	if terminal && !isHarnessHandoff(evt) {
 		delete(s.runs, evt.RunID)
 	}
 	s.mu.Unlock()

--- a/system/server/harness.go
+++ b/system/server/harness.go
@@ -197,7 +197,29 @@ func (s *Server) rememberHarnessResult(text string) {
 func (s *Server) forwardHarnessEvent(frame harness.Frame) {
 	agentID, _ := frame["agentId"].(string)
 	if agentID == "" {
-		return
+		agentID, _ = frame["agent_id"].(string)
+	}
+	if agentID == "" {
+		if payload, ok := frame["payload"].(map[string]any); ok {
+			agentID, _ = payload["agentId"].(string)
+			if agentID == "" {
+				agentID, _ = payload["agent_id"].(string)
+			}
+		}
+	}
+	if agentID == "" {
+		// A single pending Harness turn is unambiguous; older CLI event frames
+		// omitted agentId, so preserve delivery for that compatibility case.
+		s.harnessRepliesMu.Lock()
+		if len(s.harnessReplies) == 1 {
+			for id := range s.harnessReplies {
+				agentID = id
+			}
+		}
+		s.harnessRepliesMu.Unlock()
+		if agentID == "" {
+			return
+		}
 	}
 	kind, _ := frame["kind"].(string)
 	if kind == "turn.tool" {


### PR DESCRIPTION
Accepts agentId and agent_id at the event root or payload, and safely falls back to the sole pending Harness turn for legacy CLI events. This prevents Web Chat terminal results from being dropped while preserving voice delivery.