### PR TITLE
fix(tts): preserve resampling continuity across PCM chunks

### DIFF
--- a/docs/realtime-voice.md
+++ b/docs/realtime-voice.md
@@ -491,6 +491,15 @@ and at 10 ms the ~1600 round trips per reply were audible as playback stutter
 on a board whose main thread is already saturated by vision. The dedicated
 capture thread is still not implemented.
 
+Regular provider TTS (including ElevenLabs PCM at 24 kHz played at 44.1 kHz)
+uses continuous linear resampling across network PCM chunks within each
+synthesis request. It retains the boundary sample and sample clock instead of
+restarting interpolation at every chunk. Normal EOF flushes the held final
+sample to preserve `ceil(N * output_rate / input_rate)` output samples for `N`
+input samples; cancellation does not flush a tail. Head, tail, and queued
+synthesis requests each have independent resampling state. Native realtime and
+cached WAV playback paths are unchanged, as are buffering and ALSA latency.
+
 `aec.uncancelled()` reports whether the frame just read went through *without*
 real cancellation — reference underrun, bypassed stream, or mic overrun. Barge-in
 gates on it so it cannot decide on raw echo. Note what it does **not** say:

--- a/docs/vi/realtime-voice_vi.md
+++ b/docs/vi/realtime-voice_vi.md
@@ -468,6 +468,15 @@ xuống PortAudio cộng một lần ghi tham chiếu, đều trong Python; ở 
 ~1600 vòng mỗi câu trả lời nghe thành **giật tiếng** trên board mà thread chính
 đã bị vision chiếm gần hết. Thread capture riêng vẫn chưa làm.
 
+TTS thông thường qua provider (gồm ElevenLabs PCM 24 kHz phát ở 44.1 kHz)
+dùng nội suy tuyến tính liên tục qua các chunk PCM từ mạng trong từng yêu cầu
+tổng hợp. Bộ resample giữ mẫu tại biên và clock mẫu thay vì bắt đầu lại nội suy
+ở mỗi chunk. Khi EOF bình thường, mẫu cuối được giữ lại sẽ được xuất để bảo đảm
+`ceil(N * output_rate / input_rate)` mẫu đầu ra với `N` mẫu đầu vào; khi hủy thì
+không xuất phần đuôi này. Các yêu cầu tổng hợp phần đầu, phần đuôi và trong hàng
+đợi có trạng thái resample riêng. Luồng native realtime và phát WAV đã cache
+không đổi; buffering và độ trễ ALSA cũng không đổi.
+
 `aec.uncancelled()` cho biết khung vừa đọc có đi qua mà **không** được khử thật
 hay không — tham chiếu underrun, stream bị bypass, hoặc mic overrun. Barge-in
 gate theo cờ này để không quyết định dựa trên vọng âm thô. Lưu ý điều nó **không**

