### PR TITLE
fix(voice): keep music request planning out of spoken replies

### DIFF
--- a/docs/flow-monitor.md
+++ b/docs/flow-monitor.md
@@ -306,6 +306,8 @@ Some models behind openclaw/hermes (notably DeepSeek) emit their English plannin
 
 Raw deltas in `agent_last_token` stay unfiltered for debugging. Slack mid-turn streaming (`chat.appendStream`) is not filtered (append-only diffing can't retract text); the final Slack reply is.
 
+For delegated music requests, `skills/music/SKILL.md` requires leading HW markers followed by one short confirmation; song selection, noisy-transcript interpretation, and unknown-speaker attribution stay internal. `skills/input-branching/SKILL.md` also keeps routing decisions out of spoken replies. Both Go and HAL filters recognize sentence-initial `They named a/the song:` planning labels and `Speaker [identity] is unknown` bookkeeping, including in English mode. Regression coverage uses the reported “Eternal Flame” output and checks the first-sentence stream as well as the complete reply. These are targeted safeguards; identifying whether a model or proxy put reasoning into assistant text still requires the raw runtime/provider response.
+
 ### NO_REPLY suppression
 
 The agent may respond with `NO_REPLY` (or truncated forms `NO`, `NO_RE`, `NO_...`) when it decides not to respond — typically for passive sensing events like sound/motion. These are suppressed by `isAgentNoReply()` in `handler.go`: no TTS playback, no output display. Matches: exact `"NO"`, or any string starting with `"NO_"` or `"NO_RE"` (case-insensitive after trim). Source: `lifecycle_end` payload if available, otherwise fetched from `chat.history` RPC on `lifecycle_end` (async goroutine, best-effort). OpenClaw `lifecycle_end` currently does not include usage data, so `chat.history` is the primary source.

--- a/docs/vi/flow-monitor_vi.md
+++ b/docs/vi/flow-monitor_vi.md
@@ -154,6 +154,8 @@ Một số model chạy sau openclaw/hermes (điển hình DeepSeek) xả nguyê
 
 Khi có câu bị drop, lifecycle:end emit event `cot_leak_filtered` (`data.dropped` = số câu, `data.preview` = preview giới hạn). Raw delta trong `agent_last_token` giữ nguyên không lọc để debug. Slack streaming giữa turn (`chat.appendStream`) không lọc (diff append-only không rút lại text được); reply Slack cuối thì có.
 
+Với yêu cầu nhạc được delegate, `skills/music/SKILL.md` yêu cầu HW marker đứng đầu, sau đó đúng một câu xác nhận ngắn; việc chọn bài, diễn giải transcript nhiễu và xử lý danh tính chưa biết phải giữ nội bộ. `skills/input-branching/SKILL.md` cũng không cho đọc quyết định định tuyến. Cả bộ lọc Go và HAL nhận diện nhãn lập kế hoạch đầu câu `They named a/the song:` và ghi chú `Speaker [identity] is unknown`, kể cả ở chế độ English. Kiểm thử hồi quy dùng đầu ra “Eternal Flame” được báo cáo, kiểm tra cả stream câu đầu lẫn toàn bộ câu trả lời. Đây là lớp chặn có phạm vi cụ thể; muốn xác định model hay proxy đưa reasoning vào assistant text vẫn cần raw response từ runtime/provider.
+
 ### NO_REPLY suppression
 
 OpenClaw agent trả `NO_REPLY` (hoặc dạng cắt ngắn `NO`, `NO_RE`, `NO_...`) khi quyết định không cần trả lời — thường cho passive sensing events (sound, motion). `isAgentNoReply()` trong `handler.go` suppress: không phát TTS, không hiện output. Match: `"NO"` chính xác, hoặc bắt đầu bằng `"NO_"` / `"NO_RE"` (case-insensitive).

--- a/hal/drivers/voice/_internal/cot_leak_filter.py
+++ b/hal/drivers/voice/_internal/cot_leak_filter.py
@@ -51,12 +51,16 @@ logger = logging.getLogger("hal.voice")
 # TRIGGER: unambiguous CoT. "the user/the speaker" is verb-bound so that a
 # legitimate reply mentioning "the user manual" / "the user interface" does not
 # trip it; the leak corpus is always "The user is/wants/insists...".
+# Song-intent and identity planning are sentence-initial to preserve ordinary
+# song discussion and references to physical speakers.
 _TRIGGER = re.compile(
     r"(?i)(?:\bthe (?:user|speaker)s? (?:is|are|was|were|wants?|wanted|asks?"
     r"|asked|insists?|insisted|seems?|seemed|says?|said|repeats?|repeated"
     r"|claims?|claimed|mentions?|mentioned|requests?|requested|greets?|greeted"
     r"|needs?|needed)\b"
-    r"|phrasing draft|delivery guidance|spoken delivery)"
+    r"|phrasing draft|delivery guidance|spoken delivery"
+    r"|^\s*they named (?:a|the) song\s*:"
+    r"|^\s*speaker(?: identity)? is unknown\b)"
 )
 
 # SECONDARY: meta terms a legit reply could contain (dev users ask the device

--- a/hal/test/test_cot_leak_filter.py
+++ b/hal/test/test_cot_leak_filter.py
@@ -1,0 +1,54 @@
+"""Regression coverage for song-intent planning leaking into spoken replies."""
+
+import pytest
+
+from hal.drivers.voice._internal.cot_leak_filter import CoTLeakFilter, clean_transcript
+
+
+@pytest.mark.parametrize("language", ["English", ""])
+def test_song_request_keeps_confirmation_without_internal_planning(language):
+    transcript = (
+        'They named a song: "Eternal Flame" — likely the Bangles song. '
+        "Play it.Speaker is unknown — no person to attribute. "
+        "Playing Eternal Flame by The Bangles. "
+        "Playing Eternal Flame — one of the all-time greats! "
+        "Now that's what I call a favorite."
+    )
+    expected = (
+        "Playing Eternal Flame by The Bangles. "
+        "Playing Eternal Flame — one of the all-time greats! "
+        "Now that's what I call a favorite."
+    )
+    assert clean_transcript(transcript, language) == expected
+
+
+@pytest.mark.parametrize("language", ["English", ""])
+@pytest.mark.parametrize(
+    "planning",
+    [
+        'They named the song: "Eternal Flame" — likely the Bangles song.',
+        "Speaker is unknown — no person to attribute.",
+        "Speaker identity is unknown — no person to attribute.",
+    ],
+)
+def test_song_planning_markers_work_independently(language, planning):
+    speech_filter = CoTLeakFilter(language)
+    assert speech_filter.filter_text(planning) == ""
+    assert speech_filter.filter_text("Playing Eternal Flame by The Bangles.") == (
+        "Playing Eternal Flame by The Bangles."
+    )
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "They named a song after their hometown.",
+        "They named the song Eternal Flame.",
+        "In the interview they named a song: Eternal Flame.",
+        "Your speaker is connected over Bluetooth.",
+        "Your speaker is unknown to this Bluetooth adapter.",
+        "The speaker identity is unknown to the conference organizers.",
+    ],
+)
+def test_normal_song_and_physical_speaker_discussion_is_preserved(reply):
+    assert clean_transcript(reply, "English") == reply

