### PR TITLE
fix: include voice tasks missing HAL snapshots in completion KPI

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -147,10 +147,14 @@ make hal-lint
 cd hal && .venv/bin/python -m pytest test/test_telemetry_flag.py -q
 ```
 
-Voice task completion also emits `voice_metrics_task_execution` from OS
-lifecycle/local-intent boundaries and HAL realtime return. Join it to the
-versioned HAL interaction cohort before scoring: arbitrary backend runs are
-not voice tasks. “Completed” means execution finished, not semantic correctness
+Voice task tracking emits `voice_metrics_task_started` at OS receipt and run
+binding for `voice`, `voice_command`, and `voice_followup`, plus
+`voice_metrics_task_execution` at OS lifecycle/local-intent/dispatch-failure
+boundaries and HAL realtime return. Merge OS starts and versioned HAL task
+snapshots by device + interaction/run before scoring, so OS-only voice paths
+count once even without HAL instrumentation. Arbitrary backend runs and
+`voice_agent_handled` memory sync do not create tasks. The default reporting
+horizon is 0 seconds: unfinished eligible tasks stay in the denominator. “Completed” means execution finished, not semantic correctness
 or finished audio playback. See the [KPI-3 agent query/report runbook](voice-metrics.md#agent-runbook-query-and-report-kpi-3).
 
 For `voice_metrics_*`, INFO `[telemetry] delivered` confirms successful AA HTTP

--- a/docs/vi/telemetry_vi.md
+++ b/docs/vi/telemetry_vi.md
@@ -143,10 +143,13 @@ make hal-lint
 cd hal && .venv/bin/python -m pytest test/test_telemetry_flag.py -q
 ```
 
