### PR TITLE
fix(tts): reduce AEC overhead and add playback headroom

### DIFF
--- a/docs/realtime-voice.md
+++ b/docs/realtime-voice.md
@@ -499,7 +499,8 @@ blocks to this wrapper. Their previous outer 10 ms loop defeated the wrapper's
 batching and kept 100 device/AEC calls per second under vision load. Cached
 playback now uses 25 calls per second, plus a final partial block, and checks
 cancellation between blocks. This can add up to 30 ms to the interval between
-stop checks compared with the old loop; ALSA buffering itself is unchanged.
+stop checks compared with the old loop. This is not an acoustic stop bound:
+audio already queued in the output device can remain audible after a stop.
 
 Regular provider TTS (including ElevenLabs PCM at 24 kHz played at 44.1 kHz)
 uses continuous linear resampling across network PCM chunks within each
@@ -508,8 +509,33 @@ restarting interpolation at every chunk. Normal EOF flushes the held final
 sample to preserve `ceil(N * output_rate / input_rate)` output samples for `N`
 input samples; cancellation does not flush a tail. Head, tail, and queued
 synthesis requests each have independent resampling state. Native realtime
-resampling and whole-file cached WAV resampling are unchanged, as are ALSA
-buffering and latency.
+resampling and whole-file cached WAV resampling are unchanged.
+
+AEC reference resampling caches SciPy's default Kaiser FIR coefficients by
+reduced sample-rate ratio and dtype (up to 32 entries), avoiding filter design
+on every speaker write. `resample_poly` still performs its usual gain and
+padding; the reference waveform and FIFO pacing remain unchanged. Before the
+first speaker write of a playback, HAL prepares the reference filter so a cold
+SciPy import/filter design cannot stall playback after its first 40 ms. This
+preparation is skipped when AEC is inactive or sample rates match. Cancellation
+is checked between slices, including after preparation; a stop acknowledgement
+chime can still play while the speech stop flag is set.
+
+Playback stream creation requests `max(0.120s, default_high_output_latency)`
+and logs the actual negotiated latency. The previously observed device default
+of 43.5 ms barely covered one 40 ms write slice. The 120 ms request provides
+three slices of scheduling headroom while preserving larger defaults such as
+Bluetooth outputs; it is neither a guaranteed buffer size nor a fix for network
+jitter. More queued audio can extend the audible tail after cancellation.
+
+`_WatchedStream.write` combines PortAudio's underflow results across all slices.
+Mid-playback underflows are logged at most once every 5 seconds with a cumulative
+count, `writer_gap_ms`, and `previous_aec_ms`; playback boundaries (which may
+follow idle) are debug-only and
+keepalive writes are excluded. These output underflows report playback starvation,
+whereas an AEC reference underrun only reports missing cancellation-reference
+samples and does not establish a speaker underrun. These local playback changes
+still require listening verification on hardware.
 
 `aec.uncancelled()` reports whether the frame just read went through *without*
 real cancellation — reference underrun, bypassed stream, or mic overrun. Barge-in

--- a/docs/vi/realtime-voice_vi.md
+++ b/docs/vi/realtime-voice_vi.md
@@ -477,8 +477,9 @@ WAV cache (gồm lời xác nhận khi single-click) cũng ghi qua wrapper theo 
 40 ms. Vòng ngoài 10 ms trước đây làm mất tác dụng gom block của wrapper và
 vẫn chạy 100 lượt ghi loa/AEC mỗi giây khi vision đang tải. Nay phát cache dùng
 25 lượt mỗi giây, cộng block cuối nếu còn dư, và kiểm tra hủy giữa các block.
-Khoảng cách giữa hai lần kiểm tra stop có thể tăng tối đa 30 ms so với vòng cũ;
-buffering ALSA không đổi.
+Khoảng cách giữa hai lần kiểm tra stop có thể tăng tối đa 30 ms so với vòng cũ.
+Đây không phải giới hạn thời gian loa ngừng tiếng: audio đã xếp trong buffer
+thiết bị vẫn có thể còn phát sau khi stop.
 
 TTS thông thường qua provider (gồm ElevenLabs PCM 24 kHz phát ở 44.1 kHz)
 dùng nội suy tuyến tính liên tục qua các chunk PCM từ mạng trong từng yêu cầu