--- a/skills/input-branching/SKILL.md
+++ b/skills/input-branching/SKILL.md
@@ -45,6 +45,7 @@ This is a **history entry only**. The conversation already happened. You are bei
 2. **`[HANDLED]` → always `NO_REPLY`.** No exceptions. Even if the reply seems wrong or incomplete — the user already heard it. Do not correct, echo, paraphrase, or add to it.
 3. **Log context from `[HANDLED]` silently.** If the exchange reveals mood, intent, or information worth tracking (fatigue, stress, preferences), update memory/mood/wellbeing.
 4. **Never echo tags.** `[voice-instruction]`, `[transcript]`, `[HANDLED]`, `[REPLY]` are routing metadata, not user-facing text.
+   Interpret routing, transcript differences, and speaker metadata silently. Assistant reply text is spoken aloud: start with any required HW markers and the user-facing answer, without narrating which input or skill you chose.
 5. **No prefix = normal voice event.** Process the message as-is.
 6. **Compound instructions: execute EVERY clause.** A `[voice-instruction]` often carries several actions plus a question ("Rotate to the right, hold that position, then describe what you see"). Handle each clause, in order, with the skill it belongs to — and never confirm a clause you did not actually perform. Answering the question half while silently skipping the movement (or vice versa) is the worst outcome: the user hears "done" for something that never happened.
 