-Hoàn tất tác vụ thoại còn phát `voice_metrics_task_execution` từ biên
-lifecycle/local-intent của OS và realtime trả về ở HAL. Ghép với cohort
-interaction HAL có version trước khi tính: run backend bất kỳ không phải mẫu
-thoại. “Completed” nghĩa là đã chạy xong, không đánh giá đúng yêu cầu hay phát
+Theo dõi tác vụ thoại phát `voice_metrics_task_started` khi OS nhận và bind run
+cho `voice`, `voice_command`, `voice_followup`, cùng `voice_metrics_task_execution`
+ở biên lifecycle/local-intent/dispatch lỗi của OS và realtime trả về ở HAL.
+Gộp OS start với snapshot task HAL có version bằng device + interaction/run
+trước khi chấm để lượt chỉ có OS vẫn được tính đúng một lần. Run backend bất
+kỳ và memory-sync `voice_agent_handled` không tạo lượt mới. Horizon báo cáo mặc
+định 0 giây: lượt eligible chưa xong vẫn ở mẫu số. “Completed” nghĩa là đã chạy xong, không đánh giá đúng yêu cầu hay phát
 hết audio. Xem [runbook query/report KPI-3 cho agent](voice-metrics_vi.md#runbook-cho-agent-query-và-report-kpi-3).
 
 Với `voice_metrics_*`, INFO `[telemetry] delivered` xác nhận HTTP gửi AA thành

--- a/docs/vi/voice-metrics_vi.md
+++ b/docs/vi/voice-metrics_vi.md
@@ -22,7 +22,7 @@ Mục tiêu KPI-1 và KPI-2 đều **tạm thời**. Mọi khoảng thời gian 
 | Lớp | Đường dẫn | Vai trò |
 |-----|-----------|---------|
 | Tracker ở HAL | `hal/telemetry/voice_metrics.py` | Interaction id, ack/audio cũ, cohort tác vụ và bằng chứng realtime chạy xong |
-| Bằng chứng thực thi ở OS | `system/telemetry/voice_task.go` | Biên lifecycle agent và local intent trả về. |
+| Bằng chứng thực thi ở OS | `system/telemetry/voice_task.go` | Ghi nhận tác vụ thoại nhận vào, bind run, biên lifecycle agent và local intent trả về. |
 | Reporter offline | `scripts/report_voice_task_metrics.py` | Ghép journal/AA đã lưu và báo cáo KPI-3, không gọi mạng. |
 | Ống dẫn ở HAL | `hal/telemetry/client.py` | Dùng chung: log local, hàng đợi có giới hạn, POST nền |
 | Nhận ở OS | `system/server/telemetry/delivery/http/handler.go` | `POST /api/telemetry/event` (loopback/LAN, cùng cổng chặn với `/api/sensing/event`) |
@@ -249,12 +249,31 @@ không thể phát ra câu trả lời cũ, nên không tính là thứ mà biê
 lời sai hoặc làm hành động không hiệu quả mà đạt chỉ số thực thi này. KPI không
 đánh giá đúng yêu cầu user, kết quả tool, tác động vật lý hay phát hết câu trả lời.
 
-Cohort là lượt nói do HAL ghi nhận; riêng run backend không tạo mẫu thoại.
-`voice_metrics_interaction` bổ sung các field độc lập:
+Cohort là hợp của interaction tác vụ HAL và tác vụ thoại OS nhận vào. OS phát
+`voice_metrics_task_started` trước routing hoặc thực thi local cho request
+`voice`, `voice_command`, `voice_followup`. Bao gồm delegate xuống main agent
+và đường thoại không có snapshot task HAL. Run backend bất kỳ và thông báo
+memory-sync `voice_agent_handled` không tạo lượt mới trong cohort.
+
+`voice_metrics_task_started` chứa `schema_version=1`, `interaction_id`,
+`run_id`, `event_type`, `task_started_at_ms` (Unix milliseconds). OS giữ id HAL
+nếu có, nếu thiếu thì tạo `os-voice-<random>`. Event nhận request có run id rỗng;
+event bind tới sau giữ cùng interaction id, thêm run id local/main, kể cả khi
+dispatch chưa sẵn sàng. Mỗi lần phát có timestamp riêng; reporter lấy start
+sớm nhất. Đây là cập nhật một lượt, không phải nhiều lượt. Request `voice` phải
+chờ trong queue được gán run id cố định và bind trước enqueue để replay vẫn
+ghép đúng. Lượt này ở mẫu số dưới dạng chưa xong cho tới khi có evidence
+lifecycle; nhận vào queue chưa phải hoàn tất.
+
+Gộp HAL và OS start bằng **thiết bị + interaction_id hoặc thiết bị + run_id khác
+rỗng**, kể cả alias, trước khi đếm. Tác vụ thoại OS nhận vào làm row HAL legacy
+hoặc excluded tương ứng trở thành eligible, nhưng không ghi đè quy tắc completion
+`realtime_handled`. Thiếu snapshot HAL không được làm mất tác vụ OS khỏi mẫu số.
+`voice_metrics_interaction` giữ các field độc lập:
 
 | Field | Ý nghĩa |
 |-------|---------|
-| `task_schema_version` | `1`; dòng cũ chưa có instrumentation tác vụ được báo coverage, không tính là thất bại |
+| `task_schema_version` | `1`; dòng HAL cũ không ghép được OS task start được báo coverage, không tính là thất bại |
 | `task_started_at_ms` | Unix milliseconds lúc phát hiện nói xong; chọn cohort, không dùng tính latency giữa hai process |
 | `task_revision` | Revision snapshot tăng dần; lấy lớn nhất theo thiết bị + interaction, kể cả bind run-id muộn |
 | `task_eligible` | Độc lập với eligibility ack: mute hoặc ngắt speech không loại tác vụ thực thi |
@@ -270,7 +289,7 @@ lỗi, transcript hay kết quả tool.
 |----------|-------------------|
 | `lifecycle_end` | `completed`: runtime xác nhận kết thúc, không có `data.aborted=true` hay `data.error` khác rỗng |
 | `lifecycle_end_error` | `failed`: end có aborted hoặc error vẫn là lỗi; không tự suy diễn từ `stopReason` |
-| `lifecycle_error`, `lifecycle_end_error`, `chat_error`, `local_intent_error` | `failed`: lỗi thực thi; local intent ghi nhận lỗi API hành động HAL |
+| `lifecycle_error`, `lifecycle_end_error`, `chat_error`, `local_intent_error`, `dispatch_error` | `failed`: lỗi thực thi, dispatch lỗi/chưa sẵn sàng hoặc local intent ghi nhận lỗi API hành động HAL |
 | `lifecycle_error_recovered` | `unknown`: recover chưa chứng minh chạy xong; cần end tường minh |
 | `local_intent_returned` | `completed`: handler local intent chạy xong, không ghi nhận lỗi hành động HAL; không chứng minh đúng ý user hay tác động vật lý |
 | `realtime_turn_done` | `completed`: provider phát TurnDoneEvent và HAL trả về turn đã handled |
@@ -288,17 +307,20 @@ failure. Dispatch lỗi không có execution evidence được tính failed. `Re
 ghi nhận lỗi API HAL của local intent vốn trước đây chỉ được log; handler trả
 về sau lỗi này phát `local_intent_error`, không phát completion.
 
-Horizon báo cáo mặc định tạm thời, có thể cấu hình, là **1800 giây**: mẫu số gồm lượt eligible có
-`task_started_at_ms <= as_of_ms - 1800000`. Lượt mới hơn báo riêng là
-`fresh_pending_turns`, kể cả đã xong. Lượt đủ tuổi nhưng failed, unknown hoặc
-incomplete **vẫn ở mẫu số**; eligibility chưa rõ được gắn cờ thay vì âm thầm bỏ.
-Tử số là lượt đủ tuổi có evidence được chọn là `completed`. So tỉ lệ chưa làm
-tròn với **85%**; mẫu số rỗng là **N/A** (`kpi3_pct`, `meets_target` bằng JSON `null`).
+Horizon mặc định là **0 giây**: mọi tác vụ eligible bắt đầu tới `as_of_ms`
+được đếm ngay. Lượt failed, unknown và chưa xong **vẫn ở mẫu số**. Tử số là lượt
+có evidence được chọn là `completed`. Ví dụ 85 lượt xong trên 100 lượt eligible
+là **85%**. So tỷ lệ chưa làm tròn với **85%**; mẫu số rỗng là **N/A**
+(`kpi3_pct`, `meets_target` bằng JSON `null`). Eligibility chưa rõ được báo riêng.
 
-Đây là horizon để báo cáo, **không phải timeout thực thi**. Cửa sổ ack 10 giây
-và TTL speech-active 45 giây đều không kết thúc tác vụ. Completion muộn được
-đếm khi chạy lại báo cáo với evidence mới. Phải lấy execution tới thời điểm
-as-of, không cắt kết quả theo thời điểm nói cuối của cohort.
+`--settle-seconds 1800` là chính sách báo cáo tùy chọn, không phải mặc định hay
+timeout thực thi. Khi chọn horizon dương, chỉ start tới
+`as_of_ms - settle_seconds * 1000` vào `eligible_mature_turns`; lượt mới hơn là
+`fresh_pending_turns`, kể cả đã xong. Với mặc định 0, tên field lịch sử
+`eligible_mature_turns` nghĩa là tất cả lượt eligible tới as-of. Cửa sổ ack
+10 giây và TTL speech-active 45 giây không kết thúc tác vụ. Completion muộn
+được đếm khi chạy lại report với evidence mới. Lấy execution tới as-of,
+không cắt ở thời điểm start cuối.
 
 ## Runbook cho agent: query và report KPI-3
 
@@ -313,7 +335,7 @@ Copy file về máy bằng quyền truy cập device đã có, rồi chạy từ
 
 ```bash
 python3 scripts/report_voice_task_metrics.py voice-task-journal.jsonl > voice-task-report.json
-python3 scripts/report_voice_task_metrics.py aa-export.jsonl --now-ms 1789088400000 --settle-seconds 1800 > voice-task-report.json
+python3 scripts/report_voice_task_metrics.py aa-export.jsonl --now-ms 1789088400000 --settle-seconds 0 > voice-task-report.json
 ```
 
 Reporter lọc observation trước khi chọn revision và loss counter, dùng
@@ -330,10 +352,18 @@ thật của export. `--device <hostname>` bổ sung identity khi dòng thiếu 
 bị; **không phải bộ lọc thiết bị**. Hỗ trợ journal JSONL (cả ANSI màu và
 `MESSAGE` dạng mảng byte của journald) và AA JSONL chứa
 `event_name`, `data.user_pseudo_id`, `data.event_params` dạng key/value. Giữ
-amendment và execution trong export. Reporter nhóm theo device, khử bản trùng
-HAL/OS bằng task revision. ID bắt đầu `vi-smoke-` mặc định bị loại;
+amendment và execution trong export. Reporter nhóm theo device, lấy task revision HAL lớn nhất,
+gộp snapshot HAL và event start/bind OS bằng interaction/run. ID bắt đầu `vi-smoke-` mặc định bị loại;
 `--include-synthetic --settle-seconds 0` chỉ để kiểm tra instrumentation,
-không dùng công bố KPI sản phẩm.
+không dùng công bố KPI sản phẩm. Caller diagnostic phải truyền interaction id
+`vi-smoke-`: request voice API không đánh dấu vẫn vào cohort vì telemetry không
+thể tự biết đó là người dùng thật hay test.
+
+AA lịch sử thiếu cả snapshot task HAL có version lẫn OS task-start không thể
+được reporter tự bổ sung. Flow Monitor `DONE` có thể chứng minh đã chạy xong
+trong log local, nhưng không tái tạo cohort/evidence AA còn thiếu. Báo riêng
+coverage này; không diễn giải không có lượt eligible được đo thành không có
+tác vụ thực tế chạy xong.
 
 Báo interval, as-of, horizon, nguồn (log local hay AA), từng device và tổng
 `completed_turns / eligible_mature_turns`, phần trăm, `meets_target`. Kèm
@@ -363,17 +393,57 @@ lại hàm trích xuất.
 Xem các truy vấn SQL đầy đủ (KPI-1, KPI-2, KPI-3, coverage) trong bản tiếng Anh:
 [`docs/voice-metrics.md`](../voice-metrics.md#warehouse-queries).
 
-SQL KPI-3 trong bản Anh thực hiện trích params, lấy revision mới nhất theo
-thiết bị + interaction, ghép execution bằng run/interaction, chặn memory-sync
-realtime, giữ mọi lỗi terminal và chọn evidence mới nhất khi không có lỗi,
-tách fresh/coverage và so ngưỡng 85% chưa làm
-tròn. Output realtime dở dang không có `TurnDoneEvent` vẫn incomplete. Tổng KPI
-phải lấy tổng completed chia tổng eligible, không lấy trung bình phần trăm.
-Reporter không có CLI start-window: file đầu vào quyết định interval; giữ
-amendment và execution tail. Dòng legacy thiếu start cần giới hạn khoảng
-export để coverage có nghĩa. Identity device/interaction trống phải báo riêng,
-không gộp thành device giả. Counter mất telemetry là số cộng dồn theo process,
-có thể reset khi restart: xem maxima và mốc reset, không cộng từng event.
+Agent **chỉ có AA event tracking** vẫn query và report được, không cần SSH
+hay Flow Monitor. Query ba event dưới đây, giữ `event_timestamp`,
+`data.user_pseudo_id` và toàn bộ `data.event_params` dạng mảng key/value khi xuất
+JSONL. Đổi tên bảng/cách trích params theo schema warehouse thực tế.
+
+```sql
+-- BigQuery-style; thay khoảng thời gian và device cho báo cáo thực tế.
+SELECT event_name, event_timestamp, data
+FROM event_tracking
+WHERE event_name IN (
+  'voice_metrics_interaction',
+  'voice_metrics_task_started',
+  'voice_metrics_task_execution'
+)
+  AND event_timestamp >= UNIX_SECONDS(TIMESTAMP('2026-09-11 00:00:00+07'))
+  AND event_timestamp <= UNIX_SECONDS(TIMESTAMP('2026-09-11 12:00:00+07'))
+-- AND data.user_pseudo_id = '<device identity lưu trong AA>'
+ORDER BY event_timestamp;
+```
+
+Lấy đủ start, snapshot cập nhật và execution tới as-of. Không chỉ lấy event
+completed vì sẽ loại lượt chưa xong khỏi mẫu số. Nếu cohort cần chứa lượt bắt
+đầu trước mốc dưới của export, lấy cả start của lượt đó. Reporter không có
+CLI start-window; file đầu vào quyết định khoảng dữ liệu được chấm.
+
+```bash
+python3 scripts/report_voice_task_metrics.py aa-export.jsonl --settle-seconds 0 > voice-task-report.json
+```
+
+Với cutoff lịch sử, thêm `--now-ms <Unix milliseconds của cutoff>`. Reporter
+là bộ chấm chuẩn: gộp HAL/OS bằng device + interaction/run trước khi đếm, lấy
+start sớm nhất và revision HAL lớn nhất, ghép execution, giữ lỗi terminal,
+chặn memory-sync realtime. Không duy trì SQL chấm riêng dễ đếm trùng hoặc bỏ
+lượt chỉ có OS start. Field trong params cần giữ:
+
+| Event | Field dùng chấm tác vụ |
+|-------|------------------------|
+| `voice_metrics_interaction` | `interaction_id`, `run_id`, `route`, `task_schema_version`, `task_revision`, `task_started_at_ms`, `task_eligible`, `task_eligibility_known`, `failure_reason` |
+| `voice_metrics_task_started` | `schema_version`, `interaction_id`, `run_id`, `event_type`, `task_started_at_ms` |
+| `voice_metrics_task_execution` | `schema_version`, `interaction_id`, `run_id`, `outcome`, `evidence`, `execution_at_ms` |
+
+Báo **`completed_turns / eligible_mature_turns * 100`**, cả hai số đếm,
+`meets_target`, failed/unknown/incomplete và coverage bị loại. Mặc định 0 giây
+nghĩa là mọi lượt eligible đã bắt đầu tới as-of đều ở mẫu số; mẫu số rỗng là
+N/A. `completed` nghĩa là hoàn tất kỹ thuật không có lỗi kết thúc được ghi
+nhận, không chứng minh đúng yêu cầu user. Agent không có script phải áp dụng
+đúng quy tắc gộp identity/evidence ở trên; đếm riêng số dòng execution là sai.
+Tổng KPI dùng tổng completed chia tổng eligible, không lấy trung bình phần
+trăm. Identity trống phải báo riêng, không gộp thành device giả. Counter mất
+telemetry cộng dồn theo process, có thể reset khi restart: xem maxima và mốc
+reset, không cộng từng event.
 
 ## Log local trên thiết bị
 
@@ -476,7 +546,7 @@ Không lưu transcript hoặc toàn bộ journal thiết bị vào repo.
 
 Report offline chỉ lấy mẫu giả lập đạt **2/2** với
 `--include-synthetic --settle-seconds 0`: chỉ kiểm tra instrumentation, không
-chứng minh sản phẩm đạt 85%. Snapshot 08:35 +07 với horizon chuẩn 1800 giây
+chứng minh sản phẩm đạt 85%. Snapshot 08:35 +07 với horizon 1800 giây dùng lúc đó
 cho **N/A**, hai lượt fresh pending. Đã xác minh HTTP gửi AA thành công;
 chưa thực hiện query đọc warehouse.
 
@@ -492,3 +562,23 @@ Xem [các lệnh kiểm chứng đầy đủ trong bản Anh](../voice-metrics.m
 focused Go test, 75 HAL pytest, 20 reporter unittest, HAL lint qua venv có
 pyflakes và build Linux ARM64 gắn version `0.1.88-voice-task`. Binary ARM64 cuối
 đã được cài lên device; os-server restart và active.
+
+### Sửa cohort OS — kiểm tra trên device (2026-09-11)
+
+Deploy `0.1.88-voice-task-cohort-fix` lên `.169` lúc 09:21:06 +07.
+Hai request voice-followup bằng `curl` có interaction ID
+`vi-smoke-cohort-fix-*` nhưng **không có HAL task snapshot**, tái hiện trường
+hợp thiếu cohort. Local intent hoàn tất lúc 09:21:30; lượt delegate
+`device-chat-3-1789093296472` kết thúc lúc 09:21:59 với `aborted=false`.
+Reporter chạy với `--include-synthetic` chuyển từ **1/2 = 50%** khi main agent
+còn chạy sang **2/2 = 100%** sau terminal event. Event nhận task, binding và
+execution đều có log `[telemetry] delivered`. Đây là xác nhận HTTP ingestion,
+không chứng minh dữ liệu đã query được ở warehouse hay KPI production.
+Mặc định loại lượt smoke. Binary dự phòng trên device:
+`/tmp/os-server-before-cohort-fix`.
+
+Đã pass `go test ./system/telemetry ./system/server/sensing/delivery/http
+./system/server/agent/delivery/http`; unittest reporter pass 29 test, gồm
+100 lượt / 85 hoàn tất, lượt chỉ có OS, chống đếm trùng HAL/OS. Go integration
+test kiểm tra binding khi queue và lỗi not-ready. Build os-server Linux ARM64
+pass. Không tạo giả AA event cho dữ liệu lịch sử bị thiếu.

--- a/docs/voice-metrics.md
+++ b/docs/voice-metrics.md
@@ -21,7 +21,7 @@ can be re-decided from the data instead of by re-instrumenting devices.
 | Layer | Path | Role |
 |-------|------|------|
 | HAL tracker | `hal/telemetry/voice_metrics.py` | Owns interaction ids, ack/stale detection, task cohort and realtime execution evidence. |
-| OS task evidence | `system/telemetry/voice_task.go` | Execution boundaries from agent lifecycle and local intent return. |
+| OS task evidence | `system/telemetry/voice_task.go` | Accepted voice task starts, run bindings, and execution boundaries from agent lifecycle and local intent return. |
 | Offline reporter | `scripts/report_voice_task_metrics.py` | Joins saved journal/AA events and reports KPI-3 without network access. |
 | HAL pipe | `hal/telemetry/client.py` | Generic: local log line, bounded queue, background POST. Reusable by future trackers. |
 | OS ingestion | `system/server/telemetry/delivery/http/handler.go` | `POST /api/telemetry/event` (loopback/LAN, same gate as `/api/sensing/event`). |
@@ -263,12 +263,34 @@ finish with an incorrect answer or an ineffective action and still meet this
 execution metric. It does not assess user satisfaction, tool-result correctness,
 physical effect, or whether the entire spoken answer played.
 
-The HAL utterance is the cohort; backend runs alone are never voice samples.
-`voice_metrics_interaction` adds these independent task fields:
+The cohort is the union of HAL task interactions and voice tasks accepted by
+OS. OS emits `voice_metrics_task_started` before routing or local execution
+for `voice`, `voice_command`, and `voice_followup` requests. This includes
+main-agent delegation and voice paths with no HAL task snapshot. Arbitrary
+backend runs and `voice_agent_handled` memory-sync notifications do not create
+a task cohort entry.
+
+`voice_metrics_task_started` carries `schema_version=1`, `interaction_id`,
+`run_id`, `event_type`, and `task_started_at_ms` (Unix milliseconds). OS preserves
+the incoming HAL interaction id, or creates `os-voice-<random>` when absent.
+The receipt event has an empty run id; a later binding event repeats the same
+interaction id with the local/main run id, including a not-ready dispatch.
+Each emission has its own timestamp; the reporter uses the earliest start.
+These are amendments to one turn, not additional turns. A busy queued `voice`
+request gets a fixed run id and binding before enqueue, preserving correlation
+when replayed; it remains unfinished in the denominator until lifecycle evidence
+arrives. Queue acceptance alone is not completion.
+
+Merge HAL and OS starts by **device + interaction_id or nonempty device +
+run_id**, including aliases, before counting. An accepted OS voice task makes
+a matching legacy or excluded HAL row eligible; it does not override the
+`realtime_handled` completion rule. Missing HAL instrumentation must not erase
+an accepted OS task from the denominator. `voice_metrics_interaction` retains
+these independent task fields:
 
 | Field | Meaning |
 |-------|---------|
-| `task_schema_version` | `1`; older rows lack task instrumentation and are coverage loss, not scored failures |
+| `task_schema_version` | `1`; older HAL rows without a matching OS task start are coverage loss, not scored failures |
 | `task_started_at_ms` | Unix milliseconds at detected speech end; selects the report cohort, not a cross-process latency |
 | `task_revision` | Increasing snapshot revision; keep the greatest revision per device + interaction, including late run-id bindings |
 | `task_eligible` | Independent of acknowledgement eligibility: mute and speech interruption do not exclude execution |
@@ -284,7 +306,7 @@ error text, transcript or tool output. Evidence is:
 |----------|----------------------------|
 | `lifecycle_end` | `completed`: the runtime explicitly ended execution without `data.aborted=true` or a nonempty `data.error` |
 | `lifecycle_end_error` | `failed`: even a lifecycle end is a failure when aborted or carrying an error; `stopReason` alone is not interpreted |
-| `lifecycle_error`, `lifecycle_end_error`, `chat_error`, `local_intent_error` | `failed`: execution failed; local intent observed a HAL action API error |
+| `lifecycle_error`, `lifecycle_end_error`, `chat_error`, `local_intent_error`, `dispatch_error` | `failed`: execution failed, dispatch failed/not ready, or local intent observed a HAL action API error |
 | `lifecycle_error_recovered` | `unknown`: recovery alone is not completion; wait for explicit end |
 | `local_intent_returned` | `completed`: the local intent handler finished without an observed HAL action error; this does not prove semantic correctness or the physical effect |
 | `realtime_turn_done` | `completed`: the provider emitted TurnDoneEvent and HAL returned a handled turn |
@@ -302,20 +324,21 @@ Dispatch failure without execution evidence counts as failed. `Result.ExecutionF
 local-intent HAL API errors that were previously only logged, so returning from
 the handler after such an error emits `local_intent_error`, not a completion.
 
-The provisional, configurable default reporting horizon is **1800 seconds**: the denominator includes
-eligible turns with `task_started_at_ms <= as_of_ms - 1800000`. Fresher turns
-are reported separately as `fresh_pending_turns`, even if already completed.
-Mature failed, unknown, and incomplete turns **stay in the denominator**;
-missing eligibility knowledge is flagged rather than silently removed.
-The numerator is mature turns whose selected evidence says `completed`.
-Compare the unrounded fraction to **85%**; an empty denominator is **N/A**
-(`kpi3_pct` and `meets_target` are JSON `null`).
+The default settling horizon is **0 seconds**: count every eligible task
+started through `as_of_ms` immediately. Failed, unknown, and unfinished turns
+**stay in the denominator**. The numerator is turns with selected `completed`
+evidence. Thus 85 completed out of 100 eligible turns is **85%**. Compare the
+unrounded fraction to **85%**; an empty denominator is **N/A** (`kpi3_pct` and
+`meets_target` are JSON `null`). Missing eligibility knowledge is reported.
 
-This horizon is a reporting choice, **not an execution timeout**. Neither the
-10-second ack observation nor the 45-second speech-active TTL ends a task.
-A late completion is counted when the report is rerun with later evidence.
-Always collect execution results through the stated as-of time; do not cut
-results off at the cohort's last speech timestamp.
+`--settle-seconds 1800` is an optional reporting policy, not the default or an
+execution timeout. With a positive horizon, only starts at or before
+`as_of_ms - settle_seconds * 1000` enter `eligible_mature_turns`; newer turns
+are `fresh_pending_turns`, even if completed. At the default 0, the historical
+field name `eligible_mature_turns` means all eligible turns through as-of.
+Neither the 10-second ack observation nor the 45-second speech-active TTL ends
+a task. A late completion counts when the report is rerun with later evidence.
+Collect execution results through as-of, not just through the last start.
 
 ## Agent runbook: query and report KPI-3
 
@@ -330,7 +353,7 @@ then run from the repo root (or pipe the export to stdin):
 
 ```bash
 python3 scripts/report_voice_task_metrics.py voice-task-journal.jsonl > voice-task-report.json
-python3 scripts/report_voice_task_metrics.py aa-export.jsonl --now-ms 1789088400000 --settle-seconds 1800 > voice-task-report.json
+python3 scripts/report_voice_task_metrics.py aa-export.jsonl --now-ms 1789088400000 --settle-seconds 0 > voice-task-report.json
 ```
 
 `--now-ms` fixes an as-of Unix millisecond timestamp for reproducibility; use
@@ -346,10 +369,19 @@ metric state rather than loading the entire journal into memory.
 without device identity; it is **not a device filter**. Journal JSONL (including ANSI-colored messages and journald `MESSAGE` byte
 arrays) and AA JSONL with `event_name`, `data.user_pseudo_id`, and `data.event_params` key/value
 pairs are accepted. Preserve amendments and execution events in the export.
-The reporter groups by device and deduplicates HAL/OS copies by task revision.
+The reporter groups by device, keeps the greatest HAL task revision, and merges
+HAL snapshots with OS start/binding events by interaction/run identity.
 Smoke interactions beginning `vi-smoke-` are excluded by default;
 `--include-synthetic --settle-seconds 0` is only for instrumentation checks,
-never a production KPI claim.
+never a production KPI claim. Diagnostic callers must supply a `vi-smoke-`
+interaction id: an unmarked accepted voice API request counts in the cohort,
+because telemetry cannot infer whether it came from a person or a test.
+
+Historical AA records missing both a versioned HAL task snapshot and an OS
+task-start event cannot be backfilled by this reporter. A Flow Monitor `DONE`
+row may prove execution ended in local logs, but does not reconstruct missing
+AA cohort/evidence. Report that coverage gap separately; never interpret zero
+instrumented eligible turns as zero actual tasks completed.
 
 Report the interval, as-of time, settling horizon, source (local logs or AA),
 per-device and aggregate `completed_turns / eligible_mature_turns`, percent,
@@ -478,91 +510,58 @@ WHERE event_name LIKE 'voice_metrics_%';
 
 ### KPI-3 warehouse extraction and scoring
 
-Use the same schema assumption and `param` helper above. This BigQuery-style
-example selects a seven-day speech cohort and reads evidence through as-of.
-Set the actual export/query cutoff and device filter in `raw` when needed.
-Do not filter execution rows to mature speech timestamps. Partial realtime
-output without provider `TurnDoneEvent` remains incomplete.
+An agent with **only AA event tracking access** can produce this report; device
+SSH and Flow Monitor access are unnecessary. Export the three event names below
+as JSONL, preserving `event_timestamp`, `data.user_pseudo_id` (device identity),
+and the complete `data.event_params` key/value array. Adapt the table name and
+array accessor to the actual warehouse schema; the schema here is an assumption.
 
 ```sql
-WITH config AS (
-  SELECT UNIX_MILLIS(CURRENT_TIMESTAMP()) AS as_of_ms, 1800000 AS settle_ms
-), raw AS (
-  SELECT event_name, event_timestamp, data.user_pseudo_id AS device,
-    data.event_params AS p
-  FROM event_tracking, config
-  WHERE event_name IN ('voice_metrics_interaction', 'voice_metrics_task_execution')
-    AND event_timestamp <= DIV(as_of_ms, 1000)
-    AND NOT STARTS_WITH(COALESCE(param(data.event_params, 'interaction_id'), ''), 'vi-smoke-')
-), snapshots AS (
-  SELECT device, param(p, 'interaction_id') AS interaction_id,
-    param(p, 'run_id') AS run_id, param(p, 'route') AS route,
-    param(p, 'task_schema_version') AS version,
-    param(p, 'task_eligible') AS eligible,
-    param(p, 'task_eligibility_known') AS eligibility_known,
-    param(p, 'failure_reason') AS failure_reason,
-    SAFE_CAST(param(p, 'task_started_at_ms') AS INT64) AS started_ms,
-    ROW_NUMBER() OVER (
-      PARTITION BY device, param(p, 'interaction_id')
-      ORDER BY COALESCE(SAFE_CAST(param(p, 'task_revision') AS INT64), 0) DESC,
-               event_timestamp DESC
-    ) AS revision_rank
-  FROM raw WHERE event_name = 'voice_metrics_interaction'
-), cohort AS (
-  SELECT s.* FROM snapshots s, config
-  WHERE revision_rank = 1
-    AND COALESCE(device, '') != '' AND COALESCE(interaction_id, '') != ''
-    -- Legacy/missing-start rows retained for coverage, not scoring.
-    AND (started_ms BETWEEN as_of_ms - 7*86400000 AND as_of_ms OR started_ms IS NULL)
-), executions AS (
-  SELECT device, param(p, 'interaction_id') AS interaction_id,
-    param(p, 'run_id') AS run_id, param(p, 'outcome') AS outcome,
-    param(p, 'evidence') AS evidence,
-    SAFE_CAST(param(p, 'execution_at_ms') AS INT64) AS execution_ms
-  FROM raw, config
-  WHERE event_name = 'voice_metrics_task_execution'
-    AND param(p, 'schema_version') = '1'
-    AND SAFE_CAST(param(p, 'execution_at_ms') AS INT64) <= as_of_ms
-), joined AS (
-  SELECT c.*, e.outcome AS execution_outcome,
-    COUNTIF(e.outcome = 'failed') OVER (
-      PARTITION BY c.device, c.interaction_id
-    ) AS terminal_errors,
-    ROW_NUMBER() OVER (
-      PARTITION BY c.device, c.interaction_id
-      ORDER BY e.execution_ms DESC,
-        CASE e.outcome WHEN 'failed' THEN 2 WHEN 'completed' THEN 1 ELSE 0 END DESC
-    ) AS evidence_rank
-  FROM cohort c LEFT JOIN executions e
-    ON c.device = e.device
-    AND (c.interaction_id = e.interaction_id
-         OR (COALESCE(c.run_id, '') != '' AND c.run_id = e.run_id))
-    AND (COALESCE(c.route, '') != 'realtime_handled' OR e.evidence = 'realtime_turn_done')
-), scored AS (
-  SELECT *, version = '1' AND COALESCE(eligible, '') != 'false'
-      AND started_ms <= as_of_ms - settle_ms AS mature,
-    IF(terminal_errors > 0, 'failed', COALESCE(execution_outcome,
-      IF(COALESCE(failure_reason, '') != '', 'failed', 'incomplete'))) AS task_outcome
-  FROM joined, config WHERE evidence_rank = 1
+-- BigQuery-style AA-only export. Set the actual interval and optional device.
+SELECT event_name, event_timestamp, data
+FROM event_tracking
+WHERE event_name IN (
+  'voice_metrics_interaction',
+  'voice_metrics_task_started',
+  'voice_metrics_task_execution'
 )
-SELECT device,
-  COUNTIF(mature) AS eligible_mature_turns,
-  COUNTIF(mature AND task_outcome = 'completed') AS completed_turns,
-  COUNTIF(mature AND task_outcome = 'failed') AS failed_turns,
-  COUNTIF(mature AND task_outcome = 'unknown') AS unknown_turns,
-  COUNTIF(mature AND task_outcome = 'incomplete') AS incomplete_turns,
-  COUNTIF(version = '1' AND COALESCE(eligible, '') != 'false'
-    AND started_ms > as_of_ms - settle_ms) AS fresh_pending_turns,
-  COUNTIF(version = '1' AND eligible = 'false') AS ineligible_turns,
-  COUNTIF(COALESCE(version, '') != '1') AS legacy_turns_excluded,
-  COUNTIF(version = '1' AND started_ms IS NULL) AS missing_start_time_turns_excluded,
-  COUNTIF(version = '1' AND COALESCE(eligible, '') != 'false'
-    AND COALESCE(eligibility_known, '') != 'true') AS eligibility_unknown_turns,
-  100 * SAFE_DIVIDE(COUNTIF(mature AND task_outcome = 'completed'), COUNTIF(mature)) AS kpi3_pct,
-  IF(COUNTIF(mature) = 0, NULL,
-    100 * COUNTIF(mature AND task_outcome = 'completed') >= 85 * COUNTIF(mature)) AS meets_target
-FROM scored GROUP BY device;
+  AND event_timestamp >= UNIX_SECONDS(TIMESTAMP('2026-09-11 00:00:00+07'))
+  AND event_timestamp <= UNIX_SECONDS(TIMESTAMP('2026-09-11 12:00:00+07'))
+-- AND data.user_pseudo_id = '<device identity stored in AA>'
+ORDER BY event_timestamp;
 ```
+
+The example interval is illustrative. Include all start/snapshot amendments and
+execution evidence through the desired as-of time. Do not export only completed
+execution events: that removes unfinished tasks from the denominator. Include
+starts before the export lower bound if their turns belong to the chosen report
+cohort. The reporter has no start-window CLI; input coverage defines its interval.
+
+Use the repository reporter as the authoritative scorer, avoiding a separate SQL
+implementation that can double-count HAL/OS aliases or omit OS-only tasks:
+
+```bash
+python3 scripts/report_voice_task_metrics.py aa-export.jsonl --settle-seconds 0 > voice-task-report.json
+```
+
+For a historical cutoff, also pass `--now-ms <cutoff in Unix milliseconds>`.
+The reporter merges starts by device + interaction/run, keeps the earliest start
+and greatest HAL revision, joins execution evidence, and applies the sticky
+terminal-error and realtime rules above. The fields needed inside event params are:
+
+| Event | Fields used for task scoring |
+|-------|------------------------------|
+| `voice_metrics_interaction` | `interaction_id`, `run_id`, `route`, `task_schema_version`, `task_revision`, `task_started_at_ms`, `task_eligible`, `task_eligibility_known`, `failure_reason` |
+| `voice_metrics_task_started` | `schema_version`, `interaction_id`, `run_id`, `event_type`, `task_started_at_ms` |
+| `voice_metrics_task_execution` | `schema_version`, `interaction_id`, `run_id`, `outcome`, `evidence`, `execution_at_ms` |
+
+Report **`completed_turns / eligible_mature_turns * 100`**, along with both counts,
+`meets_target`, failed/unknown/incomplete counts and coverage exclusions. At the
+default 0-second horizon, all eligible started turns through as-of are in the
+denominator. An empty denominator is N/A. `completed` means technically finished
+without observed terminal errors; it does not mean the user's request was done
+correctly. Without the repository script, use the same identity merge and evidence
+rules described above; counting `voice_metrics_task_execution` rows alone is invalid.
 
 Count empty device/interaction identities separately before scoring and repair
 the export; do not merge them into a fabricated device. For aggregate KPI,
@@ -580,7 +579,7 @@ SELECT data.user_pseudo_id AS device,
   MAX(SAFE_CAST(param(data.event_params, 'hal_dropped_total') AS INT64)) AS hal_dropped_max,
   MAX(SAFE_CAST(param(data.event_params, 'hal_failed_total') AS INT64)) AS hal_failed_max
 FROM event_tracking
-WHERE event_name IN ('voice_metrics_interaction', 'voice_metrics_task_execution')
+WHERE event_name IN ('voice_metrics_interaction', 'voice_metrics_task_started', 'voice_metrics_task_execution')
   AND event_timestamp >= UNIX_SECONDS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY))
 GROUP BY device;
 ```
@@ -688,7 +687,7 @@ No transcript or full device journal is stored in this repo.
 
 The synthetic-only offline report was **2/2** with
 `--include-synthetic --settle-seconds 0`: an instrumentation check, not evidence
-that production meets 85%. At the 08:35 +07 snapshot, the normal 1800-second
+that production meets 85%. At the 08:35 +07 snapshot, the then-used 1800-second
 report was **N/A**, with two fresh pending turns. AA HTTP send success was
 verified; no warehouse read query was performed.
 
@@ -710,3 +709,23 @@ python3 -m unittest discover -s scripts/tests -p 'test_report_voice_task_metrics
 /tmp/voice-task-test-venv/bin/python hal/scripts/lint.py
 GOOS=linux GOARCH=arm64 go build -ldflags '-s -w -X go.autonomous.ai/os/system/server/config.OSVersion=0.1.88-voice-task' -o /tmp/os-server-voice-task ./system/cmd/os-server
 ```