@@ -487,7 +488,32 @@ tổng hợp. Bộ resample giữ mẫu tại biên và clock mẫu thay vì b�
 `ceil(N * output_rate / input_rate)` mẫu đầu ra với `N` mẫu đầu vào; khi hủy thì
 không xuất phần đuôi này. Các yêu cầu tổng hợp phần đầu, phần đuôi và trong hàng
 đợi có trạng thái resample riêng. Resample native realtime và resample toàn
-file WAV cache không đổi; buffering và độ trễ ALSA cũng không đổi.
+file WAV cache không đổi.
+
+Resample tham chiếu AEC cache hệ số FIR Kaiser mặc định của SciPy theo tỉ lệ
+tần số lấy mẫu đã rút gọn và dtype (tối đa 32 mục), tránh thiết kế lại bộ lọc
+ở mỗi lần ghi loa. `resample_poly` vẫn xử lý gain và padding như trước; dạng
+sóng tham chiếu và nhịp ghi FIFO không đổi. Trước lần ghi loa đầu của mỗi lượt
+phát, HAL chuẩn bị bộ lọc tham chiếu để lần import SciPy/thiết kế bộ lọc đầu
+tiên không làm khựng sau 40 ms audio đầu. Bỏ qua chuẩn bị khi AEC chưa hoạt
+động hoặc sample rate bằng nhau. Kiểm tra hủy giữa các lát, kể cả sau chuẩn bị;
+chime xác nhận stop vẫn được phát khi cờ dừng lời nói đang bật.
+
+Khi mở stream phát, hệ thống yêu cầu `max(0.120s, default_high_output_latency)`
+và log độ trễ thực tế đã thương lượng. Mặc định 43.5 ms từng quan sát trên thiết
+bị chỉ nhỉnh hơn một lát ghi 40 ms. Yêu cầu 120 ms tạo khoảng dự phòng lập lịch
+bằng ba lát, đồng thời giữ mặc định lớn hơn của các đầu ra như Bluetooth; đây
+không phải bảo đảm kích thước buffer hay cách sửa jitter mạng. Audio xếp hàng
+nhiều hơn có thể kéo dài phần tiếng còn nghe sau khi hủy.
+
+`_WatchedStream.write` gộp các cờ underflow của PortAudio qua mọi lát ghi.
+Underflow giữa lúc phát được log tối đa một lần mỗi 5 giây với số lần tích lũy,
+`writer_gap_ms` và `previous_aec_ms`; ranh giới lượt phát (có thể sau idle) chỉ
+log debug, còn
+các lần ghi keepalive bị loại khỏi thống kê. Underflow đầu ra báo thiếu audio
+để phát; AEC reference underrun chỉ báo thiếu mẫu tham chiếu khử vọng và không
+chứng minh loa bị underrun. Các thay đổi phát audio cục bộ này vẫn cần được
+xác minh bằng nghe thử trên phần cứng.
 
 `aec.uncancelled()` cho biết khung vừa đọc có đi qua mà **không** được khử thật
 hay không — tham chiếu underrun, stream bị bypass, hoặc mic overrun. Barge-in

--- a/hal/drivers/voice/aec.py
+++ b/hal/drivers/voice/aec.py
@@ -16,6 +16,7 @@ import logging
 import os
 import threading
 import time
+from functools import lru_cache
 from math import gcd
 from typing import Optional
 
@@ -749,6 +750,47 @@ def wrap_mic(mic_ctx, rate: int, np):
     return AecStream(mic_ctx, _canceller, voice_cfg.AEC_TAIL_S, np)
 
 