--- a/skills/music/SKILL.md
+++ b/skills/music/SKILL.md
@@ -7,9 +7,11 @@ description: Play and stop music from YouTube through the device's speaker on us
 
 Play music through the device's speaker by searching YouTube. Use this when the user asks to play, sing, or listen to music.
 
+**Spoken output:** Everything outside HW markers in your reply is read aloud. For a play/stop request, start with the HW markers, then give one short confirmation and end the reply. Keep song-selection reasoning, transcript interpretation, and speaker attribution internal; do not add a preamble, a draft confirmation, or a second confirmation.
+
 ## Workflow
 
-1. **Specific song / artist** → play directly.
+1. **Specific song / artist** → play directly. When `[voice-instruction]` is present, use that request; a conflicting noisy `[transcript]` does not replace the song title. No habit or identity lookup is needed. Use a known speaker for `person`; otherwise omit the field silently.
 2. **Vague request** (*"play music"*, *"sing something"*) → check habit patterns first:
    ```bash
    cat /root/local/users/{name}/habit/patterns.json 2>/dev/null
@@ -48,6 +50,19 @@ Do NOT use `track`, `artist`, `title`, `song` — those return 422.
 | *"Sing me a song"* | `[HW:/emotion:{"emotion":"curious","intensity":0.6}]` What kind of vibe — chill, upbeat, or something specific? |
 | *"Something chill"* | `[HW:/audio/play:{"query":"chill acoustic playlist","person":"alice"}][HW:/emotion:{"emotion":"happy","intensity":0.8}]` Here's some chill vibes! |
 | *"Stop the music"* | `[HW:/audio/stop:{}]` Music stopped. |
+
+Delegated request with an unknown speaker and noisy transcript:
+
+Input:
+```text
+[voice-instruction] Play Eternal Flame
+[transcript] Uh, my favorite song, uh, Ethan of Lamb.
+```
+
+Reply:
+```text
+[HW:/audio/play:{"query":"Eternal Flame The Bangles"}][HW:/emotion:{"emotion":"happy","intensity":0.8}] Playing Eternal Flame by The Bangles.
+```
 
 ## How HW markers work
 

--- a/system/server/agent/delivery/http/cot_leak_filter.go
+++ b/system/server/agent/delivery/http/cot_leak_filter.go
@@ -48,6 +48,10 @@ var cotTriggerRe = regexp.MustCompile(
 		`|claims?|claimed|mentions?|mentioned|requests?|requested|greets?|greeted` +
 		`|needs?|needed)\b` +
 		`|phrasing draft|delivery guidance|spoken delivery` +
+		// Song-selection planning labels and speaker-identity bookkeeping can
+		// leak without "the user". Anchor these to avoid ordinary song/device discussion.
+		`|^\s*they named (?:a|the) song\s*:` +
+		`|^\s*speaker(?: identity)? is unknown\b` +
 		`|\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b)`,
 )
 

--- a/system/server/agent/delivery/http/cot_leak_filter_test.go
+++ b/system/server/agent/delivery/http/cot_leak_filter_test.go
@@ -3,7 +3,56 @@ package http
 import (
 	"strings"
 	"testing"
+
+	"go.autonomous.ai/os/system/server/config"
 )
+
+const songPlanningLeak = `They named a song: "Eternal Flame" — likely the Bangles song. Play it.Speaker is unknown — no person to attribute. `
+const songPlanningReply = `Playing Eternal Flame by The Bangles. Playing Eternal Flame — one of the all-time greats! Now that's what I call a favorite.`
+
+func TestSongPlanningLeakEnglish(t *testing.T) {
+	for _, lang := range []string{"", "en", "en-US"} {
+		t.Run(lang, func(t *testing.T) {
+			if got := newCoTLeakFilter(lang).filterText(songPlanningLeak + songPlanningReply); got != songPlanningReply {
+				t.Fatalf("got %q, want %q", got, songPlanningReply)
+			}
+		})
+	}
+}
+
+func TestSongPlanningFirstSentenceStream(t *testing.T) {
+	h := &AgentHandler{
+		config:           &config.Config{STTLanguage: "en"},
+		assistantBuf:     make(map[string]*strings.Builder),
+		streamedCleanLen: make(map[string]int),
+	}
+	// Feed the real leak across sentence boundaries, including missing whitespace.
+	for _, delta := range []string{`They named a song: "Eternal Flame" — likely the Bangles song. `, `Play it.Speaker is unknown — no person to attribute. `} {
+		h.accumulateAssistantDelta("song", delta)
+		if got := h.tryFirstSentenceFlush("song"); got != "" {
+			t.Fatalf("planning reached streaming TTS: %q", got)
+		}
+		if _, marked := h.streamedCleanLen["song"]; marked {
+			t.Fatal("planning must not mark the run as spoken")
+		}
+	}
+	h.accumulateAssistantDelta("song", "Playing Eternal Flame by The Bangles. Enjoy")
+	if got := h.tryFirstSentenceFlush("song"); got != "Playing Eternal Flame by The Bangles." {
+		t.Fatalf("clean confirmation did not stream: %q", got)
+	}
+}
+
+func TestSongPlanningDoesNotDropOrdinaryDiscussion(t *testing.T) {
+	for _, text := range []string{
+		`They named the song after their hometown.`,
+		`The Bluetooth speaker is unknown to this app.`,
+		`You asked for Eternal Flame. Playing it now.`,
+	} {
+		if got := newCoTLeakFilter("en").filterText(text); got != text {
+			t.Errorf("ordinary reply changed: %q -> %q", text, got)
+		}
+	}
+}
 
 // The real DeepSeek leak captured on device 2026-07-06 (emotion.detected turn,
 // openclaw + deepseek): full English planning monologue ahead of the reply.


### PR DESCRIPTION
A delegated request to play Eternal Flame played the correct song but also spoke song-selection planning and unknown-speaker bookkeeping. Tighten the music and voice-routing skills so playback replies start with HW markers and contain one short confirmation, with transcript interpretation and attribution kept internal.

Extend the existing Go and HAL CoT filters to recognize the reported planning phrases, including English replies. Add regressions for the captured output, first-sentence streaming, and ordinary song/speaker discussion, and update English and Vietnamese Flow Monitor docs.

Validation:
- `go test ./system/server/agent/delivery/http -count=1` — passed.
- `/tmp/bug-music-cot-tests/bin/python -m pytest hal/test/test_cot_leak_filter.py -q` — 14 passed; temporary venv used because system Python lacks pytest.
- `python3 /Users/macbookpro/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/music` — passed.
- `python3 /Users/macbookpro/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/input-branching` — passed.
- `git diff --check` — passed before commit.

The reported setup uses DeepSeek 4.0 through an LLM proxy. These are prompt and output safeguards; raw runtime/provider responses are still needed to determine whether the model or proxy mixed reasoning into assistant content. No live model/device validation or deployment was performed.