+
+### OS cohort correction — device verification (2026-09-11)
+
+Deployed `0.1.88-voice-task-cohort-fix` to `.169` at 09:21:06 +07.
+Two direct `curl` voice-followup requests supplied `vi-smoke-cohort-fix-*`
+interaction IDs but **no HAL task snapshots**, reproducing the missing-cohort
+case. Local intent completed at 09:21:30; delegated run
+`device-chat-3-1789093296472` ended at 09:21:59 with `aborted=false`.
+The reporter with `--include-synthetic` moved from **1/2 = 50%** while the
+main agent was running to **2/2 = 100%** after its terminal event. Receipt,
+binding and execution events all had `[telemetry] delivered` records.
+This verifies HTTP ingestion, not warehouse visibility or production KPI.
+Smoke turns remain excluded by default. Backup binary on the device:
+`/tmp/os-server-before-cohort-fix`.
+
+Validation: `go test ./system/telemetry ./system/server/sensing/delivery/http
+./system/server/agent/delivery/http` passed; reporter unittest discovery passed
+29 tests, including 100 starts / 85 completions, OS-only turns, HAL/OS dedup,
+queue binding and not-ready handling (the latter two in Go integration tests).
+Linux ARM64 os-server build passed. No historical AA records were fabricated.

--- a/scripts/report_voice_task_metrics.py
+++ b/scripts/report_voice_task_metrics.py
@@ -2,7 +2,8 @@
 """Report execution completion KPI from saved journal JSONL or AA event exports.
 
 Example: python3 scripts/report_voice_task_metrics.py journal.jsonl --device lamp
-The settling horizon selects mature turns; it is never an execution timeout.
+By default all observed eligible turns count, including unfinished execution.
+An optional settling horizon selects mature turns; it is never an execution timeout.
 No network calls are made. Completion measures execution, not answer correctness.
 """
 