--- a/hal/drivers/voice/tts/resampler.py
+++ b/hal/drivers/voice/tts/resampler.py
@@ -1,0 +1,42 @@
+"""Continuous linear PCM resampling with state owned by one synthesis request."""
+
+import numpy as np
+
+
+class PCMResampler:
+    """Keep the sample clock and boundary sample across network chunks.
+
+    Integer counters keep the output independent of transport chunk sizes.
+    At EOF, hold the final sample to preserve the full input duration.
+    """
+
+    def __init__(self, src_rate: int, dst_rate: int):
+        self.src_rate = src_rate
+        self.dst_rate = dst_rate
+        self._received = 0
+        self._emitted = 0
+        self._tail = np.empty(0, dtype=np.float32)
+
+    def process(self, samples, *, final: bool = False):
+        samples = np.asarray(samples, dtype=np.float32)
+        if self.src_rate == self.dst_rate:
+            return samples
+        start = self._received - len(self._tail)
+        buf = np.concatenate((self._tail, samples))
+        self._received += len(samples)
+        if not len(buf):
+            return np.empty(0, dtype=np.float32)
+        if final:
+            end = (self._received * self.dst_rate + self.src_rate - 1) // self.src_rate
+        else:
+            # Emit only positions for which the right interpolation sample exists.
+            end = ((self._received - 1) * self.dst_rate) // self.src_rate + 1
+        positions = (
+            np.arange(self._emitted, end, dtype=np.int64) * self.src_rate
+        ) / self.dst_rate - start
+        out = np.interp(positions, np.arange(len(buf)), buf).astype(np.float32)
+        self._emitted = end
+        # Keep the last sample even when downsampling skips beyond this chunk.
+        keep = min(max(self._emitted * self.src_rate // self.dst_rate - start, 0), len(buf) - 1)
+        self._tail = buf[keep:].copy()
+        return out

--- a/hal/drivers/voice/tts/service.py
+++ b/hal/drivers/voice/tts/service.py
@@ -21,6 +21,7 @@ from typing import Optional
 import numpy as np
 
 from hal.drivers.voice import aec
+from hal.drivers.voice.tts.resampler import PCMResampler
 from hal.drivers.voice.tts.backend import (
     TTSBackend,
     TTS_SAMPLE_RATE,
@@ -1367,6 +1368,9 @@ class TTSService:
         """Yield float32 sample frames from the TTS backend's PCM stream."""
         np = self._np
         src_rate = self._backend.sample_rate
+        # Head, tail and queued pre-synthesis run concurrently. Each iterator
+        # owns its sample clock; never share the realtime resampler's state.
+        resampler = PCMResampler(src_rate, dst_rate)
         remainder = b""
         first_audio_logged = False
         t0 = time.perf_counter()
@@ -1389,10 +1393,11 @@ class TTSService:
                 np.frombuffer(raw[:usable], dtype=np.int16).astype(np.float32)
                 / 32768.0
             )
-            # Boost TTS volume (provider-specific: OpenAI 2.5x, ElevenLabs 1.5x)
+            # Apply the provider's gain before resampling, including the EOF tail.
             samples = np.clip(samples * self._backend.volume_boost, -1.0, 1.0)
-            if dst_rate != src_rate:
-                samples = self._resample(samples, src_rate, dst_rate)
+            samples = resampler.process(samples)
+            if not len(samples):
+                continue
             if ttfb_tag and not first_audio_logged:
                 first_audio_logged = True
                 logger.info(
@@ -1402,15 +1407,10 @@ class TTSService:
                 )
             yield samples.reshape(-1, 1)
 
-        if not self._stop_event.is_set() and len(remainder) >= 2:
-            usable = len(remainder) - (len(remainder) % 2)
-            samples = (
-                np.frombuffer(remainder[:usable], dtype=np.int16).astype(np.float32)
-                / 32768.0
-            )
-            if dst_rate != src_rate:
-                samples = self._resample(samples, src_rate, dst_rate)
-            yield samples.reshape(-1, 1)
+        if not self._stop_event.is_set():
+            samples = resampler.process([], final=True)
+            if len(samples):
+                yield samples.reshape(-1, 1)
 
     def _stream_chunk_with_retry(self, stream, text: str, dst_rate: int, idx: int, total: int, ttfb_tag: Optional[str] = None) -> int:
         """Stream one text chunk with retry; return written sample count."""

--- a/hal/test/test_tts_stream_resampling.py
+++ b/hal/test/test_tts_stream_resampling.py
@@ -1,0 +1,78 @@
+"""Provider PCM must sound the same regardless of network packet boundaries."""
+
+import math
+import threading
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from hal.drivers.voice.tts.service import TTSService
+
+
+def _service(packets, src_rate=24000, boost=1.0):
+    svc = object.__new__(TTSService)
+    svc._np = np
+    svc._stop_event = threading.Event()
+    svc._voice = "test"
+    svc._model = "test"
+    svc._speed = 1.1
+    svc._instructions = None
+    svc._backend = SimpleNamespace(
+        sample_rate=src_rate, volume_boost=boost,
+        stream_pcm=lambda **kwargs: iter(packets),
+    )
+    return svc
+
+
+def _collect(frames):
+    frames = list(frames)
+    assert all(f.dtype == np.float32 and f.ndim == 2 and f.shape[1] == 1 for f in frames)
+    return np.concatenate(frames).ravel() if frames else np.empty(0, dtype=np.float32)
+
+
+@pytest.mark.parametrize("src,dst", [(24000, 44100), (24000, 48000), (22050, 44100),
+                                      (48000, 16000), (24000, 24000)])
+@pytest.mark.parametrize("packet_bytes", [1, 7, 4096, 100000])
+def test_pcm_matches_continuous_sample_clock_for_any_packet_boundaries(src, dst, packet_bytes):
+    # A high-frequency signal exposes seams that speech envelopes can hide.
+    pcm = (np.sin(2 * np.pi * 3100 * np.arange(2401) / src) * 24000).astype(np.int16)
+    raw = pcm.tobytes()
+    packets = [raw[i:i + packet_bytes] for i in range(0, len(raw), packet_bytes)]
+    actual = _collect(_service(packets, src)._iter_tts_samples("hello", dst))
+    count = math.ceil(len(pcm) * dst / src)
+    expected = np.interp(np.arange(count) * src / dst, np.arange(len(pcm)), pcm / 32768.)
+    assert len(actual) == count
+    np.testing.assert_allclose(actual, expected, atol=1e-7, rtol=0)
+
+
+@pytest.mark.parametrize("raw", [b"", b"\x01", b"\x00\x40", b"\x00\x40\xff"])
+def test_empty_short_and_incomplete_pcm_at_eof(raw):
+    actual = _collect(_service([raw])._iter_tts_samples("hello", 44100))
+    expected = [0.5, 0.5] if len(raw) >= 2 else []
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_cancel_does_not_flush_held_sample():
+    svc = _service([b"\x00\x40"])
+    frames = svc._iter_tts_samples("hello", 44100)
+    np.testing.assert_array_equal(next(frames), [[0.5]])
+    svc._stop_event.set()
+    assert list(frames) == []
+
+
+def test_parallel_syntheses_do_not_share_resampling_state():
+    raw = np.arange(103, dtype=np.int16).tobytes()
+    svc = _service([raw[:77], raw[77:]])
+    head = svc._iter_tts_samples("head", 44100)
+    tail = svc._iter_tts_samples("tail", 44100)
+    first_head = next(head)
+    actual_tail = _collect(tail)
+    actual_head = _collect([first_head, *head])
+    np.testing.assert_array_equal(actual_head, actual_tail)
+    np.testing.assert_array_equal(actual_head, _collect(svc._iter_tts_samples("next", 44100)))
+
+
+def test_gain_also_applies_to_flushed_tail():
+    actual = _collect(_service([b"\x00\x20"], boost=2.5)._iter_tts_samples("hello", 44100))
+    np.testing.assert_array_equal(actual, [0.625, 0.625])


### PR DESCRIPTION
Provider TTS resampled each PCM network chunk independently, resetting the sample clock at every boundary. For ElevenLabs 24 kHz audio played at 44.1 kHz, this made the output depend on transport chunk sizes and introduced timing discontinuities that can cause audible artifacts.

Keep the sample clock and boundary sample within each synthesis request, with independent state for concurrent head, tail and queued synthesis. Flush the final sample at normal EOF to preserve output duration, and discard the tail on cancellation. Add regression coverage and matching English/Vietnamese documentation. First-clause splitting, native realtime playback, cached WAV playback and ALSA buffering are unchanged.

Validation:
- `/tmp/tts-speaker-test-venv/bin/python -m pytest -q hal/test/test_tts_stream_resampling.py hal/test/test_tts_playback_tracking.py hal/test/test_tts_turn_queue.py hal/test/test_tts_stop_wakes_drain.py` — 54 passed.
- `git diff --check` — passed.
- Orange Pi Python 3.12/NumPy smoke check: chunked 24→44.1 kHz resampling matches a continuous interpolation reference and produces exactly 44,100 samples for one second of input.
- Deployed the two Python files to the user's test device with backup; verified matching SHA-256 hashes, successful HAL startup and healthy audio/TTS. Listening validation is pending; this does not establish that every reported stutter has been resolved.
