### PR TITLE
fix: upgrade incompatible Node before OpenClaw updates

### DIFF
--- a/docs/bootstrap-ota.md
+++ b/docs/bootstrap-ota.md
@@ -565,6 +565,17 @@ os-server proxies this as `GET /api/system/ota-versions`.
 | `codex` / `claudecode` / `opencode` / `picoclaw` | Run `software-update <key>` — only on the device whose `agent_runtime` IS that runtime |
 | `hermes` | Not in the loop: `hermes update` cannot be pinned, so a `min_version` it never reaches would re-trigger every poll. SSH-only. |
 
+Manual and force OpenClaw updates run `software-update openclaw`. Before
+installing the version selected by OTA metadata, the updater reads that npm
+package's `engines.node` range and checks it with npm's bundled semver library.
+A compatible Node installation is retained. Otherwise, it installs system
+Node 24.x through NodeSource and apt, then checks the range again before
+installing OpenClaw and restarting its service. Missing engine metadata,
+compatibility-check errors, or a failed/incompatible Node upgrade abort before
+the OpenClaw install and restart. Node is a shared system dependency; a
+successful Node upgrade is not rolled back if the later OpenClaw install fails.
+This prerequisite handling does not change the automatic-update gate above.
+
 **Why the agent CLIs are gated on `agent_runtime`, not on the binary:**
 `scripts/imager/build-orangepi.sh` bakes every agent CLI onto every lamp /
 intern-v2 image regardless of `DEFAULT_AGENT`, so `inPath("codex")` is true even

--- a/docs/vi/bootstrap-ota.md
+++ b/docs/vi/bootstrap-ota.md
@@ -550,6 +550,17 @@ resolve từ `metadata.devices.<device_type>` lồng nhau thay vì danh sách co
 | `codex` / `claudecode` / `opencode` / `picoclaw` | Chạy `software-update <key>` — CHỈ trên thiết bị có `agent_runtime` đúng bằng runtime đó |
 | `hermes` | Không nằm trong loop: `hermes update` không pin được, nên một `min_version` nó không bao giờ đạt sẽ kích lại mỗi vòng poll. Chỉ chạy tay qua SSH. |
 
+Cập nhật OpenClaw thủ công và force update chạy `software-update openclaw`.
+Trước khi cài phiên bản trong OTA metadata, updater đọc `engines.node` của
+package npm đó và kiểm tra bằng thư viện semver đi kèm npm. Node đang tương
+thích được giữ nguyên; nếu chưa tương thích, updater cài Node hệ thống nhánh
+24.x qua NodeSource và apt, rồi kiểm tra lại trước khi cài OpenClaw và restart
+dịch vụ. Thiếu engine metadata, lỗi kiểm tra, hoặc nâng Node thất bại/vẫn chưa
+tương thích đều dừng trước bước cài OpenClaw và restart. Node là dependency
+chung của hệ thống; nếu đã nâng Node thành công nhưng cài OpenClaw thất bại,
+updater không rollback Node. Xử lý prerequisite này không thay đổi gate cập
+nhật tự động ở trên.
+
 **Vì sao CLI của agent gate theo `agent_runtime` chứ không theo binary:**
 `scripts/imager/build-orangepi.sh` bake CLI của MỌI agent lên mọi image lamp /
 intern-v2 bất kể `DEFAULT_AGENT`, nên `inPath("codex")` vẫn đúng trên máy đang

--- a/scripts/provision/software-update
+++ b/scripts/provision/software-update
@@ -8,6 +8,68 @@ ROLLBACK_DIR="/root/bootstrap/rollback"
 WEB_ROOT="/usr/share/nginx/html/setup"
 HAL_DIR="/opt/hal"
 
