### PR TITLE
fix(harness): route terminal events by run id

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -811,6 +811,8 @@ best-effort follow-up is logged, but does not change the successful upload resul
 
 #### `chat.send` + `chat.event`
 
+Internal `NO_REPLY` handoff sentinels are suppressed from `chat.event`; clients receive Harness progress and the final Harness response instead.
+
 Lets the backend (and through it a phone app) hold the **same conversation the
 web monitor's chat holds**. The web chat is two halves — `POST
 /api/sensing/event` with `type:"web_chat"` to start a turn (this path forwards

--- a/docs/vi/mqtt_vi.md
+++ b/docs/vi/mqtt_vi.md
@@ -788,6 +788,8 @@ không biến kết quả upload thành thất bại.
 
 #### `chat.send` + `chat.event`
 
+Sentinel nội bộ `NO_REPLY` dùng khi chuyển tiếp sẽ được loại khỏi `chat.event`; client sẽ nhận tiến trình Harness và phản hồi cuối cùng.
+
 Cho phép backend (và qua đó là app mobile) giữ **đúng cuộc hội thoại mà chat trên
 web monitor đang giữ**. Chat web gồm 2 nửa — `POST /api/sensing/event` với
 `type:"web_chat"` để mở turn (đường này forward y như `type:"mqtt_chat"`), và

--- a/system/server/device/delivery/mqtt/chat_stream.go
+++ b/system/server/device/delivery/mqtt/chat_stream.go
@@ -23,6 +23,14 @@ func isHarnessHandoff(evt domain.MonitorEvent) bool {
 	return strings.Contains(s, "sent to") && (strings.Contains(s, "agent") || strings.Contains(s, "harness"))
 }
 
+func isSilentReply(evt domain.MonitorEvent) bool {
+	if evt.Type != "chat_response" {
+		return false
+	}
+	s := strings.TrimSpace(strings.ToLower(evt.Summary))
+	return s == "no_reply" || s == "[no reply]" || strings.Contains(s, "no_reply")
+}
+
 // Streaming an agent turn back to the backend over MQTT.
 //
 // The web chat renders a turn from the monitor bus (GET /api/agent/events):
@@ -220,6 +228,14 @@ func (s *ChatStream) handle(evt domain.MonitorEvent) {
 		delete(s.runs, evt.RunID)
 	}
 	s.mu.Unlock()
+	// NO_REPLY is an internal handoff sentinel. It must never become a visible
+	// assistant message in web or mobile chat. Keep normal terminal bookkeeping.
+	if isSilentReply(evt) {
+		if terminal {
+			slog.Info("chat stream suppressed silent reply", "component", "mqtt-chat", "run_id", evt.RunID)
+		}
+		return
+	}
 
 	// Pending text goes out first: a tool chip that overtook the sentence it
 	// followed would render out of order on the phone.

--- a/system/server/harness.go
+++ b/system/server/harness.go
@@ -278,6 +278,21 @@ func (s *Server) forwardHarnessEvent(frame harness.Frame) {
 				}
 			}
 		}
+		// Legacy CLI frames may carry an unrelated agentId. When there is only
+		// one pending device turn, the route is still unambiguous.
+		if !ok {
+			var onlyID string
+			for id := range s.harnessReplies {
+				if onlyID != "" {
+					onlyID = ""
+					break
+				}
+				onlyID = id
+			}
+			if onlyID != "" {
+				agentID, reply, ok = onlyID, s.harnessReplies[onlyID], true
+			}
+		}
 	}
 	terminal := kind == "turn.summary" || kind == "turn.error" || kind == "agent.error" || kind == "question.open"
 	if ok && terminal {

--- a/system/server/harness.go
+++ b/system/server/harness.go
@@ -197,6 +197,30 @@ func (s *Server) rememberHarnessResult(text string) {
 func (s *Server) forwardHarnessEvent(frame harness.Frame) {
 	agentID, _ := frame["agentId"].(string)
 	if agentID == "" {
+		// Some Harness transports identify the originating request by run ID
+		// instead of agent ID. Resolve that directly to the pending device turn.
+		runID, _ := frame["runId"].(string)
+		if runID == "" {
+			runID, _ = frame["run_id"].(string)
+		}
+		if payload, ok := frame["payload"].(map[string]any); ok && runID == "" {
+			runID, _ = payload["runId"].(string)
+			if runID == "" {
+				runID, _ = payload["run_id"].(string)
+			}
+		}
+		if runID != "" {
+			s.harnessRepliesMu.Lock()
+			for id, reply := range s.harnessReplies {
+				if reply.runID == runID {
+					agentID = id
+					break
+				}
+			}
+			s.harnessRepliesMu.Unlock()
+		}
+	}
+	if agentID == "" {
 		agentID, _ = frame["agent_id"].(string)
 	}
 	if agentID == "" {

--- a/system/server/harness.go
+++ b/system/server/harness.go
@@ -265,6 +265,20 @@ func (s *Server) forwardHarnessEvent(frame harness.Frame) {
 	}
 	s.harnessRepliesMu.Lock()
 	reply, ok := s.harnessReplies[agentID]
+	// Some CLI versions include a stale or target agentId in the event while
+	// preserving the originating run_id. Prefer the run mapping when the direct
+	// agent lookup misses so Web/MQTT turns receive the same terminal event as
+	// voice turns.
+	if !ok {
+		if runID := harnessFrameRunID(frame); runID != "" {
+			for id, candidate := range s.harnessReplies {
+				if candidate.runID == runID {
+					agentID, reply, ok = id, candidate, true
+					break
+				}
+			}
+		}
+	}
 	terminal := kind == "turn.summary" || kind == "turn.error" || kind == "agent.error" || kind == "question.open"
 	if ok && terminal {
 		delete(s.harnessReplies, agentID)
@@ -287,6 +301,22 @@ func (s *Server) forwardHarnessEvent(frame harness.Frame) {
 	if !s.agentHandler.DeliverHarnessResponse(reply.runID, text) {
 		slog.Warn("Harness result had no pending device turn", "component", "harness", "run_id", reply.runID)
 	}
+}
+
+func harnessFrameRunID(frame harness.Frame) string {
+	for _, key := range []string{"runId", "run_id"} {
+		if value, _ := frame[key].(string); value != "" {
+			return value
+		}
+	}
+	if payload, ok := frame["payload"].(map[string]any); ok {
+		for _, key := range []string{"runId", "run_id"} {
+			if value, _ := payload[key].(string); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
 }
 
 func harnessToolEvent(frame harness.Frame) (name, args string) {


### PR DESCRIPTION
Routes Harness lifecycle and terminal events to the original Web Chat and MQTT Chat turn when the transport provides run_id instead of agentId. Preserves voice delivery while fixing missing remote results in chat channels.