@@ -84,9 +85,10 @@ def normalize(row, default_device=None):
             "event_id": row.get("event_id", params.get("event_id", ""))}
 
 
-def report(rows, now_ms, settle_seconds=1800, default_device=None, include_synthetic=False):
+def report(rows, now_ms, settle_seconds=0, default_device=None, include_synthetic=False):
     interactions = {}
     executions = []
+    starts = {}
     coverage = Counter()
     losses = {}
     for row in rows:
@@ -124,7 +126,7 @@ def report(rows, now_ms, settle_seconds=1800, default_device=None, include_synth
         device_losses = losses.setdefault(device, Counter())
         for field in LOSS_COUNTERS:
             device_losses[field] = max(device_losses[field], params.get(field) or 0)
-        if event["event_name"] not in ("voice_metrics_interaction", "voice_metrics_task_execution"):
+        if event["event_name"] not in ("voice_metrics_interaction", "voice_metrics_task_started", "voice_metrics_task_execution"):
             continue
         interaction_id = params.get("interaction_id")
         if not include_synthetic and str(interaction_id or "").startswith("vi-smoke-"):
@@ -141,21 +143,106 @@ def report(rows, now_ms, settle_seconds=1800, default_device=None, include_synth
             coverage["missing_interaction_id_events"] += 1
             continue
         key = (device, str(interaction_id))
+        if event["event_name"] == "voice_metrics_task_started":
+            if str(params.get("schema_version")) != "1":
+                continue
+            if params.get("task_started_at_ms") is None:
+                coverage["malformed_events"] += 1
+                continue
+            params["_observed_at_ms"] = observed_at_ms
+            starts.setdefault(key, []).append(params)
+            continue
         # Revision is authoritative; canonical JSON makes equal revisions independent
         # of export ordering. Producers should never change an existing revision.
         rank = (params.get("task_revision") or 0, json.dumps(params, sort_keys=True))
         if key not in interactions or rank > interactions[key][0]:
             interactions[key] = (rank, params)
 
+    # Merge the two cohort sources by device + interaction ID or a bound run.
+    # Starts can arrive before HAL finalizes its snapshot and before run binding.
+    records = []
+    for key in interactions.keys() | starts.keys():
+        hal = interactions.get(key, (None, {}))[1]
+        accepted = starts.get(key, [])
+        turn = dict(hal)
+        if accepted:
+            bound = [event for event in accepted if event.get("run_id")]
+            latest = max(bound, key=lambda event: (
+                event.get("_observed_at_ms") or event["task_started_at_ms"],
+                event["task_started_at_ms"], json.dumps(event, sort_keys=True)), default={})
+            if latest:
+                turn["run_id"] = latest["run_id"]
+            if turn.get("route") != "realtime_handled":
+                turn.update(task_schema_version=1, task_eligible=True,
+                            task_eligibility_known=True)
+            times = [event["task_started_at_ms"] for event in accepted]
+            if hal.get("task_started_at_ms") is not None:
+                times.append(hal["task_started_at_ms"])
+            turn["task_started_at_ms"] = min(times)
+        turn["interaction_id"] = key[1]
+        records.append((key[0], turn))
+
+    parents = list(range(len(records)))
+
+    def root(index):
+        while parents[index] != index:
+            parents[index] = parents[parents[index]]
+            index = parents[index]
+        return index
+
+    owners = {}
+    for index, (device, turn) in enumerate(records):
+        for field in ("interaction_id", "run_id"):
+            if turn.get(field):
+                key = (device, field, str(turn[field]))
+                if key in owners:
+                    parents[root(index)] = root(owners[key])
+                owners[key] = index
+    groups = {}
+    for index, record in enumerate(records):
+        groups.setdefault(root(index), []).append(record)
+    cohort = []
+    for group in groups.values():
+        device = group[0][0]
+        turns = [turn for _, turn in group]
+        # Preserve realtime evidence restrictions even when an OS memory-sync
+        # request shares its run. Otherwise prefer a proven accepted task.
+        turn = dict(max(turns, key=lambda item: (
+            item.get("route") == "realtime_handled",
+            str(item.get("task_schema_version")) == "1",
+            _bool(item.get("task_eligible")) is True,
+            item.get("task_revision") or 0, json.dumps(item, sort_keys=True))))
+        times = [item["task_started_at_ms"] for item in turns
+                 if item.get("task_started_at_ms") is not None]
+        if times:
+            turn["task_started_at_ms"] = min(times)
+        identifiers = {(device, field, str(item[field])) for item in turns
+                       for field in ("interaction_id", "run_id") if item.get(field)}
+        cohort.append((device, turn, identifiers))
+
     indexed = {}
+    unique_executions = {}
     for device, execution in executions:
+        identity = (device, execution["_event_id"] or json.dumps(execution, sort_keys=True))
+        unique_executions[identity] = (device, execution)
+    for identity, (device, execution) in unique_executions.items():
+        if execution["execution_at_ms"] > now_ms:
+            continue
         for field in ("run_id", "interaction_id"):
             identifier = execution.get(field)
             if identifier:
-                indexed.setdefault((device, field, str(identifier)), []).append(execution)
+                indexed.setdefault((device, field, str(identifier)), {})[identity] = execution
+    cohort_identifiers = set().union(*(identifiers for _, _, identifiers in cohort))
+    matched = {identity for identifier in cohort_identifiers
+               for identity in indexed.get(identifier, {})}
+    unmatched = [execution for identity, (_, execution) in unique_executions.items()
+                 if identity not in matched and execution["execution_at_ms"] <= now_ms]
+    coverage["unmatched_execution_events"] = len(unmatched)
+    coverage["unmatched_completed_execution_events"] = sum(
+        execution.get("outcome") == "completed" for execution in unmatched)
     devices = {}
     cutoff = now_ms - settle_seconds * 1000
-    for (device, interaction_id), (_, turn) in interactions.items():
+    for device, turn, identifiers in cohort:
         counts = devices.setdefault(device, Counter())
         if str(turn.get("task_schema_version")) != "1":
             counts["legacy_turns_excluded"] += 1
@@ -173,9 +260,8 @@ def report(rows, now_ms, settle_seconds=1800, default_device=None, include_synth
         if int(started) > cutoff:
             counts["fresh_pending_turns"] += 1
             continue
-        candidates = list(indexed.get((device, "interaction_id", interaction_id), []))
-        if turn.get("run_id"):
-            candidates.extend(indexed.get((device, "run_id", str(turn["run_id"])), []))
+        candidates = list({identity: execution for identifier in identifiers
+                           for identity, execution in indexed.get(identifier, {}).items()}.values())
         if turn.get("route") == "realtime_handled":
             candidates = [e for e in candidates if e.get("evidence") == "realtime_turn_done"]
         candidates = [e for e in candidates if (e.get("execution_at_ms") or 0) <= now_ms]
@@ -242,7 +328,7 @@ def main():
     parser.add_argument("files", nargs="*", help="JSONL exports (stdin when omitted)")
     parser.add_argument("--device", help="Fallback identity for rows without a device/hostname")
     parser.add_argument("--now-ms", type=int, default=int(time.time() * 1000))
-    parser.add_argument("--settle-seconds", type=int, default=1800)
+    parser.add_argument("--settle-seconds", type=int, default=0)
     parser.add_argument("--include-synthetic", action="store_true")
     args = parser.parse_args()
     if args.settle_seconds < 0:

--- a/scripts/tests/test_report_voice_task_metrics.py
+++ b/scripts/tests/test_report_voice_task_metrics.py
@@ -27,9 +27,90 @@ def execution(identifier="v1", **overrides):
     return dict(event_name="voice_metrics_task_execution", device_id="lamp", params=params)
 
 
+def started(identifier="v1", **overrides):
+    params = dict(interaction_id=identifier, run_id="run-" + identifier,
+                  schema_version=1, task_started_at_ms=1000, event_type="voice_followup")
+    params.update(overrides)
+    return dict(event_name="voice_metrics_task_started", device_id="lamp", params=params)
+
+
 class ReportTests(unittest.TestCase):
     def summary(self, rows):
         return metrics.report(rows, now_ms=2000000)["aggregate"]
+
+    def test_os_start_without_hal_is_eligible_and_can_complete(self):
+        result = self.summary([started("os-voice-1"), execution("os-voice-1")])
+        self.assertEqual(result["eligible_mature_turns"], 1)
+        self.assertEqual(result["completed_turns"], 1)
+
+    def test_os_and_hal_cohorts_deduplicate_by_interaction_or_run(self):
+        for os_start in (started(), started("fallback", run_id="run-v1")):
+            result = self.summary([turn(), os_start, execution(), execution()])
+            self.assertEqual(result["eligible_mature_turns"], 1)
+            self.assertEqual(result["completed_turns"], 1)
+
+    def test_binding_keeps_earliest_start_and_latest_nonempty_run(self):
+        initial = started(run_id="", task_started_at_ms=1000)
+        bound = started(run_id="run-v1", task_started_at_ms=300000)
+        later_empty = started(run_id="", task_started_at_ms=400000)
+        for rows in ([initial, bound, later_empty], [later_empty, bound, initial]):
+            result = metrics.report(rows + [execution()], 2000000,
+                                    settle_seconds=1800)["aggregate"]
+            self.assertEqual(result["eligible_mature_turns"], 1)
+            self.assertEqual(result["completed_turns"], 1)
+        newer_binding = started(run_id="new-run", task_started_at_ms=500000)
+        result = self.summary([newer_binding, bound, initial, execution()])
+        self.assertEqual(result["incomplete_turns"], 1)
+
+    def test_started_without_terminal_is_immediately_in_denominator(self):
+        result = self.summary([started(task_started_at_ms=1999999)])
+        self.assertEqual(result["eligible_mature_turns"], 1)
+        self.assertEqual(result["incomplete_turns"], 1)
+        self.assertEqual(result["kpi3_pct"], 0)
+
+    def test_hundred_started_eighty_five_completed_is_eighty_five_percent(self):
+        rows = [started(str(i)) for i in range(100)]
+        rows += [execution(str(i)) for i in range(85)]
+        result = self.summary(rows)
+        self.assertEqual(result["eligible_mature_turns"], 100)
+        self.assertEqual(result["completed_turns"], 85)
+        self.assertEqual(result["kpi3_pct"], 85)
+        self.assertTrue(result["meets_target"])
+
+    def test_os_acceptance_upgrades_legacy_and_excluded_hal(self):
+        for hal in (turn(task_schema_version=None), turn(task_eligible=False),
+                    turn("other", run_id="run-v1", task_eligible=False)):
+            result = self.summary([hal, started(), execution()])
+            self.assertEqual(result["eligible_mature_turns"], 1)
+            self.assertEqual(result["completed_turns"], 1)
+            self.assertEqual(result["legacy_turns_excluded"], 0)
+            self.assertEqual(result["ineligible_turns"], 0)
+
+    def test_os_start_cannot_override_realtime_evidence_or_exclusion(self):
+        for os_start in (started(), started("fallback", run_id="run-v1")):
+            result = self.summary([turn(route="realtime_handled"), os_start, execution()])
+            self.assertEqual(result["completed_turns"], 0)
+            self.assertEqual(result["incomplete_turns"], 1)
+            result = self.summary([turn(route="realtime_handled", task_eligible=False),
+                                   os_start, execution()])
+            self.assertEqual(result["eligible_mature_turns"], 0)
+
+    def test_unmatched_execution_coverage_is_deduplicated(self):
+        orphan = execution("orphan")
+        result = metrics.report([started(), execution(), orphan, orphan,
+                                 execution("failed", outcome="failed")], 2000000)
+        self.assertEqual(result["aggregate"]["completed_turns"], 1)
+        self.assertEqual(result["coverage"]["unmatched_execution_events"], 2)
+        self.assertEqual(result["coverage"]["unmatched_completed_execution_events"], 1)
+
+    def test_started_smoke_and_future_binding_are_excluded(self):
+        result = metrics.report([started("vi-smoke-check"),
+                                 started(run_id=""),
+                                 {**started(), "observed_at_ms": 2000001}, execution()], 2000000)
+        self.assertEqual(result["aggregate"]["eligible_mature_turns"], 1)
+        self.assertEqual(result["aggregate"]["incomplete_turns"], 1)
+        self.assertEqual(result["coverage"]["synthetic_events_excluded"], 1)
+        self.assertEqual(result["coverage"]["future_events_excluded"], 1)
 
     def test_duplicate_revisions_and_completion_after_ten_seconds(self):
         old = turn(task_eligible=False)
@@ -66,7 +147,8 @@ class ReportTests(unittest.TestCase):
 
     def test_empty_and_fresh_are_na(self):
         self.assertIsNone(self.summary([])["kpi3_pct"])
-        report = self.summary([turn(task_started_at_ms=1999999)])
+        report = metrics.report([turn(task_started_at_ms=1999999)],
+                                now_ms=2000000, settle_seconds=1800)["aggregate"]
         self.assertEqual(report["fresh_pending_turns"], 1)
         self.assertIsNone(report["meets_target"])
 

--- a/system/server/sensing/delivery/http/handler.go
+++ b/system/server/sensing/delivery/http/handler.go
@@ -195,7 +195,10 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 		return
 	}
 
-	startPayload := map[string]any{"type": req.Type, "message": req.Message}
+	// Record receipt before execution or routing can fail. Preserve HAL ownership
+	// when present, and create one for direct API voice requests otherwise.
+	req.InteractionID = telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, "")
+	startPayload := map[string]any{"type": req.Type, "message": req.Message, "interaction_id": req.InteractionID}
 
 	// look.capture is MONITOR-ONLY. The realtime `look` tool already sent the
 	// frame straight to the model, so forwarding text here would inject a
@@ -243,6 +246,7 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 			// Generate a dedicated local-intent trace ID so this turn doesn't
 			// share the global trace of an in-flight agent turn.
 			localRunID := fmt.Sprintf("local-intent-%d", time.Now().UnixMilli())
+			telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, localRunID)
 			turnStart := flow.Start("sensing_input", startPayload, localRunID)
 			flow.Log("intent_match", map[string]any{"message": req.Message, "tts": result.TTSText, "rule": result.Rule, "actions": result.Actions}, localRunID)
 			if result.TTSText != "" {
@@ -571,14 +575,15 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 		// dedup think "sent" while the agent never saw the event, blocking the
 		// next real transition for 5 min.
 		if shouldQueueEvent(req.Type, req.Message, inVoiceWindow) {
-			// Pre-allocate runID for chat (web_chat / mqtt_chat) so the web
-			// client and the MQTT chat.send ack can correlate events when this
-			// turn replays. Other queued types don't need a runID (HAL doesn't
-			// track them).
+			// Preserve voice metric correlation through queued replay as well
+			// as chat acknowledgements. The queue carries the fixed run ID.
 			var queuedRunID string
-			if isChat {
+			if isChat || isVoice {
 				_, queuedRunID = h.agentGateway.NextChatRunID()
-				h.agentGateway.MarkWebChatRun(queuedRunID)
+				telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, queuedRunID)
+				if isChat {
+					h.agentGateway.MarkWebChatRun(queuedRunID)
+				}
 			}
 			busyReason := "agent busy, will replay on idle"
 			if speakerBusy {
@@ -635,6 +640,10 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 	// No local match — forward to OpenClaw agent
 	if !h.agentGateway.IsReady() {
 		notReadyRunID := fmt.Sprintf("not-ready-%d", time.Now().UnixMilli())
+		telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, notReadyRunID)
+		if isVoice {
+			telemetry.ReportTaskExecution(notReadyRunID, req.InteractionID, "failed", "dispatch_error")
+		}
 		turnStart := flow.Start("sensing_input", startPayload, notReadyRunID)
 		flow.End("sensing_input", turnStart, map[string]any{"error": "agent not connected"}, notReadyRunID)
 		// Announce once via TTS so user knows the brain is restarting (cooldown 60s).
@@ -659,6 +668,7 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 
 	// Same run_id as chat.send / JSONL: SetTrace before flow.Start so enter matches this turn (not previous).
 	reqID, runID := h.agentGateway.NextChatRunID()
+	telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, runID)
 	flow.SetTrace(runID)
 
 	// Mark this run as guard-active so SSE handler broadcasts the agent response via Telegram.
@@ -834,6 +844,9 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 	}
 
 	if err != nil {
+		if isVoice {
+			telemetry.ReportTaskExecution(runID, req.InteractionID, "failed", "dispatch_error")
+		}
 		// Forward failed — drop the voice mark so we don't keep state
 		// for a run that will never produce a lifecycle.start.
 		DefaultFillerManager.Cancel(runID)

--- a/system/server/sensing/delivery/http/voice_task_metrics_test.go
+++ b/system/server/sensing/delivery/http/voice_task_metrics_test.go
@@ -1,0 +1,86 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.autonomous.ai/os/system/monitor"
+	"go.autonomous.ai/os/system/server/config"
+)
+
+type queuedVoiceGateway struct {
+	busyGateway
+	fixedRun string
+}
+
+func (g *queuedVoiceGateway) NextChatRunID() (string, string) {
+	return "request-voice", "queued-voice-run"
+}
+func (g *queuedVoiceGateway) QueuePendingEvent(_, _ string, _ []string, run string) { g.fixedRun = run }
+
+func TestVoiceTaskMetricSurvivesMissingHALAndQueuedReplay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, queued := range []bool{false, true} {
+		t.Run(map[bool]string{false: "not_ready", true: "queued"}[queued], func(t *testing.T) {
+			var logs bytes.Buffer
+			previous := slog.Default()
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+			defer slog.SetDefault(previous)
+			h := &SensingHandler{monitorBus: monitor.ProvideBus(), config: &config.Config{}}
+			gw := &queuedVoiceGateway{}
+			if queued {
+				h.agentGateway = gw
+			} else {
+				h.agentGateway = &idleGateway{}
+			}
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/api/sensing/event", strings.NewReader(`{"type":"voice","message":"calculate nineteen times twenty three"}`))
+			c.Request.Header.Set("Content-Type", "application/json")
+			h.PostEvent(c)
+			var starts []map[string]any
+			var outcomes []map[string]any
+			for _, line := range bytes.Split(logs.Bytes(), []byte("\n")) {
+				var row map[string]any
+				if json.Unmarshal(line, &row) != nil || row["msg"] != "[telemetry] event" {
+					continue
+				}
+				var params map[string]any
+				if err := json.Unmarshal([]byte(row["params"].(string)), &params); err != nil {
+					t.Fatal(err)
+				}
+				if row["event_name"] == "voice_metrics_task_started" {
+					starts = append(starts, params)
+				}
+				if row["event_name"] == "voice_metrics_task_execution" {
+					outcomes = append(outcomes, params)
+				}
+			}
+			if len(starts) != 2 {
+				t.Fatalf("expected receipt and binding, got %d; response %s", len(starts), rec.Body.String())
+			}
+			id := starts[0]["interaction_id"].(string)
+			if !strings.HasPrefix(id, "os-voice-") || starts[1]["interaction_id"] != id {
+				t.Fatalf("lost identity: %+v", starts)
+			}
+			if queued {
+				if gw.fixedRun != "queued-voice-run" || starts[1]["run_id"] != gw.fixedRun {
+					t.Fatalf("queue lost metric correlation: %+v", starts)
+				}
+				if len(outcomes) != 0 {
+					t.Fatal("queued turn must remain incomplete")
+				}
+			} else {
+				if rec.Code != http.StatusServiceUnavailable || len(outcomes) != 1 || outcomes[0]["outcome"] != "failed" || outcomes[0]["interaction_id"] != id {
+					t.Fatalf("not-ready task missing failure: %+v", outcomes)
+				}
+			}
+		})
+	}
+}

