### PR TITLE
fix(voice): smooth cached cues and preserve sentence playback

### DIFF
--- a/docs/realtime-voice.md
+++ b/docs/realtime-voice.md
@@ -301,10 +301,13 @@ silence already spent, so such a final closes the session on the next frame
 while the user is still talking (device-observed 04/09/2026 on lamp-0c89:
 final `'Hello.'` at 09:22:50.766, session closed 114ms later, mid-sentence).
 Running the clock from the final gives the speaker a real window to carry on.
+The short clock applies only when `final_ts >= last_confirmed_speech`: if
+confirmed speech continues after that final, `turn_should_close` returns to the
+2.5s fallback until a new final arrives. An old final cannot shorten a later pause.
 Sitting on the long clock after that evidence is dead air in front of every
 realtime commit — it was the largest fixed cost between the user falling silent
-and the model hearing the audio. With no final in hand there is no such
-evidence, so an empty or noise-only session keeps the long fallback clock,
+and the model hearing the audio. With no current final in hand there is no such
+evidence, so resumed speech and empty or noise-only sessions use the long fallback clock,
 `SILENCE_TIMEOUT_S` (2.5s). Set `HAL_ENDPOINT_SILENCE_S=0` to go back to the
 single long clock; raise it if the device starts cutting people off at natural
 mid-sentence pauses.
@@ -491,14 +494,22 @@ and at 10 ms the ~1600 round trips per reply were audible as playback stutter
 on a board whose main thread is already saturated by vision. The dedicated
 capture thread is still not implemented.
 
+Cached WAV cues (including the single-click acknowledgement) also submit 40 ms
+blocks to this wrapper. Their previous outer 10 ms loop defeated the wrapper's
+batching and kept 100 device/AEC calls per second under vision load. Cached
+playback now uses 25 calls per second, plus a final partial block, and checks
+cancellation between blocks. This can add up to 30 ms to the interval between
+stop checks compared with the old loop; ALSA buffering itself is unchanged.
+
 Regular provider TTS (including ElevenLabs PCM at 24 kHz played at 44.1 kHz)
 uses continuous linear resampling across network PCM chunks within each
 synthesis request. It retains the boundary sample and sample clock instead of
 restarting interpolation at every chunk. Normal EOF flushes the held final
 sample to preserve `ceil(N * output_rate / input_rate)` output samples for `N`
 input samples; cancellation does not flush a tail. Head, tail, and queued
-synthesis requests each have independent resampling state. Native realtime and
-cached WAV playback paths are unchanged, as are buffering and ALSA latency.
+synthesis requests each have independent resampling state. Native realtime
+resampling and whole-file cached WAV resampling are unchanged, as are ALSA
+buffering and latency.
 
 `aec.uncancelled()` reports whether the frame just read went through *without*
 real cancellation — reference underrun, bypassed stream, or mic overrun. Barge-in
@@ -1376,16 +1387,17 @@ Read the counters in the session-END log line: `substituted` at ~100 % of
    in the middle of a live turn.
 5. **Consume.** `for output in stream_output()`:
    - `TextOutput` → sentences are flushed to TTS (`speak` / `speak_queue`).
-     The **first** utterance of a turn does not wait for a sentence terminator:
-     once the buffer holds a usable clause it is cut at the last comma /
-     semicolon / colon (or, past `HAL_REALTIME_FIRST_CHUNK_MAX_CHARS`, at the
-     last word break) and spoken immediately, with the remainder queued behind
-     it — the split lands where a speaker would breathe, and only the first
-     chunk is ever cut this way because it is the only one the user waits out in
-     silence. A clause shorter than 8 characters is a runt ("Sure,") and keeps
-     buffering. `HAL_REALTIME_FIRST_CHUNK_MAX_CHARS=0` restores waiting for the
-     full sentence. Native audio is unaffected: the model's own audio streams
-     frame by frame and never went through this path.
+     By default (`HAL_REALTIME_FIRST_CHUNK_MAX_CHARS=0`), the first complete
+     sentence is spoken immediately; later sentences continue through the
+     pre-synthesis queue. This does not wait for the whole reply. A positive
+     value opts into splitting the first incomplete sentence at its last clause
+     boundary (`,` `;` `:` `—`), or at a word break beyond that character limit.
+     Complete sentences bypass this early splitter. It preserves square-bracket
+     voice tags, including during whitespace fallback, and does not split at
+     numeric commas/colons or URL colons. A candidate needs at least 8 visible
+     characters outside voice tags. Early splitting can reduce initial waiting
+     but still create gaps between synthesis requests; it is an opt-in tradeoff.
+     Native audio is unaffected and continues to stream frame by frame.
      If `speak` returns busy (another non-interruptible TTS holds the
      speaker, e.g. an ambient nudge), the sentence falls back to
      `speak_queue` so the reply plays after it instead of being lost.