+# Use npm's bundled semver implementation: engine ranges can include unions
+# and upper bounds, so a major-version comparison is not sufficient.
+node_satisfies_engine() {
+  node - "$1" "$(command -v npm)" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+try {
+  const npmDir = path.dirname(fs.realpathSync(process.argv[3]));
+  const semver = require(require.resolve('semver', { paths: [npmDir] }));
+  const range = process.argv[2];
+  if (!semver.validRange(range)) throw new Error('Invalid Node engine range');
+  process.exit(semver.satisfies(process.version, range) ? 0 : 1);
+} catch (error) {
+  console.error('[software-update] Cannot check Node compatibility:', error.message);
+  process.exit(2);
+}
+NODE
+}
+
+ensure_openclaw_node() {
+  local version="$1" engine_json engine status setup_script
+  engine_json=$(npm view "openclaw@$version" engines.node --json) || return 1
+  engine=$(printf '%s' "$engine_json" | jq -er 'select(type == "string" and length > 0)') || {
+    echo "[software-update] Missing Node requirement for openclaw@$version" >&2
+    return 1
+  }
+  if node_satisfies_engine "$engine"; then
+    return 0
+  else
+    status=$?
+    # A broken checker must not trigger a system package upgrade.
+    [ "$status" -eq 1 ] || return "$status"
+  fi
+  echo "[software-update] openclaw@$version requires Node $engine; upgrading system Node to 24.x"
+  setup_script=$(mktemp) || return 1
+  if ! curl -fsSL https://deb.nodesource.com/setup_24.x -o "$setup_script"; then
+    rm -f "$setup_script"
+    return 1
+  fi
+  if ! bash "$setup_script"; then
+    rm -f "$setup_script"
+    return 1
+  fi
+  rm -f "$setup_script"
+  apt-get install -y nodejs || return 1
+  hash -r
+  node_satisfies_engine "$engine" || {
+    echo "[software-update] Node still does not satisfy $engine; refusing OpenClaw install (check Node version and PATH)" >&2
+    return 1
+  }
+}
+
+update_openclaw() {
+  local version="$1"
+  ensure_openclaw_node "$version" || return 1
+  npm install -g "openclaw@$version" || { echo "npm install openclaw failed"; return 1; }
+  openclaw plugins install "@openclaw/discord@$version" --force 2>&1 || echo "[software-update] WARN: discord plugin install failed (non-fatal)"
+  openclaw plugins install "@openclaw/slack@$version" --force 2>&1 || echo "[software-update] WARN: slack plugin install failed (non-fatal)"
+  systemctl restart openclaw || return 1
+  echo "openclaw updated to $version"
+}
+
 # Web is a directory install, so retain the complete prior bundle and whether
 # nginx was running. The backup is only replaced after the new ZIP has been
 # downloaded and unpacked into a sibling staging directory.
@@ -648,12 +710,7 @@ elif [ "$APP" = "bootstrap" ]; then
   systemctl restart bootstrap
   echo "bootstrap updated to $VERSION"
 elif [ "$APP" = "openclaw" ]; then
-  VER="${VERSION:-latest}"
-  npm install -g "openclaw@${VER}" || { echo "npm install openclaw failed"; exit 1; }
-  openclaw plugins install @openclaw/discord@${VER} --force 2>&1 || echo "[software-update] WARN: discord plugin install failed (non-fatal)"
-  openclaw plugins install @openclaw/slack@${VER} --force 2>&1 || echo "[software-update] WARN: slack plugin install failed (non-fatal)"
-  systemctl restart openclaw
-  echo "openclaw updated to $VER"
+  update_openclaw "$VERSION"
 elif [ "$APP" = "codex" ]; then
   # The Codex CLI is a static musl binary published on GitHub releases — there
   # is no url/sha256 in metadata (nothing of ours is hosted on GCS for it), so