--- a/system/telemetry/voice_task.go
+++ b/system/telemetry/voice_task.go
@@ -15,9 +15,35 @@ func ReportTaskLifecycleEnd(runID string, aborted, hasError bool) {
 	ReportTaskExecution(runID, "", "completed", "lifecycle_end")
 }
 
+// ReportVoiceTaskStarted records the denominator independently of HAL delivery.
+// Repeating it with the assigned run ID binds the same turn without adding a turn.
+// Non-task events, including realtime memory sync, never enter this cohort.
+func ReportVoiceTaskStarted(eventType, interactionID, runID string) string {
+	switch eventType {
+	case "voice", "voice_command", "voice_followup":
+	default:
+		return interactionID
+	}
+	if interactionID == "" {
+		interactionID = "os-voice-" + rand.Text()
+	}
+	Report(Event{
+		Name: "voice_metrics_task_started",
+		ID:   "vts-" + rand.Text(),
+		Params: map[string]any{
+			"schema_version":     1,
+			"interaction_id":     interactionID,
+			"run_id":             runID,
+			"event_type":         eventType,
+			"task_started_at_ms": time.Now().UnixMilli(),
+		},
+	})
+	return interactionID
+}
+
 // ReportTaskExecution records an execution boundary, not answer correctness.
 // These observations may include non-voice runs; consumers must join them to