@@ -1529,7 +1541,7 @@ is a top-level `config.json` flag:
 | `HAL_REALTIME_ENABLED` | `true` | Master gate for the realtime pipeline |
 | `wakeword` | ROBOT.md `voice.wakeword` on a fresh config, else `false` | Top-level config-file wake-word gate. When true, a matching interim transcript is provisional only: HAL commits buffered audio to realtime or forwards a command only after an STT **final** result confirms a configured wake phrase. The transcript is split into sentences (`.` `!` `?`) and the phrase is accepted at the start **or the end** of any sentence; mid-sentence occurrences are rejected. The confirmation re-checks the assembled, still-punctuated transcript so the `\w+`-only merge step cannot retract a gate a partial opened. If that exact re-check fails but a partial had already matched exactly, the name alone may differ by one letter and the gate still confirms: STT rewrites its own hypothesis in the final, and on lamp-0c89 (04/09/2026) the partial `hello lamp` came back as `Hello, lamb.`, which dropped the whole turn — no realtime turn, no thinking cue, and the question fell through to the much slower main agent. The prefix (`hello`, `hey`, …) must still match exactly and the loose rule can never OPEN a gate, only confirm one an exact partial opened, so a near-miss word in ambient speech still wakes nothing. It is logged as `Wake-word confirmed with a one-letter STT slip` so the rate stays countable — many of them means the STT boost terms are not doing their job. The supported prefixes are `hello`, `hey`, `hi`, `alo`, `okay`, `ok`, and `wake up`, applied to the permanent common alias (`hey autonomous`), device type (`hey lamp`), and current agent name (`hey Luna`). A runtime rename updates only the agent-name aliases. Bare names and other prefixes do not arm the gate. A rejected utterance is discarded and its transient listening LED restores to the normal resting state; it never leaves the persistent idle effect active. A confirmed turn opens the follow-up focus window; turns in that window are forwarded as `voice_followup` without another phrase. Every authorized turn dispatches to os-server: a spoken realtime reply becomes a silent `voice_agent_handled` sync event; unavailable, silent, failed, or delegated realtime follows the normal path. If realtime is disabled, the confirmed final transcript follows the normal os-server path. Missing/false preserves the pre-gate always-listening flow unchanged. On a config.json os-server creates, the initial value comes from the body's `voice.wakeword` (see Wake-word gate above); a config loaded without the key stays `false`. HAL restarts after a local Settings save or MQTT `wakeword.gate`. |
 | `HAL_WAKEWORD_FOLLOWUP_TIMEOUT_S` | `20` | Idle seconds for the short post-command focus window. Each accepted `voice_command` or `voice_followup` refreshes it. `0` disables follow-ups and requires a wake phrase for every mic session. Ignored when `wakeword` is false. |
-| `HAL_ENDPOINT_SILENCE_S` | `0.8` | Silence needed to close the turn once STT has emitted a final segment, measured from that final's arrival (a mid-utterance EndOfTurn therefore cannot close the session retroactively). `0` disables it, leaving only the long `HAL_SILENCE_TIMEOUT` clock. |
+| `HAL_ENDPOINT_SILENCE_S` | `0.8` | Silence needed after STT final arrival, only while `final_ts >= last_confirmed_speech`. Continued confirmed speech after that final restores the 2.5s fallback until a new final arrives. `0` disables the short clock, leaving `HAL_SILENCE_TIMEOUT`. |
 | `HAL_SILENCE_VAD_ENABLED` | `true` | Require Silero to confirm speech before the end-of-turn silence clock is refreshed. RMS remains the cheap pre-gate; set `false` to fall back to pure-RMS silence detection. |
 | `HAL_SILENCE_VAD_WINDOW_FRAMES` | `3` | Number of frames batched per Silero run for that check — Silero costs ~20 ms/frame on ARM and its LSTM needs more than one 64 ms frame to settle. |
 | `HAL_REALTIME_PROVIDER` | `gemini` | `none` \| `gemini` \| `openai` \| `qwen` |
@@ -1540,7 +1552,7 @@ is a top-level `config.json` flag:
 | `HAL_REALTIME_LOOK_RECV_TIMEOUT_S` | `20.0` | Silent-turn watchdog used instead of the default for turns where a `look` fired (per-turn, via `extend_recv_timeout()`). Gemini's forced thinking over a text-dense frame can stay silent >8 s right before the answer — the default watchdog was killing those turns. Raising it delays the look-frame handoff, so keep `HAL_GEMINI_VISION_HANDOFF_MAX_AGE_S` above it |
 | `HAL_REALTIME_REQUIRE_TRANSCRIPT` | `true` | Never commit an empty-STT turn to the model. A final transcript containing only punctuation or symbols (for example `.`) is normalized to empty before gaze, speaker-ID, realtime, dispatch, or follow-up refresh; it cannot create a `voice_followup`. Real speech that nova-3 missed (short utterances) is voiced and passes the VAD/Silero guards, so committing its raw audio makes the model invent a reply to silence (a generic greeting, often with a name nobody said). When `true`, any empty-STT turn is dropped regardless of duration/voicing — silence beats a wrong reply. Set `false` to fall back to the Silero-gated audio-only path below. |
 | `HAL_REALTIME_AI_REJECT_FILTER` | `true` | Registers `reject_turn` and enables the isolated `should_drop_realtime_rejection()` policy gate. An explicit tool call drops a transcript before OS dispatch; a silent model completion, timeout, or error still falls back to the main agent. The separate deterministic noise guard is also terminal for audio it already classified as non-speech. Set `false` to disable this experimental AI filter without changing the rest of realtime routing. |
-| `HAL_REALTIME_FIRST_CHUNK_MAX_CHARS` | `90` | Time-to-first-audio on the text (non-native-audio) path: the FIRST utterance of a turn is cut at the last clause boundary (`,` `;` `:` `—`) and spoken immediately instead of waiting for a sentence terminator; past this many characters with no clause boundary it is cut at the last word break. The remainder is queued behind it, so the reply is still spoken in order. A clause under 8 characters keeps buffering (a runt like `Sure,` alone sounds like a stutter). Only the first chunk is ever cut this way. `0` restores waiting for the full sentence. |
+| `HAL_REALTIME_FIRST_CHUNK_MAX_CHARS` | `0` | Default: speak the first complete sentence immediately and pre-synthesize later sentences in the queue, without waiting for the whole reply. Positive values opt into first-clause splitting, with a word-break fallback beyond this limit; complete sentences bypass the splitter. Keeps bracketed voice tags intact (also at whitespace fallback), skips numeric commas/colons and URL colons, and requires 8 visible characters outside tags. Early splitting may leave gaps between synthesis requests. |
 | `HAL_REALTIME_MIN_COMMIT_DURATION_S` | `0.8` | Sessions shorter than this with no STT transcript are treated as VAD noise and not committed to the model. Only consulted when `HAL_REALTIME_REQUIRE_TRANSCRIPT=false`. |
 | `HAL_REALTIME_NOISE_GUARD_MAX_WORDS` | `3` | Extends the Silero voiced-ratio guard to turns that DO have a transcript, up to this many words. STT invents a short filler out of room noise and reports full confidence for it, so such a turn used to bypass every guard (they all only ran on an empty transcript) and commit pure noise to the model. A transcript of at most this many words is re-checked against `HAL_REALTIME_NOISE_SPEECH_RATIO` and dropped when the audio was never voiced; a real short command is voiced and still commits. The ratio is measured over the voiced SPAN — first to last voiced chunk — not the whole buffer, because a capture carries VAD pre-roll at the front and a 200ms tail at the back, and that fixed padding dilutes a short utterance far more than a long one. Measuring the whole buffer dropped a real `Yes, that's right.` at 0.500 (`peak=1.000`), inverting the guard's purpose against the very turns it screens. Sustained noise still fails, since its voiced chunks are sparse within the span too. Longer transcripts are never re-checked, so the floor can't silence a real utterance. `0` disables. |
 | `HAL_REALTIME_SESSION_IDLE_RESET_S` | `240` | Cost control: when a turn arrives after this many seconds of silence, recycle (rebuild) the session **after** that turn so the next turn drops the per-turn context the provider re-bills on a long-lived session. A post-pause turn is effectively a new conversation; long-term continuity survives via the reloaded `summary.md`. For native-audio Gemini, this is skipped when a successful pre-turn recycle already made the same idle gap fresh. `0` disables. Reuses the zombie-recovery rebuild path. |