+@lru_cache(maxsize=32)
+def _reference_resample_filter(up: int, down: int, dtype: str):
+    """Cache SciPy's default polyphase FIR for a reduced ratio and dtype.
+
+    Speaker writes may be only a few milliseconds long. Rebuilding the same
+    Kaiser filter for every write puts avoidable work on the playback thread.
+    Keep the unscaled coefficients: resample_poly applies the upsampling gain
+    and padding itself, exactly as it does for its default window.
+    """
+    import numpy as np
+    import scipy.signal
+
+    max_rate = max(up, down)
+    half_len = 10 * max_rate
+    coefficients = scipy.signal.firwin(
+        2 * half_len + 1, 1.0 / max_rate, window=("kaiser", 5.0)
+    ).astype(np.dtype(dtype))
+    coefficients.setflags(write=False)
+    return coefficients
+
+
+def prepare_reference(rate: int) -> None:
+    """Prime optional resampling before playback, without publishing audio.
+
+    Importing SciPy and designing the first filter after a speaker write can
+    starve the next write. Call before the first audio is handed to the device;
+    reference_write still handles an unprepared or subsequently changed route.
+    """
+    canceller = _canceller
+    if _reference is None or canceller is None or rate == canceller._rate:
+        return
+    try:
+        import numpy as np
+
+        dst = canceller._rate
+        g = gcd(dst, rate)
+        _reference_resample_filter(dst // g, rate // g, np.dtype(np.float32).str)
+    except Exception as e:
+        logger.debug("AEC reference preparation skipped: %s", e)
+
+
 def reference_write(samples, rate: int) -> None:
     """Record float32 audio on its way to the speaker. Never raises.
 
@@ -768,7 +810,9 @@ def reference_write(samples, rate: int) -> None:
             import scipy.signal
 
             g = gcd(dst, rate)
-            mono = scipy.signal.resample_poly(mono, dst // g, rate // g)
+            up, down = dst // g, rate // g
+            coefficients = _reference_resample_filter(up, down, mono.dtype.str)
+            mono = scipy.signal.resample_poly(mono, up, down, window=coefficients)
         pcm16 = (np.clip(mono, -1.0, 1.0) * 32767).astype(np.int16)
         ref.write(pcm16.tobytes())
     except Exception as e:

--- a/hal/drivers/voice/tts/service.py
+++ b/hal/drivers/voice/tts/service.py
@@ -75,6 +75,10 @@ TTS_WRITE_STALL_S = 8.0
 # lost the GIL mid-utterance to be audible as stutter. 40ms cuts that 4x and
 # still paces the reference far finer than AEC_REF_MS (500ms) of buffer.
 TTS_REF_SLICE_S = 0.040
+# Leave three slices of scheduling headroom for blocking playback plus AEC.
+# A device's "high" default can be only ~43ms, barely one 40ms slice. Preserve
+# larger defaults (notably Bluetooth); PortAudio may round the requested value.
+TTS_OUTPUT_LATENCY_S = 0.120
 
 
 class _WatchedStream:
@@ -86,9 +90,29 @@ class _WatchedStream:
     def __init__(self, stream, owner):
         self._stream = stream
         self._owner = owner
+        self._underflows = 0
+        self._last_underflow_log = float("-inf")
+        self._last_write_end = None
+        self._last_reference_s = 0.0
+
+    def _note_underflow(self, started: float) -> None:
+        # Idle keepalive deliberately lets the sink run dry between writes.
+        # The first write after idle is not evidence of a glitch within speech.
+        if not getattr(self._owner, "_audio_written_fired", False):
+            logger.debug("TTS output underflow at playback boundary (may follow idle)")
+            return
+        self._underflows += 1
+        if started - self._last_underflow_log < 5.0:
+            return
+        self._last_underflow_log = started
+        gap_ms = 0.0 if self._last_write_end is None else (started - self._last_write_end) * 1000
+        logger.warning(
+            "TTS output underflow during playback (total=%d, writer_gap_ms=%.1f, "
+            "previous_aec_ms=%.1f) — speaker ran out of samples",
+            self._underflows, gap_ms, self._last_reference_s * 1000,
+        )
 
     def write(self, data, *, track_playback: bool = True):
-        self._owner._write_started_ts = time.monotonic()
         # Echo reference, paced to PLAYBACK, not to synthesis.
         #
         # Covers synthesized speech, the queue drain and realtime native audio,
@@ -109,6 +133,11 @@ class _WatchedStream:
         # at 500): a bigger buffer lets the reference run further ahead of the
         # speaker, so the misalignment grows instead of the coverage.
         rate = self._owner._stream_rate
+        if not getattr(self._owner, "_audio_written_fired", False):
+            # Importing SciPy/designing the first FIR after the first 40ms of
+            # speech has reached the device can drain even a larger buffer.
+            # Pay that cold-start cost before handing any speech to the sink.
+            aec.prepare_reference(rate)
         # Slice the caller's own object so an ndarray stays an ndarray (its
         # dtype is what tells the device how to read the samples); len() is
         # frames for an ndarray and bytes for a buffer, hence the two steps.
@@ -120,15 +149,21 @@ class _WatchedStream:
             total = 0
         if total == 0:
             try:
+                self._owner._write_started_ts = time.monotonic()
                 return self._stream.write(data)
             finally:
                 self._owner._write_started_ts = None
         try:
-            result = None
+            result = False
             for off in range(0, total, step):
+                stop_event = getattr(self._owner, "_stop_event", None)
+                if track_playback and stop_event is not None and stop_event.is_set():
+                    return result
                 chunk = data[off:off + step]
+                started = time.monotonic()
+                self._owner._write_started_ts = started
                 try:
-                    result = self._stream.write(chunk)
+                    underflowed = self._stream.write(chunk)
                 except self._owner._sd.PortAudioError:
                     # Someone tore this stream down while we were mid-write:
                     # the stall watchdog aborting it, stop()/barge-in, or
@@ -147,6 +182,15 @@ class _WatchedStream:
                         off, total,
                     )
                     return result
+                write_end = time.monotonic()
+                self._owner._write_started_ts = None
+                if underflowed:
+                    # PortAudio reports xruns as a boolean, not an exception.
+                    # Keep flags from EVERY slice; later successful writes must
+                    # not erase the evidence of a gap earlier in this call.
+                    result = True
+                    self._note_underflow(started)
+                self._last_write_end = write_end
                 # This is the one place every playback reaches the device —
                 # synthesized speech, the queue drain, cached WAVs and realtime
                 # native audio all pass through here. Measuring at the write
@@ -154,10 +198,10 @@ class _WatchedStream:
                 # playback path cannot silently escape the metrics.
                 if track_playback:
                     self._owner._note_audio_written()
-                # Re-stamp per slice: the stall watchdog times ONE blocking
-                # write, and a long block is now many short ones.
-                self._owner._write_started_ts = time.monotonic()
+                # The watchdog monitors device writes, not DSP between writes.
+                reference_start = time.monotonic()
                 aec.reference_write(chunk, rate)
+                self._last_reference_s = time.monotonic() - reference_start
             return result
         finally:
             self._owner._write_started_ts = None
@@ -410,17 +454,27 @@ class TTSService:
         # the whole process. One failed write is recoverable; SIGABRT is not.
         from hal.drivers.audio_route import stream_open_guard
 
+        latency = TTS_OUTPUT_LATENCY_S
+        try:
+            info = self._sd.query_devices(self._output_device, "output")
+            latency = max(latency, float(info["default_high_output_latency"]))
+        except Exception:
+            logger.debug("Output latency query failed; using %.3fs", latency, exc_info=True)
         with stream_open_guard():
             stream = self._sd.OutputStream(
                 samplerate=dst_rate,
                 channels=TTS_CHANNELS,
                 dtype="float32",
                 device=self._output_device,
+                latency=latency,
             )
             stream.start()
         self._stream = _WatchedStream(stream, self)
         self._stream_rate = dst_rate
-        logger.info("Persistent OutputStream opened at %d Hz", dst_rate)
+        logger.info(
+            "Persistent OutputStream opened at %d Hz (requested_latency=%.3fs, actual_latency=%s)",
+            dst_rate, latency, stream.latency,
+        )
         return self._stream
 
     def _invalidate_stream(self):

--- a/hal/test/test_aec_reference_resampling.py
+++ b/hal/test/test_aec_reference_resampling.py
@@ -1,0 +1,111 @@
+"""Reference filter reuse preserves the existing PCM and playback input."""
+
+from math import gcd
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import scipy.signal
+
+from hal.drivers.voice import aec
+
+
+@pytest.fixture(autouse=True)
+def clear_filter_cache():
+    aec._reference_resample_filter.cache_clear()
+    yield
+    aec._reference_resample_filter.cache_clear()
+
+
+@pytest.mark.parametrize("src_rate", [44100, 48000])
+@pytest.mark.parametrize("frame_count", [1, 137, 441, 480, 1764, 1920, 8191])
+def test_cached_filter_matches_default_exactly(src_rate, frame_count, monkeypatch):
+    dst_rate = 16000
+    samples = np.random.default_rng(7).uniform(-1.2, 1.2, frame_count).astype(np.float32)
+    original = samples.copy()
+    g = gcd(src_rate, dst_rate)
+    up, down = dst_rate // g, src_rate // g
+    expected = scipy.signal.resample_poly(samples, up, down)
+    coefficients = aec._reference_resample_filter(up, down, samples.dtype.str)
+    actual = scipy.signal.resample_poly(samples, up, down, window=coefficients)
+    np.testing.assert_array_equal(actual, expected)
+
+    reference = aec.EchoReference(dst_rate)
+    monkeypatch.setattr(aec, "_reference", reference)
+    monkeypatch.setattr(aec, "_canceller", SimpleNamespace(_rate=dst_rate))
+    aec.reference_write(samples.reshape(-1, 1), src_rate)
+    expected_pcm = (np.clip(expected, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+    pcm, underran = reference.read(len(expected_pcm))
+    assert not underran
+    assert pcm == expected_pcm
+    np.testing.assert_array_equal(samples, original)
+    assert not coefficients.flags.writeable
+
+
+def test_repeated_writes_design_the_filter_once(monkeypatch):
+    reference = aec.EchoReference(16000)
+    monkeypatch.setattr(aec, "_reference", reference)
+    monkeypatch.setattr(aec, "_canceller", SimpleNamespace(_rate=16000))
+    with patch.object(scipy.signal, "firwin", wraps=scipy.signal.firwin) as design:
+        for size in (441, 137, 1764):
+            aec.reference_write(np.zeros(size, dtype=np.float32), 44100)
+        # The doubled source and destination rates share the reduced ratio.
+        monkeypatch.setattr(aec, "_canceller", SimpleNamespace(_rate=32000))
+        aec.reference_write(np.zeros(882, dtype=np.float32), 88200)
+        assert design.call_count == 1
+
+
+def test_filter_cache_separates_dtype_and_is_bounded():
+    single = aec._reference_resample_filter(1, 3, np.dtype(np.float32).str)
+    double = aec._reference_resample_filter(1, 3, np.dtype(np.float64).str)
+    assert single.dtype == np.float32
+    assert double.dtype == np.float64
+    for down in range(2, 40):
+        aec._reference_resample_filter(1, down, np.dtype(np.float32).str)
+    assert aec._reference_resample_filter.cache_info().currsize == 32
+
+
+def test_same_rate_does_not_design_a_filter(monkeypatch):
+    reference = aec.EchoReference(16000)
+    monkeypatch.setattr(aec, "_reference", reference)
+    monkeypatch.setattr(aec, "_canceller", SimpleNamespace(_rate=16000))
+    aec.reference_write(np.zeros(160, dtype=np.float32), 16000)
+    assert aec._reference_resample_filter.cache_info().misses == 0
+
+
+def test_prepare_primes_first_write_without_publishing_audio(monkeypatch):
+    reference = aec.EchoReference(16000)
+    canceller = SimpleNamespace(_rate=16000)
+    monkeypatch.setattr(aec, "_reference", reference)
+    monkeypatch.setattr(aec, "_canceller", canceller)
+    with patch.object(scipy.signal, "firwin", wraps=scipy.signal.firwin) as design:
+        aec.prepare_reference(44100)
+        assert design.call_count == 1
+        assert reference.history() == b""
+        assert reference.idle_for() == float("inf")
+        assert aec._reference is reference
+        assert aec._canceller is canceller
+        aec.reference_write(np.zeros(441, dtype=np.float32), 44100)
+        assert design.call_count == 1
+        assert len(reference.history()) == 320
+
+
+@pytest.mark.parametrize("enabled,same_rate", [(False, False), (True, True)])
+def test_prepare_noop_does_not_import_or_build_filter(monkeypatch, enabled, same_rate):
+    import builtins
+
+    monkeypatch.setattr(aec, "_reference", aec.EchoReference(16000) if enabled else None)
+    monkeypatch.setattr(aec, "_canceller", SimpleNamespace(_rate=16000) if enabled else None)
+    with patch.object(builtins, "__import__", side_effect=AssertionError("unexpected import")) as importing:
+        aec.prepare_reference(16000 if same_rate else 44100)
+    importing.assert_not_called()
+    assert aec._reference_resample_filter.cache_info().misses == 0
+
+
+def test_prepare_dependency_failure_is_best_effort(monkeypatch):
+    monkeypatch.setattr(aec, "_reference", aec.EchoReference(16000))
+    monkeypatch.setattr(aec, "_canceller", SimpleNamespace(_rate=16000))
+    with patch.object(aec, "_reference_resample_filter", side_effect=ImportError("unavailable")):
+        aec.prepare_reference(44100)
+    assert aec._reference.history() == b""

--- a/hal/test/test_tts_output_headroom.py
+++ b/hal/test/test_tts_output_headroom.py
@@ -1,0 +1,254 @@
+"""Exercise the paced writer against a deterministic, continuously draining sink."""
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import numpy as np
+
+from hal.drivers.voice.tts import service as module
+
+
+class Clock:
+    now = 1.0
+
+    def monotonic(self):
+        return self.now
+
+
+class Sink:
+    def __init__(self, clock, samplerate, latency, **kwargs):
+        self.clock = clock
+        self.rate = samplerate
+        self.latency = latency
+        self.buffered = 0.0
+        self.last = clock.now
+        self.writes = []
+        self.xruns = 0
+
+    def start(self):
+        pass
+
+    def write(self, data):
+        elapsed = self.clock.now - self.last
+        underran = bool(self.writes) and elapsed > self.buffered + 1e-9
+        self.xruns += int(underran)
+        self.buffered = max(0.0, self.buffered - elapsed)
+        duration = len(data) / self.rate
+        # Blocking write waits for room, while hardware continues draining.
+        wait = max(0.0, self.buffered + duration - self.latency)
+        self.clock.now += wait
+        self.buffered = self.buffered + duration - wait
+        self.last = self.clock.now
+        self.writes.append(data.copy())
+        return underran
+
+
+def _owner(monkeypatch, default_latency=0.0435):
+    import hal.drivers.audio_route as route
+
+    clock = Clock()
+    monkeypatch.setattr(module.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(route, "stream_open_guard", nullcontext)
+    owner = object.__new__(module.TTSService)
+    owner._output_device = 4
+    owner._stream = None
+    owner._stream_rate = None
+    owner._audio_written_fired = False
+    owner._on_playback_audio = None
+    sinks = []
+
+    def open_stream(**kwargs):
+        sink = Sink(clock, **kwargs)
+        sinks.append(sink)
+        return sink
+
+    owner._sd = SimpleNamespace(
+        OutputStream=open_stream,
+        query_devices=lambda *args: {"default_high_output_latency": default_latency},
+        PortAudioError=RuntimeError,
+    )
+    return owner, clock, sinks
+
+
+def test_playback_survives_a_short_writer_scheduling_stall(monkeypatch, caplog):
+    """A 70ms scheduling/AEC stall emptied the observed 43.5ms device buffer.
+
+    This models buffer consumption, not OS scheduling or acoustic quality.
+    No PCM is dropped, repeated or modified to conceal the simulated gap.
+    """
+    audio = np.arange(44100, dtype=np.float32).reshape(-1, 1)
+    results = []
+    for requested in (0.0, 0.120):
+        monkeypatch.setattr(module, "TTS_OUTPUT_LATENCY_S", requested)
+        owner, clock, sinks = _owner(monkeypatch)
+        reference = []
+
+        def aec_write(data, rate):
+            reference.append(data.copy())
+            clock.now += 0.002
+            if len(reference) == 10:
+                clock.now += 0.070
+
+        monkeypatch.setattr(module.aec, "reference_write", aec_write)
+        stream = owner._ensure_stream(44100)
+        result = stream.write(audio)
+        results.append((result, sinks[0].xruns))
+        np.testing.assert_array_equal(np.concatenate(sinks[0].writes), audio)
+        np.testing.assert_array_equal(np.concatenate(reference), audio)
+        assert owner._write_started_ts is None
+    assert results == [(True, 1), (False, 0)]
+    assert "TTS output underflow during playback" in caplog.text
+    assert "previous_aec_ms=72.0" in caplog.text
+
+
+def test_does_not_shrink_a_bluetooth_devices_larger_buffer(monkeypatch):
+    owner, _, sinks = _owner(monkeypatch, default_latency=0.250)
+    stream = owner._ensure_stream(24000)
+    assert sinks[0].latency == 0.250
+    assert owner._ensure_stream(24000) is stream
+    assert len(sinks) == 1
+
+
+def test_latency_query_failure_still_uses_headroom(monkeypatch):
+    owner, _, sinks = _owner(monkeypatch)
+    owner._sd.query_devices = lambda *args: {}
+    owner._ensure_stream(44100)
+    assert sinks[0].latency == 0.120
+
+
+def test_underflow_flags_accumulate_and_logs_are_rate_limited(monkeypatch, caplog):
+    owner, clock, sinks = _owner(monkeypatch)
+    stream = owner._ensure_stream(44100)
+    flags = iter([True, True, True, False])
+    sinks[0].write = lambda data: next(flags)
+    monkeypatch.setattr(module.aec, "reference_write", lambda data, rate: None)
+    frame = np.zeros((1764, 1), dtype=np.float32)
+    # Onset after idle isn't a mid-utterance underrun.
+    assert stream.write(frame) is True
+    assert "during playback" not in caplog.text
+    assert stream.write(np.concatenate([frame, frame, frame])) is True
+    assert stream._underflows == 2
+    assert caplog.text.count("TTS output underflow during playback") == 1
+    clock.now += 5.1
+    sinks[0].write = lambda data: True
+    stream.write(frame)
+    assert caplog.text.count("TTS output underflow during playback") == 2
+
+
+def test_keepalive_does_not_report_a_speech_underflow(monkeypatch, caplog):
+    owner, _, sinks = _owner(monkeypatch)
+    stream = owner._ensure_stream(44100)
+    sinks[0].write = lambda data: True
+    assert stream.write_untapped(np.zeros(882, dtype=np.float32)) is True
+    assert stream._underflows == 0
+    assert "during playback" not in caplog.text
+
+
+def test_cold_reference_setup_happens_before_the_first_speaker_sample(monkeypatch):
+    owner, clock, sinks = _owner(monkeypatch)
+    stream = owner._ensure_stream(44100)
+    preparations = []
+
+    def prepare(rate):
+        assert not sinks[0].writes
+        assert owner._write_started_ts is None
+        preparations.append(rate)
+        clock.now += 0.400  # Model a slow first SciPy import/filter setup.
+
+    owner._write_started_ts = None
+    monkeypatch.setattr(module.aec, "prepare_reference", prepare)
+    monkeypatch.setattr(module.aec, "reference_write", lambda data, rate: None)
+    assert stream.write(np.zeros((44100, 1), dtype=np.float32)) is False
+    assert preparations == [44100]
+    assert sinks[0].xruns == 0
+    assert owner._write_started_ts is None
+
+
+def test_stop_during_cold_setup_never_starts_cancelled_speech(monkeypatch):
+    import threading
+
+    owner, _, sinks = _owner(monkeypatch)
+    owner._stop_event = threading.Event()
+    stream = owner._ensure_stream(44100)
+    monkeypatch.setattr(module.aec, "prepare_reference", lambda rate: owner._stop_event.set())
+    stream.write(np.zeros((44100, 1), dtype=np.float32))
+    assert not sinks[0].writes
+    assert owner._audio_written_fired is False
+
+
+def test_long_write_stops_between_slices_but_gesture_chime_can_still_play(monkeypatch):
+    import threading
+
+    owner, _, sinks = _owner(monkeypatch)
+    owner._stop_event = threading.Event()
+    stream = owner._ensure_stream(44100)
+    monkeypatch.setattr(module.aec, "reference_write", lambda data, rate: owner._stop_event.set())
+    stream.write(np.zeros((44100, 1), dtype=np.float32))
+    assert len(sinks[0].writes) == 1
+    assert len(sinks[0].writes[0]) == 1764
+    stream.write(np.zeros((441, 1), dtype=np.float32), track_playback=False)
+    assert len(sinks[0].writes) == 2
+
+
+def test_device_failure_clears_watchdog_and_does_not_report_playback(monkeypatch):
+    import pytest
+
+    owner, _, sinks = _owner(monkeypatch)
+    stream = owner._ensure_stream(44100)
+    references = []
+    monkeypatch.setattr(module.aec, "reference_write", lambda data, rate: references.append(data))
+
+    def fail(data):
+        assert owner._write_started_ts is not None
+        raise RuntimeError("device disconnected")
+
+    sinks[0].write = fail
+    with pytest.raises(RuntimeError, match="device disconnected"):
+        stream.write(np.zeros((1764, 1), dtype=np.float32))
+    assert owner._write_started_ts is None
+    assert owner._audio_written_fired is False
+    assert references == []
+
+
+def test_released_stream_does_not_replay_cancelled_audio(monkeypatch):
+    owner, _, sinks = _owner(monkeypatch)
+    stream = owner._ensure_stream(44100)
+    references = []
+    monkeypatch.setattr(module.aec, "reference_write", lambda data, rate: references.append(data))
+
+    def release_during_write(data):
+        owner._stream = None
+        raise RuntimeError("stream was closed")
+
+    sinks[0].write = release_during_write
+    assert stream.write(np.zeros((44100, 1), dtype=np.float32)) is False
+    assert owner._write_started_ts is None
+    assert owner._audio_written_fired is False
+    assert references == []
+
+
+def test_watchdog_only_covers_the_device_write(monkeypatch):
+    owner, _, sinks = _owner(monkeypatch)
+    stream = owner._ensure_stream(44100)
+    original_write = sinks[0].write
+    phases = []
+
+    def write(data):
+        assert owner._write_started_ts is not None
+        phases.append("device")
+        return original_write(data)
+
+    def observed(owner_id):
+        assert owner._write_started_ts is None
+        phases.append("metrics")
+
+    def reference(data, rate):
+        assert owner._write_started_ts is None
+        phases.append("aec")
+
+    owner._playback_owner = "test"
+    owner._on_playback_audio = observed
+    sinks[0].write = write
+    monkeypatch.setattr(module.aec, "reference_write", reference)
+    stream.write(np.zeros((3528, 1), dtype=np.float32))
+    assert phases == ["device", "metrics", "aec", "device", "aec"]


### PR DESCRIPTION
TTS playback performed AEC filter design after every speaker write, including a cold SciPy import after the first audio slice. The previously observed 43.5 ms output buffer provided little tolerance for scheduling delays between 40 ms writes. These changes address reproducible software causes of playback starvation without changing the reference waveform.

- Cache up to 32 default SciPy FIR filters by reduced sample-rate ratio and dtype, and prepare the first filter before handing speech to the speaker.
- Request max(120 ms, device default high output latency), preserve larger device defaults, and log negotiated latency.
- Preserve PortAudio underflow flags across slices and log mid-playback underruns with writer-gap and AEC timing, throttled to once per five seconds. Playback boundaries and idle keepalive are handled separately.
- Check cancellation between slices, including after cold preparation; keep stop acknowledgement chimes available. Limit watchdog timing to actual device writes.
- Update English/Vietnamese docs and add regression coverage for PCM equivalence, scheduling stalls, cold initialization, cancellation, stream teardown and diagnostics.

Validation:
- `/tmp/tts-speaker-test-venv/bin/python -m pytest -q hal/test/test_tts_output_headroom.py hal/test/test_aec_reference_resampling.py hal/test/test_aec_echo_envelope.py hal/test/test_first_chunk_split.py hal/test/test_realtime_reply_metrics.py hal/test/test_silence_budget.py hal/test/test_tts_stream_resampling.py hal/test/test_tts_playback_tracking.py hal/test/test_tts_turn_queue.py hal/test/test_tts_stop_wakes_drain.py` — 147 passed.
- `/tmp/tts-speaker-test-venv/bin/python hal/scripts/lint.py` — passed (334 files).
- `git diff --check` and pyflakes on the new test files — passed.
- Deterministic sink simulation reproduces an underrun with 43.5 ms buffering and a 70 ms writer stall; the same workload passes with the new headroom without dropping or modifying PCM.

Hardware listening verification is pending; this patch has not been deployed. Requested latency is not a guaranteed buffer size or a solution for network jitter. Additional buffered audio may extend the audible tail after stop, and device AEC alignment still needs listening verification. This follows the already merged #335 and #336; it does not include their changes again.