-// an eligible HAL voice task by run_id or interaction_id before scoring it.
+// an eligible voice task by run_id or interaction_id before scoring it.
 func ReportTaskExecution(runID, interactionID, outcome, evidence string) {
 	if runID == "" && interactionID == "" {
 		return
@@ -29,7 +55,7 @@ func ReportTaskExecution(runID, interactionID, outcome, evidence string) {
 		if outcome != "completed" {
 			return
 		}
-	case "lifecycle_error", "lifecycle_end_error", "chat_error", "local_intent_error":
+	case "lifecycle_error", "lifecycle_end_error", "chat_error", "local_intent_error", "dispatch_error":
 		if outcome != "failed" {
 			return
 		}

--- a/system/telemetry/voice_task_test.go
+++ b/system/telemetry/voice_task_test.go
@@ -94,3 +94,41 @@ func TestTaskExecutionRejectsUncorrelatedAndUnboundedValues(t *testing.T) {
 		t.Fatalf("unexpected observations: %+v", m.events)
 	}
 }
+
+func TestVoiceTaskStartsPreserveOwnershipAndExcludeNonTasks(t *testing.T) {
+	m := newMock(nil, 3)
+	withPipe(t, m)
+	id := ReportVoiceTaskStarted("voice_followup", "", "")
+	if id == "" {
+		t.Fatal("direct voice request must receive an interaction ID")
+	}
+	if got := ReportVoiceTaskStarted("voice_followup", id, "main-run"); got != id {
+		t.Fatal("binding changed the turn identity")
+	}
+	ReportVoiceTaskStarted("voice_command", "vi-from-hal", "local-run")
+	for _, typ := range []string{"voice_agent_handled", "voice_listening", "web_chat", "motion"} {
+		ReportVoiceTaskStarted(typ, "", "background-run")
+	}
+	m.wait(t, 3)
+	if len(m.events) != 3 {
+		t.Fatalf("non-task event entered denominator: %d", len(m.events))
+	}
+	for i, event := range m.events {
+		if event.name != "voice_metrics_task_started" || event.params["schema_version"] != 1 {
+			t.Fatalf("invalid start event: %+v", event)
+		}
+		if _, ok := event.params["task_started_at_ms"].(int64); !ok {
+			t.Fatal("missing start timestamp")
+		}
+		wantID := id
+		if i == 2 {
+			wantID = "vi-from-hal"
+		}
+		if event.params["interaction_id"] != wantID {
+			t.Fatalf("wrong ownership: %+v", event.params)
+		}
+	}
+	if m.events[1].params["run_id"] != "main-run" {
+		t.Fatal("missing main-agent correlation")
+	}
+}


### PR DESCRIPTION
Voice tasks could finish in the main agent and appear as DONE in Flow Monitor while being absent from the KPI report because their HAL task snapshot was missing or legacy. Record task receipt and run binding in OS so these turns enter the denominator before execution, including queued voice requests and dispatch failures.

Merge OS starts with HAL snapshots by device and interaction/run identity without double-counting. The reporter defaults to a zero-second settling horizon: unfinished tasks stay in the denominator, so 85 completed out of 100 eligible turns reports 85%. Preserve realtime completion rules and expose unmatched execution coverage. Update English and Vietnamese docs with AA export instructions for all three events and the report command.

Validation:
- `go test ./system/telemetry ./system/server/sensing/delivery/http ./system/server/agent/delivery/http` passed, including missing-HAL, not-ready and queued-binding cases.
- `python3 -m unittest discover -s scripts/tests -p test_report_voice_task_metrics.py`: 29 tests passed, including 100 starts / 85 completions and HAL/OS deduplication.
- Linux ARM64 os-server build and `git diff --check` passed.
- Deployed to device .169. Two marked curl smoke tasks with no HAL snapshots reported 1/2 while the main agent was running, then 2/2 after completion. Receipt, binding and completion events all logged AA `delivered`.

Completion means technical execution ended without observed terminal errors, not semantic correctness. Smoke turns are excluded from production reports by default. Missing historical AA events are not backfilled; delivery logs prove HTTP ingestion, not warehouse visibility.