--- a/docs/vi/realtime-voice_vi.md
+++ b/docs/vi/realtime-voice_vi.md
@@ -281,11 +281,16 @@ bắn EndOfTurn cho cả quãng lấy hơi *giữa* một câu nói, nên nếu 
 cuối thì ngân sách ngắn bị áp ngược vào quãng im lặng đã trôi qua và phiên chết
 ngay frame kế tiếp trong khi người dùng còn đang nói (đo trên lamp-0c89
 04/09/2026: final `'Hello.'` lúc 09:22:50.766, phiên đóng sau đó 114ms, giữa
-câu). Chạy đồng hồ từ final cho người nói một cửa sổ thật để nói tiếp. Ngồi chờ hết
-đồng hồ dài sau bằng chứng đó là dead air nằm trước mọi lần commit realtime —
+câu). Chạy đồng hồ từ final cho người nói một cửa sổ thật để nói tiếp.
+Đồng hồ ngắn chỉ áp dụng khi `final_ts >= last_confirmed_speech`: nếu có tiếng
+nói được xác nhận sau final đó, `turn_should_close` quay lại ngưỡng dự phòng
+2.5s cho tới khi có final mới. Final cũ không thể rút ngắn quãng nghỉ tiếp theo.
+Ngồi chờ hết đồng hồ dài sau bằng chứng đó là dead air nằm trước mọi lần commit
+realtime —
 đây là chi phí cố định lớn nhất giữa lúc người dùng ngừng nói và lúc model nghe
-được audio. Không có final thì không có bằng chứng đó, nên phiên rỗng hoặc chỉ
-có tiếng ồn vẫn giữ đồng hồ dự phòng dài `SILENCE_TIMEOUT_S` (2.5s). Đặt
+được audio. Không có final còn hiệu lực thì không có bằng chứng đó, nên khi
+người dùng nói tiếp hoặc phiên rỗng/chỉ có tiếng ồn, hệ thống dùng đồng hồ dự
+phòng dài `SILENCE_TIMEOUT_S` (2.5s). Đặt
 `HAL_ENDPOINT_SILENCE_S=0` để quay lại một đồng hồ dài duy nhất; tăng lên nếu
 thiết bị bắt đầu cắt lời ở những quãng nghỉ giữa câu.
 
@@ -468,14 +473,21 @@ xuống PortAudio cộng một lần ghi tham chiếu, đều trong Python; ở 
 ~1600 vòng mỗi câu trả lời nghe thành **giật tiếng** trên board mà thread chính
 đã bị vision chiếm gần hết. Thread capture riêng vẫn chưa làm.
 
+WAV cache (gồm lời xác nhận khi single-click) cũng ghi qua wrapper theo block
+40 ms. Vòng ngoài 10 ms trước đây làm mất tác dụng gom block của wrapper và
+vẫn chạy 100 lượt ghi loa/AEC mỗi giây khi vision đang tải. Nay phát cache dùng
+25 lượt mỗi giây, cộng block cuối nếu còn dư, và kiểm tra hủy giữa các block.
+Khoảng cách giữa hai lần kiểm tra stop có thể tăng tối đa 30 ms so với vòng cũ;
+buffering ALSA không đổi.
+
 TTS thông thường qua provider (gồm ElevenLabs PCM 24 kHz phát ở 44.1 kHz)
 dùng nội suy tuyến tính liên tục qua các chunk PCM từ mạng trong từng yêu cầu
 tổng hợp. Bộ resample giữ mẫu tại biên và clock mẫu thay vì bắt đầu lại nội suy
 ở mỗi chunk. Khi EOF bình thường, mẫu cuối được giữ lại sẽ được xuất để bảo đảm
 `ceil(N * output_rate / input_rate)` mẫu đầu ra với `N` mẫu đầu vào; khi hủy thì
 không xuất phần đuôi này. Các yêu cầu tổng hợp phần đầu, phần đuôi và trong hàng
-đợi có trạng thái resample riêng. Luồng native realtime và phát WAV đã cache
-không đổi; buffering và độ trễ ALSA cũng không đổi.
+đợi có trạng thái resample riêng. Resample native realtime và resample toàn
+file WAV cache không đổi; buffering và độ trễ ALSA cũng không đổi.
 
 `aec.uncancelled()` cho biết khung vừa đọc có đi qua mà **không** được khử thật
 hay không — tham chiếu underrun, stream bị bypass, hoặc mic overrun. Barge-in
@@ -1273,13 +1285,16 @@ liên tục đồng ý.
    nhìn như đứng hình.
 
    Cùng lúc commit cũng arm **dead-air filler** (`_WaitFiller`) — nửa phần tiếng