--- a/scripts/provision/tests/test_software_update_openclaw.py
+++ b/scripts/provision/tests/test_software_update_openclaw.py
@@ -1,0 +1,136 @@
+"""Exercise the OpenClaw updater without network, package, or service changes."""
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "software-update"
+
+
+def shell_function(name):
+    match = re.search(
+        rf"^{re.escape(name)}\(\) \{{\n.*?^\}}$",
+        SCRIPT.read_text(),
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"Missing shell function: {name}")
+    return match.group(0)
+
+
+MOCKS = r'''
+event() { printf '%s\n' "$*" >> "$EVENTS"; }
+npm() {
+  event "npm $*"
+  if [ "$1" = view ]; then
+    [ "$FAIL" != metadata ] || return 1
+    case "$FAIL" in
+      null_metadata) printf '%s\n' 'null' ;;
+      empty_metadata) printf '%s\n' '""' ;;
+      *) printf '%s\n' '">=24.16.0 <25 || >=26.1.0"' ;;
+    esac
+  elif [ "$1" = install ]; then
+    [ "$FAIL" != install ] || return 1
+  fi
+}
+node_satisfies_engine() {
+  event "engine $*"
+  [ "$FAIL" != checker ] || return 2
+  [ "$SCENARIO" = compatible ] && return 0
+  [ "$FAIL" != incompatible ] && [ -f "$UPGRADED" ]
+}
+node() { printf '%s\n' 'v22.23.1'; }
+curl() {
+  event "curl $*"
+  [ "$FAIL" != download ]
+}
+bash() {
+  event "bash $*"
+  [ "$FAIL" != setup ]
+}
+apt-get() {
+  event "apt-get $*"
+  [ "$FAIL" != apt ] || return 1
+  touch "$UPGRADED"
+}
+openclaw() { event "openclaw $*"; }
+systemctl() { event "systemctl $*"; }
+'''
+
+
+class OpenClawUpdateTests(unittest.TestCase):
+    def run_update(self, scenario="incompatible", failure=""):
+        functions = "\n".join(
+            shell_function(name)
+            for name in ("ensure_openclaw_node", "update_openclaw")
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            events = directory / "events"
+            result = subprocess.run(
+                ["/bin/bash", "-c", "set -e\n" + functions + MOCKS
+                 + '\nupdate_openclaw "2026.9.3"\n'],
+                env={
+                    **os.environ,
+                    "EVENTS": str(events),
+                    "UPGRADED": str(directory / "upgraded"),
+                    "TMPDIR": temporary,
+                    "SCENARIO": scenario,
+                    "FAIL": failure,
+                },
+                capture_output=True,
+                text=True,
+            )
+            return result, events.read_text().splitlines() if events.exists() else []
+
+    def test_compatible_node_installs_without_upgrade(self):
+        result, events = self.run_update(scenario="compatible")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("npm view openclaw@2026.9.3 engines.node --json", events)
+        self.assertIn("npm install -g openclaw@2026.9.3", events)
+        self.assertIn("systemctl restart openclaw", events)
+        self.assertFalse(any(line.startswith(("curl ", "bash ", "apt-get "))
+                             for line in events), events)
+
+    def test_incompatible_node_upgrades_and_rechecks_before_install(self):
+        result, events = self.run_update()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(any("setup_24.x" in line for line in events), events)
+        install = events.index("npm install -g openclaw@2026.9.3")
+        upgrade = events.index("apt-get install -y nodejs")
+        checks = [index for index, line in enumerate(events)
+                  if line.startswith("engine ")]
+        self.assertEqual(len(checks), 2, events)
+        self.assertLess(checks[0], upgrade)
+        self.assertLess(upgrade, checks[1])
+        self.assertLess(checks[1], install)
+        self.assertLess(install, events.index("systemctl restart openclaw"))
+
+    def test_failures_prevent_package_install_and_service_restart(self):
+        for failure in ("metadata", "null_metadata", "empty_metadata", "checker",
+                        "download", "setup", "apt", "incompatible"):
+            with self.subTest(failure=failure):
+                result, events = self.run_update(failure=failure)
+                self.assertNotEqual(result.returncode, 0, events)
+                self.assertFalse(any(line.startswith("npm install ")
+                                     for line in events), events)
+                self.assertFalse(any(line.startswith("systemctl ")
+                                     for line in events), events)
+                if failure in ("metadata", "null_metadata", "empty_metadata", "checker"):
+                    self.assertFalse(any(line.startswith(("curl ", "bash ", "apt-get "))
+                                         for line in events), events)
+
+    def test_package_install_failure_does_not_restart(self):
+        result, events = self.run_update(scenario="compatible", failure="install")
+        self.assertNotEqual(result.returncode, 0, events)
+        self.assertIn("npm install -g openclaw@2026.9.3", events)
+        self.assertFalse(any(line.startswith(("systemctl ", "openclaw "))
+                             for line in events), events)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
OpenClaw force updates can fail with EBADENGINE on devices running Node 22 (for example, OpenClaw 2026.9.3 requires >=24.16.0 <25 or >=26.1.0). The updater now checks the target package's engines.node using npm's bundled semver, retains compatible Node installations, and installs system Node 24.x through NodeSource when needed before rechecking and installing OpenClaw.

Metadata/checker errors and failed or still-incompatible Node upgrades stop before OpenClaw installation or restart. English and Vietnamese OTA docs describe the behavior. A successful system Node upgrade is not rolled back if the subsequent OpenClaw install fails.

Validation: bash -n scripts/provision/software-update; python3 -m unittest discover -s scripts/provision/tests -v (4 tests, including 8 prerequisite failure subcases); git diff --check. Also exercised the actual semver helper with accepted, rejected, and invalid ranges. Package/service tests use mocks; no device deployment or real apt upgrade performed.