-   của chính cue đó. (Câu **đầu tiên** của một lượt không chờ dấu kết câu: khi
-   buffer đã có một mệnh đề dùng được, nó được cắt ở dấu phẩy / chấm phẩy / hai
-   chấm cuối cùng — hoặc ở khoảng trắng cuối nếu đã vượt
-   `HAL_REALTIME_FIRST_CHUNK_MAX_CHARS` — và nói ngay, phần còn lại xếp hàng
-   phía sau. Chỉ chunk đầu được cắt kiểu này vì đó là chunk duy nhất người dùng
-   phải ngồi im chờ; mệnh đề ngắn dưới 8 ký tự bị coi là cụt và tiếp tục chờ.
-   Đặt `=0` để quay lại chờ trọn câu. Native audio không bị ảnh hưởng.)
+   của chính cue đó. Mặc định (`HAL_REALTIME_FIRST_CHUNK_MAX_CHARS=0`), câu
+   hoàn chỉnh đầu tiên được nói ngay; các câu sau vẫn được tổng hợp trước qua
+   hàng đợi, không chờ toàn bộ câu trả lời. Giá trị dương bật tùy chọn cắt câu
+   đầu chưa hoàn chỉnh tại ranh giới mệnh đề cuối (`,` `;` `:` `—`), hoặc tại
+   khoảng trắng khi vượt giới hạn ký tự. Câu hoàn chỉnh bỏ qua bộ cắt sớm này.
+   Bộ cắt giữ nguyên voice tag trong ngoặc vuông, kể cả khi cắt theo khoảng
+   trắng; không cắt tại dấu phẩy/hai chấm trong số hoặc dấu hai chấm của URL.
+   Phần được cắt cần ít nhất 8 ký tự hiển thị ngoài tag. Cắt sớm có thể giảm
+   thời gian chờ ban đầu nhưng vẫn tạo khoảng ngắt giữa các yêu cầu tổng hợp,
+   nên chỉ bật khi chấp nhận đánh đổi này. Native audio vẫn stream từng frame.
    Sau `HAL_REALTIME_FILLER_DELAY_S` (mặc định 1.5s) mà vẫn
    chưa có output nào, HAL gọi `POST /api/sensing/filler` và os-server phát một
    câu filler mở đầu từ cache — pool phrase, ngôn ngữ và WAV cache đều nằm ở
@@ -1474,6 +1489,7 @@ trong `config.json`:
 | `HAL_REALTIME_ENABLED` | `true` | Cổng tổng cho pipeline realtime |
 | `wakeword` | `voice.wakeword` trong ROBOT.md khi config còn mới, ngược lại `false` | Cổng wake word top-level trong config file. Khi bật, partial khớp chỉ là tín hiệu tạm: HAL chỉ commit audio buffer sang realtime hoặc forward command sau khi STT **final** xác nhận wake phrase. Transcript được tách thành câu (`.` `!` `?`) và phrase được chấp nhận ở đầu **hoặc cuối** bất kỳ câu nào; xuất hiện giữa câu bị từ chối. Bước xác nhận kiểm lại trên transcript đã ghép mà vẫn còn dấu câu, để bước merge chỉ giữ `\w+` không rút lại cái gate mà một partial đã mở. Nếu bước kiểm khớp tuyệt đối đó trượt nhưng trước đó đã có một partial khớp chính xác, thì riêng chữ TÊN được phép lệch 1 ký tự và gate vẫn được xác nhận: STT tự viết lại giả thuyết của nó ở final, và trên lamp-0c89 (04/09/2026) partial `hello lamp` quay lại thành `Hello, lamb.` làm rơi cả lượt — không mở lượt realtime, không có cue thinking, câu hỏi rơi xuống main agent chậm hơn nhiều. Tiền tố (`hello`, `hey`, …) vẫn phải khớp tuyệt đối, và luật lỏng này KHÔNG BAO GIỜ mở được gate mà chỉ xác nhận lại gate do một partial khớp chính xác đã mở, nên một từ gần giống trong lời nói xung quanh vẫn không đánh thức được gì. Nó được log riêng thành `Wake-word confirmed with a one-letter STT slip` để còn đếm được — nhiều dòng này nghĩa là keyterm boost đang không làm tròn việc. Các prefix hỗ trợ là `hello`, `hey`, `hi`, `alo`, `okay`, `ok`, `wake up`, áp dụng cho alias chung cố định (`hey autonomous`), device type (`hey lamp`) và tên agent hiện tại (`hey Luna`). Runtime rename chỉ cập nhật alias theo tên agent. Bare name và các prefix khác không mở gate. Một câu bị từ chối sẽ bị bỏ và LED `listening` tạm thời được restore về trạng thái nghỉ bình thường; không bao giờ để hiệu ứng `idle` cố định tiếp tục chạy. Một lượt đã xác nhận mở cửa sổ focus follow-up; lượt trong cửa sổ đó được forward dưới type `voice_followup` mà không cần wake phrase khác. Mọi lượt được phép đều dispatch sang os-server: câu realtime đã nói thành event đồng bộ im lặng `voice_agent_handled`; realtime unavailable, im lặng, lỗi hoặc delegate đi theo đường thường. Nếu realtime tắt, final transcript đã xác nhận đi theo đường os-server thường. Thiếu/`false` giữ nguyên luồng luôn lắng nghe trước gate. Với `config.json` do os-server tạo ra, giá trị khởi tạo lấy từ `voice.wakeword` của body (xem phần Cổng wake word ở trên); config nạp lên mà không có key thì vẫn là `false`. HAL restart sau khi lưu ở local Settings hoặc MQTT `wakeword.gate`. |
 | `HAL_WAKEWORD_FOLLOWUP_TIMEOUT_S` | `20` | Số giây idle của cửa sổ focus sau lệnh. Mỗi `voice_command` hoặc `voice_followup` được nhận sẽ refresh cửa sổ. `0` tắt follow-up và buộc mỗi phiên mic phải có wake phrase. Bị bỏ qua khi `wakeword` là false. |
+| `HAL_ENDPOINT_SILENCE_S` | `0.8` | Thời gian im lặng từ lúc STT final về, chỉ áp dụng khi `final_ts >= last_confirmed_speech`. Nếu có tiếng nói được xác nhận sau final đó, quay lại ngưỡng dự phòng 2.5s tới khi có final mới. `0` tắt đồng hồ ngắn, chỉ dùng `HAL_SILENCE_TIMEOUT`. |
 | `HAL_SILENCE_VAD_ENABLED` | `true` | Yêu cầu Silero xác nhận có tiếng nói trước khi refresh đồng hồ im lặng kết thúc lượt. RMS vẫn là cổng chặn rẻ chạy trước; đặt `false` để quay về phát hiện im lặng thuần RMS. |
 | `HAL_SILENCE_VAD_WINDOW_FRAMES` | `3` | Số frame gom lại cho mỗi lần chạy Silero ở bước kiểm đó — Silero tốn ~20 ms/frame trên ARM và LSTM của nó cần hơn một frame 64 ms mới ổn định. |
 | `HAL_REALTIME_PROVIDER` | `gemini` | `none` \| `gemini` \| `openai` \| `qwen` |
@@ -1484,6 +1500,7 @@ trong `config.json`:
 | `HAL_REALTIME_LOOK_RECV_TIMEOUT_S` | `20.0` | Watchdog im-lặng dùng thay mặc định cho turn có `look` (theo từng turn, qua `extend_recv_timeout()`). Gemini bị ép thinking trên frame dày chữ có thể im >8 s ngay trước khi trả lời — watchdog mặc định giết nhầm mấy turn đó. Nâng nó lên là hoãn luôn handoff frame `look`, nên phải giữ `HAL_GEMINI_VISION_HANDOFF_MAX_AGE_S` cao hơn |
 | `HAL_REALTIME_REQUIRE_TRANSCRIPT` | `true` | Không bao giờ commit turn empty-STT lên model. Final transcript chỉ có dấu câu/ký hiệu (ví dụ `.`) được chuẩn hoá thành empty trước gaze, speaker-ID, realtime, dispatch hay refresh follow-up; nó không thể tạo `voice_followup`. Giọng thật mà nova-3 miss (câu ngắn) vẫn là voiced nên qua hết guard VAD/Silero, commit audio thô khiến model bịa câu trả lời cho khoảng im lặng (lời chào chung chung, thường kèm tên không ai nói). Khi `true`, mọi turn empty-STT bị bỏ bất kể duration/voicing — im còn hơn trả lời sai. Đặt `false` để quay về đường audio-only gated bằng Silero bên dưới. |
 | `HAL_REALTIME_AI_REJECT_FILTER` | `true` | Đăng ký `reject_turn` và bật policy gate tách riêng `should_drop_realtime_rejection()`. Tool call rõ ràng sẽ bỏ transcript trước OS dispatch; model im lặng, timeout hay lỗi vẫn fallback sang main agent. Noise guard deterministic riêng cũng terminal cho audio mà nó đã phân loại là không phải tiếng nói. Đặt `false` để tắt filter AI thử nghiệm này mà không đổi phần routing realtime còn lại. |
+| `HAL_REALTIME_FIRST_CHUNK_MAX_CHARS` | `0` | Mặc định nói ngay câu hoàn chỉnh đầu tiên và tổng hợp trước các câu sau qua hàng đợi, không chờ toàn bộ câu trả lời. Giá trị dương bật cắt mệnh đề đầu, hoặc cắt theo khoảng trắng khi vượt giới hạn này; câu hoàn chỉnh bỏ qua bộ cắt. Giữ nguyên voice tag trong ngoặc vuông (kể cả khi cắt theo khoảng trắng), bỏ qua dấu phẩy/hai chấm trong số và dấu hai chấm của URL, yêu cầu 8 ký tự hiển thị ngoài tag. Cắt sớm vẫn có thể tạo khoảng ngắt giữa các yêu cầu tổng hợp. |
 | `HAL_REALTIME_MIN_COMMIT_DURATION_S` | `0.8` | Session ngắn hơn ngưỡng này mà không có STT transcript bị coi là nhiễu VAD, không commit lên model. Chỉ xét khi `HAL_REALTIME_REQUIRE_TRANSCRIPT=false`. |
 | `HAL_REALTIME_NOISE_GUARD_MAX_WORDS` | `3` | Mở rộng guard voiced-ratio của Silero sang cả turn CÓ transcript, tối đa ngần này từ. STT bịa một từ đệm ngắn từ tiếng ồn phòng và báo confidence tối đa cho nó, nên turn kiểu đó trước đây lọt hết mọi guard (guard chỉ chạy khi transcript rỗng) và commit nhiễu thuần lên model. Transcript nhiều nhất ngần này từ sẽ bị kiểm lại theo `HAL_REALTIME_NOISE_SPEECH_RATIO` và bị bỏ nếu audio chưa từng voiced; lệnh ngắn nói thật vẫn là voiced nên vẫn commit. Tỉ lệ được đo trên **span voiced** — từ chunk voiced đầu tới chunk voiced cuối — chứ không phải toàn buffer, vì bản capture luôn kèm pre-roll của VAD ở đầu và 200ms đuôi giữ lại ở cuối; phần đệm cố định đó làm loãng câu ngắn nặng hơn câu dài rất nhiều. Đo toàn buffer từng vứt nhầm một câu `Yes, that's right.` nói thật ở mức 0.500 (`peak=1.000`) — tức là guard quay ra phạt đúng lớp câu nó sinh ra để soi. Tiếng ồn kéo dài vẫn rớt, vì các chunk voiced của nó thưa ngay bên trong span. Transcript dài hơn không bao giờ bị kiểm lại, nên ngưỡng này không thể làm câm một câu nói thật. `0` = tắt. |
 | `HAL_REALTIME_SESSION_IDLE_RESET_S` | `240` | Kiểm soát chi phí: khi một turn đến sau ngần này giây im lặng, recycle (rebuild) session **sau** turn đó để turn kế tiếp bỏ phần context mỗi-turn mà provider re-bill trên session sống lâu. Turn sau khoảng nghỉ dài coi như cuộc hội thoại mới; trí nhớ dài hạn vẫn còn nhờ nạp lại `summary.md`. Với Gemini native-audio, bước này bị bỏ qua nếu pre-turn recycle thành công đã làm mới session cho chính idle gap đó. `0` = tắt. Dùng lại đường rebuild của zombie-recovery. |

--- a/hal/config.py
+++ b/hal/config.py
@@ -1639,19 +1639,14 @@ REALTIME_TTS_HISTORY_MAX_CHARS: int = int(os.environ.get("HAL_REALTIME_TTS_HISTO
 # measured time-to-first-sentence, not from this default.
 REALTIME_FILLER_DELAY_S: float = float(os.environ.get("HAL_REALTIME_FILLER_DELAY_S", "1.5"))
 
-# Time-to-first-audio, text (non-native-audio) path only. Sentences are streamed
-# to TTS as they complete, so the first thing the user hears waits for a full
-# sentence terminator — and the model's opening sentence is often long. Below
-# this many characters the first utterance of a turn may instead be cut at a
-# CLAUSE boundary (comma / semicolon / colon) and spoken immediately, with the
-# remainder queued behind it; TTS is a queue, so the reply still comes out in
-# order and the split lands where a speaker would breathe anyway.
-#
-# Only ever applies to the FIRST chunk of a turn — that is the only one whose
-# latency the user is sitting in silence for. 0 disables (wait for the full
-# sentence, the pre-04/09/2026 behaviour).
+# Optional early first-clause playback on the text (non-native-audio) path.
+# Default 0 keeps the first sentence intact: play it as soon as it completes,
+# then pre-synthesize subsequent sentences in the queue. Splitting one sentence
+# into separate provider requests can break prosody and expose synthesis gaps.
+# A positive cap opts in to clause splitting, with a word-break fallback past
+# the cap. Complete sentences, numeric punctuation and voice tags stay intact.
 REALTIME_FIRST_CHUNK_MAX_CHARS: int = int(
-    os.environ.get("HAL_REALTIME_FIRST_CHUNK_MAX_CHARS", "90")
+    os.environ.get("HAL_REALTIME_FIRST_CHUNK_MAX_CHARS", "0")
 )
 
 # --- Realtime: Summarizer (Anthropic Messages API) ---

--- a/hal/drivers/voice/_internal/realtime_turn.py
+++ b/hal/drivers/voice/_internal/realtime_turn.py
@@ -29,7 +29,7 @@ logger = logging.getLogger("hal.voice")
 SENTENCE_ENDS = (".", "!", "?", "。", "！", "？")
 
 # Clause boundaries the first chunk of a turn may be cut at — see
-# split_first_chunk. Sentence enders are handled by the normal flush above them.
+# split_first_chunk. Complete sentences bypass the early cut.
 CLAUSE_ENDS = (",", ";", ":", "—", "，", "；", "：", "、")
 # Below this many characters a clause is a runt ("Ừ,", "Sure,", "Vâng,") —
 # speaking it alone sounds like a stutter, and the pause it buys is not worth
@@ -51,17 +51,34 @@ def split_first_chunk(buf: str) -> tuple[str, str]:
     the buffer still under the cap, or a boundary too early to be a phrase.
     """
     cap: int = hal_config.REALTIME_FIRST_CHUNK_MAX_CHARS
-    if cap <= 0 or len(buf) < FIRST_CHUNK_MIN_CHARS:
+    if cap <= 0 or len(buf) < FIRST_CHUNK_MIN_CHARS or buf.rstrip().endswith(SENTENCE_ENDS):
         return "", buf
-    cut: int = max(buf.rfind(c) for c in CLAUSE_ENDS)
-    if cut + 1 < FIRST_CHUNK_MIN_CHARS:
-        # No usable clause boundary. Past the cap, cut at the last word break
-        # instead: a long comma-less opener is exactly the case this exists for.
-        if len(buf) < cap:
+    # Network text can end inside a voice tag or a number. Only consider
+    # boundaries outside square brackets, and never cut after a digit.
+    clauses = []
+    spaces = []
+    depth = 0
+    visible = 0
+    for i, char in enumerate(buf):
+        if char == "[":
+            depth += 1
+        elif char == "]" and depth:
+            depth -= 1
+        elif not depth:
+            visible += 1
+            if visible < FIRST_CHUNK_MIN_CHARS:
+                continue
+            if char in CLAUSE_ENDS and not (i and buf[i - 1].isdigit()):
+                # A colon followed by '/' belongs to a URL, not a clause.
+                if char not in (":", "：") or (i + 1 < len(buf) and buf[i + 1].isspace()):
+                    clauses.append(i)
+            if char.isspace() and i < cap:
+                spaces.append(i)
+    cut = clauses[-1] if clauses else -1
+    if cut < 0:
+        if len(buf) < cap or not spaces:
             return "", buf
-        cut = buf.rfind(" ", FIRST_CHUNK_MIN_CHARS, cap)
-        if cut < 0:
-            return "", buf
+        cut = spaces[-1]
     head: str = buf[: cut + 1].strip()
     return (head, buf[cut + 1:]) if head else ("", buf)
 

--- a/hal/drivers/voice/_internal/vad_filters.py
+++ b/hal/drivers/voice/_internal/vad_filters.py
@@ -294,6 +294,9 @@ def turn_should_close(
     114ms later, while the user was still mid-sentence. Measuring from the
     final instead gives the speaker a real ENDPOINT_SILENCE_S window to carry
     on, and still closes that much after a final that genuinely ended the turn.
+
+    Confirmed speech after that final supersedes its endpoint. Until a new
+    final arrives, a pause in the resumed speech uses the long fallback clock.
     """
     from hal.drivers.voice._internal.config import (
         ENDPOINT_SILENCE_S,
@@ -301,7 +304,7 @@ def turn_should_close(
     )
 
     silence: float = now - last_speech_time
-    if final_ts > 0 and ENDPOINT_SILENCE_S > 0:
+    if final_ts > 0 and final_ts >= last_speech_time and ENDPOINT_SILENCE_S > 0:
         if now - final_ts >= ENDPOINT_SILENCE_S and silence >= ENDPOINT_SILENCE_S:
             return True
     return silence > SILENCE_TIMEOUT_S

--- a/hal/drivers/voice/tts/service.py
+++ b/hal/drivers/voice/tts/service.py
@@ -1929,8 +1929,10 @@ class TTSService:
 
         with self._stream_lock:
             stream = self._ensure_stream(dst_rate)
-            # Write in 10ms blocks so stop() can cut in promptly.
-            block = max(1, dst_rate // 100)
+            # Match the paced stream's 40ms slices. An outer 10ms loop defeats
+            # its batching and brings back the GIL/AEC overhead on cached cues.
+            # Check stop between slices, just as for streamed speech.
+            block = max(1, int(dst_rate * TTS_REF_SLICE_S))
             for i in range(0, len(samples), block):
                 if self._stop_event.is_set():
                     break

--- a/hal/test/test_first_chunk_split.py
+++ b/hal/test/test_first_chunk_split.py
@@ -1,7 +1,14 @@
 """Time-to-first-audio: the opening of a turn is cut at a clause boundary."""
 
+import pytest
+
 from hal import config as hal_config
 from hal.drivers.voice._internal.realtime_turn import split_first_chunk
+
+
+@pytest.fixture(autouse=True)
+def enable_early_cut(monkeypatch):
+    monkeypatch.setattr(hal_config, "REALTIME_FIRST_CHUNK_MAX_CHARS", 90)
 
 
 def test_waits_while_the_opening_is_still_a_runt():
@@ -30,4 +37,34 @@ def test_short_comma_less_opening_keeps_buffering():
 def test_zero_disables_the_early_cut(monkeypatch):
     monkeypatch.setattr(hal_config, "REALTIME_FIRST_CHUNK_MAX_CHARS", 0)
     text = "Well, that depends on where you are, but I can check"
+    assert split_first_chunk(text) == ("", text)
+
+
+@pytest.mark.parametrize("text", [
+    "Chào bạn, hôm nay bạn thế nào?",
+    "The time is 10:30.",
+    "The price is 1,000 dollars.",
+])
+def test_complete_sentence_is_never_split(text):
+    assert split_first_chunk(text) == ("", text)
+
+
+@pytest.mark.parametrize("text", [
+    "The time is 10:", "The time is 10:30",
+    "The price is 1,", "The price is 1,000 dollars",
+    "[softly, warmly] Hello there", "[softly,", "[laugh] Hi,",
+    "Read https://example.com for details",
+])
+def test_non_clause_punctuation_does_not_start_speech(text):
+    assert split_first_chunk(text) == ("", text)
+
+
+def test_tag_is_preserved_with_a_real_clause():
+    text = "[softly, warmly] Hello there, welcome"
+    assert split_first_chunk(text) == ("[softly, warmly] Hello there,", " welcome")
+
+
+def test_word_cap_never_splits_inside_a_tag(monkeypatch):
+    monkeypatch.setattr(hal_config, "REALTIME_FIRST_CHUNK_MAX_CHARS", 20)
+    text = "[speaking softly and very warmly] Hello there"
     assert split_first_chunk(text) == ("", text)

--- a/hal/test/test_realtime_reply_metrics.py
+++ b/hal/test/test_realtime_reply_metrics.py
@@ -116,25 +116,44 @@ def test_busy_queue_keeps_each_segments_realtime_answer_metadata(kpi, playback):
 
 
 @pytest.mark.parametrize("busy", [False, True])
-@pytest.mark.parametrize("chunks,spoken", [
-    (["Hello there,", " I am here.", "More to say"],
+@pytest.mark.parametrize("cap,chunks,spoken", [
+    (100, ["Hello there,", " I am here.", "More to say"],
      ["Hello there,", "I am here.", "More to say"]),
-    (["Hello there.", "Welcome back."], ["Hello there.", "Welcome back."]),
-    (["Hello there"], ["Hello there"]),
+    (100, ["Hello there.", "Welcome back."], ["Hello there.", "Welcome back."]),
+    (100, ["Hello there"], ["Hello there"]),
+    (0, ["Hello there,", " I am here.", "Welcome back."],
+     ["Hello there, I am here.", "Welcome back."]),
+    (100, ["Hello there, I am here.", "Welcome back."],
+     ["Hello there, I am here.", "Welcome back."]),
 ])
-def test_realtime_turn_marks_every_reply_segment(monkeypatch, chunks, spoken, busy):
+def test_realtime_turn_marks_every_reply_segment(monkeypatch, cap, chunks, spoken, busy):
     monkeypatch.setattr(realtime_turn.hal_config, "REALTIME_ENABLED", True)
     monkeypatch.setattr(realtime_turn.hal_config, "REALTIME_NATIVE_AUDIO", False)
     monkeypatch.setattr(realtime_turn.hal_config, "REALTIME_PROVIDER", "openai")
-    monkeypatch.setattr(realtime_turn.hal_config, "REALTIME_FIRST_CHUNK_MAX_CHARS", 100)
+    monkeypatch.setattr(realtime_turn.hal_config, "REALTIME_FIRST_CHUNK_MAX_CHARS", cap)
     monkeypatch.setattr(realtime_turn, "_thinking_cue_start", lambda: None)
     monkeypatch.setattr(realtime_turn, "_thinking_cue_clear", lambda: None)
     monkeypatch.setattr(realtime_turn, "_reply_language_name", lambda: "English")
     monkeypatch.setattr(realtime_turn, "_WaitFiller", Mock())
     realtime = Mock(available=True)
-    realtime.stream_output.return_value = iter(TextOutput(text=text) for text in chunks)
     tts = Mock()
     tts.speak.return_value = not busy
+
+    def outputs():
+        for index, text in enumerate(chunks):
+            yield TextOutput(text=text)
+            if cap == 0 and index == 0:
+                # A comma alone must not start a separate provider request.
+                tts.speak.assert_not_called()
+                tts.speak_queue.assert_not_called()
+            if cap == 0 and index == 1:
+                # The first sentence starts before the model sends sentence 2.
+                tts.speak.assert_called_once_with(
+                    spoken[0], turn_id="vi-test", realtime_reply=True,
+                )
+                assert tts.speak_queue.call_count == int(busy)
+
+    realtime.stream_output.return_value = outputs()
 
     result = realtime_turn.run_realtime_turn(
         realtime, tts, lambda text: text, "Hello", [object()], 1.0,

--- a/hal/test/test_silence_budget.py
+++ b/hal/test/test_silence_budget.py
@@ -1,9 +1,17 @@
 """End-of-turn close rule: short clock only, and only from the final's arrival."""
 
+import pytest
+
 from hal.drivers.voice._internal import config as voice_cfg
 from hal.drivers.voice._internal.vad_filters import turn_should_close
 
 NOW = 1000.0
+
+
+@pytest.fixture(autouse=True)
+def silence_budgets(monkeypatch):
+    monkeypatch.setattr(voice_cfg, "ENDPOINT_SILENCE_S", 0.8)
+    monkeypatch.setattr(voice_cfg, "SILENCE_TIMEOUT_S", 2.5)
 
 
 def test_no_final_keeps_the_long_fallback_clock():
@@ -38,5 +46,24 @@ def test_a_mid_utterance_final_does_not_close_the_turn_retroactively():
 
 def test_zero_disables_the_short_clock(monkeypatch):
     monkeypatch.setattr(voice_cfg, "ENDPOINT_SILENCE_S", 0.0)
-    quiet = NOW - (voice_cfg.ENDPOINT_SILENCE_S + 0.1)
     assert not turn_should_close(NOW, NOW - 1.0, NOW - 1.0)
+
+
+def test_resumed_speech_supersedes_the_previous_final():
+    """A final for 'Hello.' must not shorten pauses in the following question."""
+    final = NOW
+    resumed_speech = NOW + 2.0
+    assert not turn_should_close(resumed_speech + 0.9, resumed_speech, final)
+
+
+def test_resumed_speech_without_a_new_final_uses_the_fallback():
+    final = NOW
+    resumed_speech = NOW + 2.0
+    assert turn_should_close(resumed_speech + 2.6, resumed_speech, final)
+
+
+def test_new_final_rearms_the_short_clock_after_resumed_speech():
+    resumed_speech = NOW + 2.0
+    new_final = NOW + 2.2
+    assert not turn_should_close(new_final + 0.7, resumed_speech, new_final)
+    assert turn_should_close(new_final + 0.9, resumed_speech, new_final)

--- a/hal/test/test_tts_playback_tracking.py
+++ b/hal/test/test_tts_playback_tracking.py
@@ -244,3 +244,31 @@ def test_each_queued_segment_fires_once():
     service._drain_pending_queue(_tapped(service, writes))
 
     assert [owner for (owner,) in fired] == ["run:a", "run:b"]
+
+
+def test_cached_cue_batches_device_and_aec_work(monkeypatch, tmp_path):
+    """A one-second cached cue needs 25 round trips, not the old 100."""
+    from hal.drivers.voice.tts import service as tts_module
+
+    writes, references = [], []
+    service = _playback_service(tmp_path, writes, [])
+    service._device_rate = service._stream_rate = 44100
+    monkeypatch.setattr(tts_module.aec, "reference_write", lambda data, rate: references.append(len(data)))
+    service._play_wav_inline(_wav(tmp_path, seconds=1.01, rate=44100))
+
+    assert sum(writes) == 44541
+    assert writes == [1764] * 25 + [441]
+    assert references == writes
+
+
+def test_cached_cue_stop_discards_audio_after_current_slice(monkeypatch, tmp_path):
+    from hal.drivers.voice.tts import service as tts_module
+
+    writes = []
+    service = _playback_service(tmp_path, writes, [])
+    service._device_rate = service._stream_rate = 44100
+    # Model a stop arriving while the current device write is in flight.
+    monkeypatch.setattr(tts_module.aec, "reference_write", lambda data, rate: service._stop_event.set())
+    service._play_wav_inline(_wav(tmp_path, seconds=1.0, rate=44100))
+
+    assert writes == [1764]


### PR DESCRIPTION
Cached acknowledgements such as the single-click “listening” cue still submitted 10 ms blocks, defeating the shared stream's 40 ms batching. Match cached playback to 40 ms slices to reduce PortAudio/AEC round trips from about 100 to 25 per second while checking cancellation between slices. The user tested the deployed fix on the Orange Pi and reported that playback now sounds OK; speaker underruns were not directly instrumented.

Also address the voice regressions identified while investigating:
- Default early first-clause splitting to off. The first complete sentence still starts immediately, and later sentences are pre-synthesized in the queue; playback does not wait for the entire reply.
- When early splitting is explicitly enabled, preserve complete sentences, bracketed voice tags and numeric/URL punctuation.
- Ignore STT endpoints superseded by confirmed speech. Resumed speech uses the normal silence fallback until a new final arrives.
- Update English/Vietnamese documentation and add regression tests, including incremental sentence dispatch and cached-cue cancellation.

Validation:
- `/tmp/tts-speaker-test-venv/bin/python -m pytest -q hal/test/test_first_chunk_split.py hal/test/test_realtime_reply_metrics.py hal/test/test_silence_budget.py hal/test/test_tts_stream_resampling.py hal/test/test_tts_playback_tracking.py hal/test/test_tts_turn_queue.py hal/test/test_tts_stop_wakes_drain.py` — 98 passed.
- `git diff --check` — passed.
- Device Python syntax checks passed; deployed files matched local SHA-256 hashes. HAL restarted successfully and audio/TTS health checks passed. User listening test passed.

Cached stop checks now occur every 40 ms instead of 10 ms (up to 30 ms more between checks); ALSA buffering is unchanged. Existing positive `HAL_REALTIME_FIRST_CHUNK_MAX_CHARS` overrides continue to opt into early splitting. The streamed PCM resampling fix was merged separately in #335.
