### PR TITLE
telemetry: add chat and sensing task completion KPIs

### DIFF
--- a/docs/task-metrics.md
+++ b/docs/task-metrics.md
@@ -1,0 +1,64 @@
+# Chat and sensing task completion metrics
+
+These metrics use the same technical completion definition as [voice KPI-3](voice-metrics.md#kpi-3-execution-completion-not-correctness), with separate chat and sensing cohorts. **Completed means execution finished without observed terminal errors.** It does not assess answer correctness, user satisfaction, physical effects, or audio playback.
+
+## Groups and eligibility
+
+| Group | Cohort event | Eligible task |
+|-------|--------------|---------------|
+| Voice | `voice_metrics_task_started` (plus HAL task snapshots) | `voice`, `voice_command`, `voice_followup`; unchanged voice scoring |
+| Chat | `chat_metrics_task_started` | `web_chat`, `mqtt_chat` accepted by OS, including queued requests |
+| Sensing | `sensing_metrics_task_started` | Other noninternal sensing inputs selected for actual task dispatch |
+
+MQTT with `speak: true` becomes voice and belongs only to the voice group. Internal `voice_agent_handled`, `voice_listening`, `voice_listening_end`, and `look.capture` notifications create no cohort entry.
+
+Chat enters the denominator on receipt, before execution, and receives a fixed run binding when queued. Queue acceptance is not completion. Sensing enters only after dispatch selection: inputs dropped by sleep, cooldown, coalescing, expiry, or another suppression decision are not tasks. Queued sensing enters when replay selects it for dispatch. A merged Hermes ambient batch is one dispatched task, not one task per raw sensor input. For queued sensing in Hermes, emit the start only after `SendChat` is accepted or fails without retry; a known-unsent retry may regroup the batch and does not emit a start. This applies to both single and merged queued inputs. Limitation: these Hermes tasks have not entered the denominator while that send call is pending, or if the process crashes before its outcome. The other five runtimes emit queued sensing starts before dispatch and preserve the fixed run identity across known-unsent retries. A known-unsent retry does not create a terminal failure or a second task.
+
+Each start event carries `schema_version=1`, `interaction_id`, `run_id`, `event_type`, and `task_started_at_ms` (Unix milliseconds). Receipt and subsequent run binding are amendments, not separate turns. Merge identities using device + interaction id or nonempty device + run id; retain the earliest start.
+
+All three groups reuse **`voice_metrics_task_execution`** as their shared terminal evidence event. Its historical name does not restrict it to voice. Do not expect `chat_metrics_task_execution` or `sensing_metrics_task_execution`, and never count standalone execution rows as tasks. Join evidence only to the selected group's starts, on device + run id or device + interaction id.
+
+Evidence has `schema_version=1`, `interaction_id`, `run_id`, `outcome` (`completed`, `failed`, `unknown`), `evidence`, `execution_at_ms`, and boolean `error`. An explicit runtime end without abort/error is completed; terminal lifecycle/chat/dispatch errors are failed. Recovery alone is unknown. Any joined terminal failure through the report cutoff is sticky: later cleanup cannot turn it into completion. Otherwise select the latest execution timestamp (completed wins an equal-timestamp tie with unknown). Voice-specific HAL/realtime rules remain in the voice runbook.
+
+## AA-only query and report
+
+An agent needs AA event tracking read/export access and the repository reporter; device access is unnecessary. The query below assumes a BigQuery-style `event_tracking` table containing `event_name`, Unix-second `event_timestamp`, and `data` with `user_pseudo_id` and an `event_params` key/value array. Adapt table/accessors to your warehouse; this is an example schema, not a verified warehouse contract.
+
+```sql
+SELECT event_name, event_timestamp, data
+FROM event_tracking
+WHERE event_name IN (
+  'chat_metrics_task_started',
+  'sensing_metrics_task_started',
+  'voice_metrics_task_execution'
+)
+  AND event_timestamp >= UNIX_SECONDS(TIMESTAMP('2026-09-11 00:00:00+07'))
+  AND event_timestamp <= UNIX_SECONDS(TIMESTAMP('2026-09-11 12:00:00+07'))
+-- AND data.user_pseudo_id = '<device identity stored in AA>'
+ORDER BY event_timestamp;
+```
+
+Export one full row per JSONL line, preserving device identity, observation timestamps, and all params. Include **all starts and binding amendments**, not just completed turns, and execution evidence through the desired as-of time. For a single group the query may keep only that group's start name plus the shared execution name. Do not filter shared execution rows by event name prefix or by `event_type` (execution events need not carry that field). To report voice from the same export, also include `voice_metrics_task_started` and `voice_metrics_interaction`.
+
+```bash
+python3 scripts/report_voice_task_metrics.py aa-export.jsonl --group chat --settle-seconds 0 > chat-task-report.json
+python3 scripts/report_voice_task_metrics.py aa-export.jsonl --group sensing --settle-seconds 0 > sensing-task-report.json
+```
+
+For historical snapshots add `--now-ms <cutoff in Unix milliseconds>`. The default group is `voice`; specify chat/sensing explicitly. The reporter also accepts journal JSONL (`journalctl -u hal -u os-server -o json --no-pager`) from an authorized device session. `--device` supplies a missing-identity fallback, not a filter. Filter devices in the export.
+
+Input coverage defines the start interval; there is no start-window CLI. Preserve the full start/binding history for the selected cohort and its execution tail through as-of. The reporter filters observation timestamps before selecting evidence. Untimestamped exports cannot establish an accurate historical snapshot; missing timestamps and identity must be reported as coverage gaps. Historical tasks without start events cannot be reconstructed from terminal events alone.
+
+## Counts and interpretation
+
+For each group independently:
+
+```text
+completion_pct = 100 * completed_turns / eligible_mature_turns
+```
+
+The default settling horizon is **0 seconds**: all eligible starts through as-of enter `eligible_mature_turns`, including failed, unknown, and unfinished tasks. For example, **85 completed out of 100 eligible is 85%**. The default target is **≥85%**, evaluated before rounding. Zero eligible tasks means N/A (`completion_pct` and `meets_target` are null), not 0% or 100%. `completion_pct` aliases the legacy `kpi3_pct` field; `group` identifies the cohort. An optional positive `--settle-seconds` excludes newer starts into `fresh_pending_turns`; it is not an execution timeout.
+
+Report group, interval, as-of, source, horizon, completed/eligible counts, percentage, target result, failed/unknown/incomplete counts, and coverage. Across devices divide summed completed counts by summed eligible counts; do not average percentages. Keep chat, sensing, and voice results separate. An unmatched execution may belong to another group; it is not proof of a dropped task in the selected group. Telemetry loss counters are device-wide cumulative counters, not losses attributable to this group; examine maxima and restart resets rather than summing event values.
+
+`vi-smoke-`, `chat-smoke-`, and `sensing-smoke-` interactions are excluded by default. Diagnostic callers must use a smoke prefix; unmarked requests cannot be distinguished from real tasks. Queued sensing replay generates its own interaction ID from the run ID, so an ingress smoke ID is not retained: for queue diagnostics, exclude the known test run IDs in the export before scoring. `--include-synthetic` is for instrumentation checks only. A local `[telemetry] event` proves recording; `[telemetry] delivered` proves successful AA HTTP ingestion, not warehouse visibility. Confirm warehouse visibility using exported event IDs and interaction/run identities. These docs describe the implementation, not proof that any particular device has deployed it.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -157,6 +157,8 @@ count once even without HAL instrumentation. Arbitrary backend runs and
 horizon is 0 seconds: unfinished eligible tasks stay in the denominator. “Completed” means execution finished, not semantic correctness
 or finished audio playback. See the [KPI-3 agent query/report runbook](voice-metrics.md#agent-runbook-query-and-report-kpi-3).
 
-For `voice_metrics_*`, INFO `[telemetry] delivered` confirms successful AA HTTP
+Chat emits `chat_metrics_task_started` at receipt (including queued requests); sensing emits `sensing_metrics_task_started` only for selected task dispatch, after suppression/queue selection. Both reuse `voice_metrics_task_execution` for terminal evidence, joined within the chosen cohort. MQTT `speak: true` remains voice. See the [chat/sensing AA query and report runbook](task-metrics.md) for eligibility, shared evidence, and `--group chat|sensing` commands.
+
+For `voice_metrics_*`, `chat_metrics_*`, and `sensing_metrics_*`, INFO `[telemetry] delivered` confirms successful AA HTTP
 delivery, not warehouse query visibility. Use a warehouse read query/export to
 verify the latter; the ingestion key alone does not grant read access.

--- a/docs/vi/task-metrics_vi.md
+++ b/docs/vi/task-metrics_vi.md
@@ -1,0 +1,66 @@
+# Metric hoàn tất tác vụ chat và sensing
+
+Hai metric dùng cùng định nghĩa hoàn tất kỹ thuật với [KPI-3 voice](voice-metrics_vi.md#kpi-3-chạy-xong-không-đánh-giá-làm-đúng), nhưng có cohort chat và sensing riêng. **Completed nghĩa là chạy xong, không có lỗi thực thi terminal được quan sát.** Không đánh giá trả lời đúng, sự hài lòng, hiệu quả vật lý hay phát hết audio.
+
+## Nhóm và điều kiện được tính
+
+| Nhóm | Event tạo cohort | Tác vụ eligible |
+|------|-----------------|-----------------|
+| Voice | `voice_metrics_task_started` (cộng snapshot task HAL) | `voice`, `voice_command`, `voice_followup`; giữ nguyên cách chấm voice |
+| Chat | `chat_metrics_task_started` | `web_chat`, `mqtt_chat` được OS nhận, kể cả đang xếp hàng |
+| Sensing | `sensing_metrics_task_started` | Input sensing không phải nội bộ được chọn để thực sự dispatch tác vụ |
+
+MQTT có `speak: true` được chuyển thành voice, chỉ thuộc nhóm voice. Notification nội bộ `voice_agent_handled`, `voice_listening`, `voice_listening_end`, `look.capture` không tạo lượt eligible.
+
+Chat vào mẫu số ngay khi nhận, trước thực thi; khi vào queue được bind run cố định. Nhận vào queue chưa phải hoàn tất. Sensing chỉ vào mẫu số sau khi được chọn dispatch: input bị loại bởi sleep, cooldown, coalescing, expiry hay quyết định suppression khác không phải tác vụ. Sensing trong queue được tính khi replay chọn dispatch. Một batch ambient Hermes đã gộp là một tác vụ dispatch, không phải một lượt cho mỗi input sensor. Với sensing trong queue Hermes, chỉ phát start sau khi `SendChat` được nhận hoặc lỗi không retry; retry biết chắc chưa gửi có thể gộp lại batch và không phát start. Quy tắc áp dụng cả input đơn lẻ và batch đã gộp. Giới hạn: các tác vụ Hermes này chưa vào mẫu số khi send đang chờ kết quả hoặc process crash trước khi có kết quả. Năm runtime còn lại phát start cho sensing trong queue trước dispatch và giữ run id cố định qua retry biết chắc chưa gửi. Retry biết chắc chưa gửi không tạo terminal failure hay lượt mới.
+
+Event start có `schema_version=1`, `interaction_id`, `run_id`, `event_type`, `task_started_at_ms` (Unix milliseconds). Event lúc nhận và event bind run sau đó là bản bổ sung cùng lượt. Gộp theo device + interaction id hoặc device + run id không rỗng; giữ thời điểm start sớm nhất.
+
+Cả ba nhóm dùng chung **`voice_metrics_task_execution`** làm bằng chứng kết thúc. Tên lịch sử này không giới hạn event cho voice. Không có event riêng `chat_metrics_task_execution` hay `sensing_metrics_task_execution`; không đếm các execution row đứng riêng thành tác vụ. Chỉ join evidence với start của nhóm đang báo cáo bằng device + run id hoặc device + interaction id.
+
+Evidence có `schema_version=1`, `interaction_id`, `run_id`, `outcome` (`completed`, `failed`, `unknown`), `evidence`, `execution_at_ms`, boolean `error`. Runtime kết thúc rõ ràng không abort/error là completed; lỗi terminal lifecycle/chat/dispatch là failed. Recovery riêng lẻ là unknown. Bất kỳ terminal failure đã join trước cutoff đều được giữ: kết thúc cleanup sau đó không đổi lượt thành completed. Nếu không có failure, chọn execution timestamp mới nhất (cùng timestamp thì completed ưu tiên hơn unknown). Quy tắc riêng HAL/realtime của voice nằm trong runbook voice.
+
+## Query và report chỉ bằng AA
+
+Agent chỉ cần quyền đọc/export AA event tracking và reporter trong repo; không cần truy cập device. Query dưới đây giả định bảng kiểu BigQuery `event_tracking` có `event_name`, `event_timestamp` Unix seconds, `data` chứa `user_pseudo_id` và mảng key/value `event_params`. Điều chỉnh tên bảng/accessor theo warehouse thực tế; đây là schema ví dụ, chưa xác minh contract warehouse.
+
+```sql
+SELECT event_name, event_timestamp, data
+FROM event_tracking
+WHERE event_name IN (
+  'chat_metrics_task_started',
+  'sensing_metrics_task_started',
+  'voice_metrics_task_execution'
+)
+  AND event_timestamp >= UNIX_SECONDS(TIMESTAMP('2026-09-11 00:00:00+07'))
+  AND event_timestamp <= UNIX_SECONDS(TIMESTAMP('2026-09-11 12:00:00+07'))
+-- AND data.user_pseudo_id = '<device identity stored in AA>'
+ORDER BY event_timestamp;
+```
+
+Export JSONL mỗi dòng một row đầy đủ, giữ identity device, thời điểm quan sát và mọi param. Lấy **toàn bộ start và bản bổ sung bind run**, không chỉ lượt completed, cùng evidence thực thi đến thời điểm as-of. Nếu chỉ report một nhóm, query có thể chỉ lấy start của nhóm đó cộng execution dùng chung. Không lọc execution dùng chung theo prefix của nhóm hay `event_type` (execution không bắt buộc có field này). Muốn report voice từ cùng export, thêm `voice_metrics_task_started` và `voice_metrics_interaction`.
+
+```bash
+python3 scripts/report_voice_task_metrics.py aa-export.jsonl --group chat --settle-seconds 0 > chat-task-report.json
+python3 scripts/report_voice_task_metrics.py aa-export.jsonl --group sensing --settle-seconds 0 > sensing-task-report.json
+```
+
+Với snapshot lịch sử, thêm `--now-ms <cutoff in Unix milliseconds>`. Nhóm mặc định là `voice`; phải chỉ định chat/sensing. Reporter cũng nhận journal JSONL (`journalctl -u hal -u os-server -o json --no-pager`) từ phiên device đã được cho phép. `--device` chỉ bổ sung identity thiếu, không phải bộ lọc; lọc device khi export.
+
+Dữ liệu đầu vào quyết định khoảng start; CLI chưa có bộ lọc cửa sổ start. Giữ đầy đủ lịch sử start/binding của cohort và phần execution đến as-of. Reporter lọc thời điểm quan sát trước khi chọn evidence. Export thiếu timestamp không chứng minh được snapshot lịch sử chính xác; cần báo thiếu timestamp/identity là coverage gap. Không thể khôi phục tác vụ lịch sử thiếu start chỉ bằng event terminal.
+
+## Số đếm và cách diễn giải
+
+Tính riêng từng nhóm:
+
+```text
+completion_pct = 100 * completed_turns / eligible_mature_turns
+```
+
+Horizon mặc định **0 giây**: mọi start eligible đến as-of nằm trong `eligible_mature_turns`, gồm failed, unknown và chưa xong. Ví dụ **85 lượt xong trên 100 eligible là 85%**. Mục tiêu mặc định **≥85%**, so sánh trước khi làm tròn. Không có lượt eligible là N/A (`completion_pct`, `meets_target` bằng null), không phải 0% hay 100%. `completion_pct` là alias của field cũ `kpi3_pct`; `group` xác định cohort. `--settle-seconds` dương là tùy chọn chuyển start mới hơn sang `fresh_pending_turns`, không phải timeout thực thi.
+
+Report nhóm, khoảng thời gian, as-of, nguồn, horizon, completed/eligible, phần trăm, đạt mục tiêu hay chưa, failed/unknown/incomplete và coverage. Gộp device bằng tổng completed chia tổng eligible, không lấy trung bình phần trăm. Giữ kết quả chat, sensing, voice riêng. Execution không join được có thể thuộc nhóm khác; không chứng minh nhóm đang report bị mất task. Loss counter telemetry là bộ đếm tích lũy toàn device, không quy về riêng nhóm; xem max và reset khi restart, không cộng giá trị từng event.
+
+Interaction có prefix `vi-smoke-`, `chat-smoke-`, `sensing-smoke-` mặc định bị loại. Caller diagnostic phải dùng prefix smoke; request không đánh dấu không phân biệt được với tác vụ thật. `--include-synthetic` chỉ dùng kiểm tra instrumentation. Log `[telemetry] event` chứng minh ghi nhận local; `[telemetry] delivered` chứng minh HTTP ingestion AA thành công, chưa chứng minh query thấy row. Xác minh warehouse bằng event id và identity interaction/run trong export. Tài liệu mô tả implementation, không chứng minh device cụ thể đã deploy.
+
+Lưu ý test sensing qua queue: replay tạo interaction ID từ run ID, không giữ smoke ID ở request đầu vào. Khi kiểm tra queue, loại các run ID test đã biết khỏi dữ liệu xuất trước khi tính KPI.

--- a/docs/vi/telemetry_vi.md
+++ b/docs/vi/telemetry_vi.md
@@ -152,6 +152,8 @@ kỳ và memory-sync `voice_agent_handled` không tạo lượt mới. Horizon b
 định 0 giây: lượt eligible chưa xong vẫn ở mẫu số. “Completed” nghĩa là đã chạy xong, không đánh giá đúng yêu cầu hay phát
 hết audio. Xem [runbook query/report KPI-3 cho agent](voice-metrics_vi.md#runbook-cho-agent-query-và-report-kpi-3).
 
-Với `voice_metrics_*`, INFO `[telemetry] delivered` xác nhận HTTP gửi AA thành
+Chat phát `chat_metrics_task_started` ngay khi nhận (kể cả queue); sensing phát `sensing_metrics_task_started` chỉ khi được chọn dispatch tác vụ, sau quyết định suppression/queue. Cả hai dùng chung `voice_metrics_task_execution` cho terminal evidence và join trong cohort được chọn. MQTT `speak: true` vẫn là voice. Xem [runbook query và report AA chat/sensing](task-metrics_vi.md) để biết eligibility, evidence dùng chung và lệnh `--group chat|sensing`.
+
+Với `voice_metrics_*`, `chat_metrics_*`, `sensing_metrics_*`, INFO `[telemetry] delivered` xác nhận HTTP gửi AA thành
 công, chưa chứng minh query thấy row trong warehouse. Cần query/export bằng
 quyền đọc để xác minh; key ingestion không tự cấp quyền đọc.

--- a/docs/vi/voice-metrics_vi.md
+++ b/docs/vi/voice-metrics_vi.md
@@ -245,6 +245,8 @@ không thể phát ra câu trả lời cũ, nên không tính là thứ mà biê
 
 ## KPI-3: chạy xong, không đánh giá làm đúng
 
+Chat và sensing có cohort hoàn tất riêng; xem [runbook query AA chat/sensing](task-metrics_vi.md). Trang này chấm voice (`--group voice`, mặc định của reporter). Event dùng chung `voice_metrics_task_execution` còn chứa terminal ngoài voice; chỉ evidence join với cohort voice mới được tính ở đây. Report có `completion_pct` là alias của `kpi3_pct` và field `group`.
+
 “Successfully complete” nghĩa là **tác vụ đã chạy xong, không ghi nhận lỗi kết thúc thực thi**. Agent vẫn có thể trả
 lời sai hoặc làm hành động không hiệu quả mà đạt chỉ số thực thi này. KPI không
 đánh giá đúng yêu cầu user, kết quả tool, tác động vật lý hay phát hết câu trả lời.

--- a/docs/voice-metrics.md
+++ b/docs/voice-metrics.md
@@ -258,6 +258,8 @@ something the boundary had to suppress.
 
 ## KPI-3: execution completion, not correctness
 
+Chat and sensing have separate completion cohorts; see the [chat/sensing AA query runbook](task-metrics.md). This page scores voice (`--group voice`, the reporter default). The shared `voice_metrics_task_execution` event also carries non-voice terminals; only evidence joined to a voice cohort counts here. Reports expose `completion_pct` as an alias of `kpi3_pct` and include `group`.
+
 “Successfully complete” means **the task finished executing without observed terminal execution errors**. An agent may
 finish with an incorrect answer or an ineffective action and still meet this
 execution metric. It does not assess user satisfaction, tool-result correctness,

--- a/runtimes/claudecode/events.go
+++ b/runtimes/claudecode/events.go
@@ -12,6 +12,7 @@ import (
 	"go.autonomous.ai/os/system/lib/sensingmsg"
 	"go.autonomous.ai/os/system/lib/speakergate"
 	"go.autonomous.ai/os/system/skillcontext/mood"
+	"go.autonomous.ai/os/system/telemetry"
 )
 
 // pendingEvent is a sensing event buffered while the agent was busy.
@@ -239,6 +240,12 @@ func (s *ClaudeCodeService) drainPendingEvents() {
 			s.MarkSilentRun(runID)
 		}
 
+		if telemetry.TaskGroup(ev.eventType) == "sensing" {
+			// Keep this cohort stable if the socket disappears before dispatch.
+			ev.fixedRunID = runID
+			events[i] = ev
+			telemetry.ReportTaskStarted(ev.eventType, "", runID)
+		}
 		var err error
 		if len(ev.images) > 0 {
 			_, err = s.SendChatMessageWithImagesAndRun(msg, ev.images, reqID, runID)
@@ -253,6 +260,9 @@ func (s *ClaudeCodeService) drainPendingEvents() {
 				s.pendingEventsMu.Unlock()
 				flow.End("sensing_input", turnStart, map[string]any{"deferred": "disconnected before send"}, runID)
 				return
+			}
+			if telemetry.TaskGroup(ev.eventType) != "" {
+				telemetry.ReportTaskExecution(runID, "", "failed", "dispatch_error")
 			}
 			slog.Error("failed to replay pending event", "component", "sensing", "type", ev.eventType, "error", err)
 			flow.End("sensing_input", turnStart, map[string]any{"error": err.Error()}, runID)

--- a/runtimes/codex/events.go
+++ b/runtimes/codex/events.go
@@ -15,6 +15,7 @@ import (
 	"go.autonomous.ai/os/system/lib/sensingmsg"
 	"go.autonomous.ai/os/system/lib/speakergate"
 	"go.autonomous.ai/os/system/skillcontext/mood"
+	"go.autonomous.ai/os/system/telemetry"
 )
 
 // pendingEvent is a sensing event buffered while the agent was busy.
@@ -319,6 +320,12 @@ func (s *CodexService) drainPendingEvents() {
 			s.MarkSilentRun(runID)
 		}
 
+		if telemetry.TaskGroup(ev.eventType) == "sensing" {
+			// Keep this cohort stable if the socket disappears before dispatch.
+			ev.fixedRunID = runID
+			events[i] = ev
+			telemetry.ReportTaskStarted(ev.eventType, "", runID)
+		}
 		var err error
 		if len(ev.images) > 0 {
 			_, err = s.SendChatMessageWithImagesAndRun(msg, ev.images, reqID, runID)
@@ -335,6 +342,9 @@ func (s *CodexService) drainPendingEvents() {
 				s.pendingEventsMu.Unlock()
 				flow.End("sensing_input", turnStart, map[string]any{"deferred": "disconnected before send"}, runID)
 				return
+			}
+			if telemetry.TaskGroup(ev.eventType) != "" {
+				telemetry.ReportTaskExecution(runID, "", "failed", "dispatch_error")
 			}
 			slog.Error("failed to replay pending event", "component", "sensing", "type", ev.eventType, "error", err)
 			flow.End("sensing_input", turnStart, map[string]any{"error": err.Error()}, runID)

--- a/runtimes/hermes/events.go
+++ b/runtimes/hermes/events.go
@@ -13,6 +13,7 @@ import (
 	"go.autonomous.ai/os/system/lib/sensingmsg"
 	"go.autonomous.ai/os/system/lib/speakergate"
 	"go.autonomous.ai/os/system/skillcontext/mood"
+	"go.autonomous.ai/os/system/telemetry"
 )
 
 // pendingEvent is a sensing event buffered while the agent was busy.
@@ -287,9 +288,17 @@ func (s *HermesService) sendOnePending(ev pendingEvent) {
 	} else {
 		_, err = s.SendChatMessageWithRun(msg, reqID, runID)
 	}
+	// An unsent ambient event may merge with others on retry, so wait for the
+	// dispatch result before creating its cohort. A process crash during this
+	// synchronous send remains outside sensing coverage until acceptance.
+	if telemetry.TaskGroup(ev.eventType) == "sensing" && !errors.Is(err, errHermesNotReady) {
+		telemetry.ReportTaskStarted(ev.eventType, "", runID)
+	}
 	if err != nil {
 		if errors.Is(err, errHermesNotReady) {
 			s.restoreUnsent([]pendingEvent{ev})
+		} else if telemetry.TaskGroup(ev.eventType) != "" {
+			telemetry.ReportTaskExecution(runID, "", "failed", "dispatch_error")
 		}
 		slog.Error("failed to replay pending event", "component", "sensing", "type", ev.eventType, "error", err)
 		flow.End("sensing_input", turnStart, map[string]any{"error": err.Error()}, runID)
@@ -339,9 +348,17 @@ func (s *HermesService) sendMergedPending(evs []pendingEvent) {
 		RunID:   runID,
 	})
 
-	if _, err := s.SendChatMessageWithRun(merged, reqID, runID); err != nil {
+	_, err := s.SendChatMessageWithRun(merged, reqID, runID)
+	// Unsent members may be regrouped on retry. Only an accepted/failed dispatch
+	// forms a merged cohort, so no old batch ID can count multiple later runs.
+	if !errors.Is(err, errHermesNotReady) {
+		telemetry.ReportTaskStarted("sensing_drain_merged", "", runID)
+	}
+	if err != nil {
 		if errors.Is(err, errHermesNotReady) {
 			s.restoreUnsent(evs)
+		} else {
+			telemetry.ReportTaskExecution(runID, "", "failed", "dispatch_error")
 		}
 		slog.Error("failed to replay merged sensing events", "component", "sensing", "types", types, "error", err)
 		flow.End("sensing_input", turnStart, map[string]any{"error": err.Error()}, runID)

--- a/runtimes/openclaw/service_events.go
+++ b/runtimes/openclaw/service_events.go
@@ -12,6 +12,7 @@ import (
 	"go.autonomous.ai/os/system/lib/sensingmsg"
 	"go.autonomous.ai/os/system/lib/speakergate"
 	"go.autonomous.ai/os/system/skillcontext/mood"
+	"go.autonomous.ai/os/system/telemetry"
 )
 
 // pendingEvent is a sensing event buffered while the agent was busy.
@@ -258,6 +259,12 @@ func (s *OpenclawService) drainPendingEvents() {
 			s.MarkSilentRun(runID)
 		}
 
+		if telemetry.TaskGroup(ev.eventType) == "sensing" {
+			// Keep this cohort stable if the socket disappears before dispatch.
+			ev.fixedRunID = runID
+			events[i] = ev
+			telemetry.ReportTaskStarted(ev.eventType, "", runID)
+		}
 		var err error
 		if len(ev.images) > 0 {
 			_, err = s.SendChatMessageWithImagesAndRun(msg, ev.images, reqID, runID)
@@ -269,6 +276,9 @@ func (s *OpenclawService) drainPendingEvents() {
 				s.requeueUnsentEvents(events[i:])
 				flow.End("sensing_input", turnStart, map[string]any{"deferred": "disconnected before send"}, runID)
 				return
+			}
+			if telemetry.TaskGroup(ev.eventType) != "" {
+				telemetry.ReportTaskExecution(runID, "", "failed", "dispatch_error")
 			}
 			slog.Error("failed to replay pending event", "component", "sensing", "type", ev.eventType, "error", err)
 			flow.End("sensing_input", turnStart, map[string]any{"error": err.Error()}, runID)

--- a/runtimes/opencode/events.go
+++ b/runtimes/opencode/events.go
@@ -14,6 +14,7 @@ import (
 	"go.autonomous.ai/os/system/lib/sensingmsg"
 	"go.autonomous.ai/os/system/lib/speakergate"
 	"go.autonomous.ai/os/system/skillcontext/mood"
+	"go.autonomous.ai/os/system/telemetry"
 )
 
 // pendingEvent is a sensing event buffered while the agent was busy.
@@ -260,6 +261,12 @@ func (s *OpenCodeService) drainPendingEvents() {
 			s.MarkSilentRun(runID)
 		}
 
+		if telemetry.TaskGroup(ev.eventType) == "sensing" {
+			// Keep this cohort stable if the socket disappears before dispatch.
+			ev.fixedRunID = runID
+			events[i] = ev
+			telemetry.ReportTaskStarted(ev.eventType, "", runID)
+		}
 		var err error
 		if len(ev.images) > 0 {
 			_, err = s.SendChatMessageWithImagesAndRun(msg, ev.images, reqID, runID)
@@ -274,6 +281,9 @@ func (s *OpenCodeService) drainPendingEvents() {
 				s.pendingEventsMu.Unlock()
 				flow.End("sensing_input", turnStart, map[string]any{"deferred": "disconnected before send"}, runID)
 				return
+			}
+			if telemetry.TaskGroup(ev.eventType) != "" {
+				telemetry.ReportTaskExecution(runID, "", "failed", "dispatch_error")
 			}
 			slog.Error("failed to replay pending event", "component", "sensing", "type", ev.eventType, "error", err)
 			flow.End("sensing_input", turnStart, map[string]any{"error": err.Error()}, runID)

--- a/runtimes/picoclaw/events.go
+++ b/runtimes/picoclaw/events.go
@@ -12,6 +12,7 @@ import (
 	"go.autonomous.ai/os/system/lib/sensingmsg"
 	"go.autonomous.ai/os/system/lib/speakergate"
 	"go.autonomous.ai/os/system/skillcontext/mood"
+	"go.autonomous.ai/os/system/telemetry"
 )
 
 // pendingEvent is a sensing event buffered while the agent was busy.
@@ -263,6 +264,12 @@ func (s *PicoclawService) drainPendingEvents() {
 		if sourceType == "" {
 			sourceType = "user"
 		}
+		if telemetry.TaskGroup(ev.eventType) == "sensing" {
+			// Keep this cohort stable if the socket disappears before dispatch.
+			ev.fixedRunID = runID
+			events[i] = ev
+			telemetry.ReportTaskStarted(ev.eventType, "", runID)
+		}
 		_, err := s.sendChatNow(msg, ev.images, reqID, runID, sourceType)
 		// A missing socket is definitely unsent; a failed write is uncertain
 		// and must not be replayed. Keep the rest locally until this turn ends.
@@ -274,6 +281,9 @@ func (s *PicoclawService) drainPendingEvents() {
 		s.pendingEvents = append(tail, s.pendingEvents...)
 		s.pendingEventsMu.Unlock()
 		if err != nil {
+			if telemetry.TaskGroup(ev.eventType) != "" && !errors.Is(err, errDisconnectedBeforeSend) {
+				telemetry.ReportTaskExecution(runID, "", "failed", "dispatch_error")
+			}
 			slog.Error("failed to replay pending event", "component", "sensing", "type", ev.eventType, "error", err)
 			flow.End("sensing_input", turnStart, map[string]any{"error": err.Error()}, runID)
 		} else {

--- a/runtimes/picoclaw/task_metrics_test.go
+++ b/runtimes/picoclaw/task_metrics_test.go
@@ -1,0 +1,107 @@
+package picoclaw
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSensingReplayMetricStartsAfterFiltersAndReusesUnsentRun(t *testing.T) {
+	s := queueService(t)
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	s.wsConnected.Store(true) // Readiness raced with losing the actual socket.
+	s.pendingEvents = []pendingEvent{
+		{eventType: "motion.activity", msg: "expired", queuedAt: time.Now().Add(-2 * time.Minute)},
+		{eventType: "presence.enter", msg: "superseded", queuedAt: time.Now()},
+		{eventType: "presence.enter", msg: "retained", queuedAt: time.Now()},
+	}
+	s.drainPendingEvents()
+	if len(s.pendingEvents) != 1 || s.pendingEvents[0].fixedRunID == "" {
+		t.Fatalf("unsent retained cohort lost correlation: %+v", s.pendingEvents)
+	}
+	runID := s.pendingEvents[0].fixedRunID
+	frames := queueSocket(t, s)
+	s.drainPendingEvents()
+	nextQueuedFrame(t, frames, runID)
+
+	starts, failures := 0, 0
+	interactionID := ""
+	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+		var entry struct {
+			Name   string `json:"event_name"`
+			Params string `json:"params"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatal(err)
+		}
+		if entry.Name == "voice_metrics_task_execution" || entry.Name == "task_metrics_execution" {
+			failures++
+		}
+		if entry.Name != "sensing_metrics_task_started" {
+			continue
+		}
+		starts++
+		var params map[string]any
+		if err := json.Unmarshal([]byte(entry.Params), &params); err != nil {
+			t.Fatal(err)
+		}
+		if params["run_id"] != runID || params["event_type"] != "presence.enter" {
+			t.Fatalf("unexpected sensing cohort: %v", params)
+		}
+		got, _ := params["interaction_id"].(string)
+		if got == "" || (interactionID != "" && got != interactionID) {
+			t.Fatalf("retry changed cohort identity: %v", params)
+		}
+		interactionID = got
+	}
+	if starts != 2 || failures != 0 {
+		t.Fatalf("want two observations of one cohort and no terminal failures, got starts=%d failures=%d", starts, failures)
+	}
+}
+
+func TestSensingReplayWriteFailureReportsTerminalForStartedRun(t *testing.T) {
+	s := queueService(t)
+	queueSocket(t, s)
+	_ = s.wsConn.Close()
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	s.pendingEvents = []pendingEvent{{eventType: "presence.enter", msg: "retained", queuedAt: time.Now()}}
+	s.drainPendingEvents()
+	var startedRun string
+	failures := 0
+	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+		var entry struct {
+			Name   string `json:"event_name"`
+			Params string `json:"params"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatal(err)
+		}
+		if entry.Name != "sensing_metrics_task_started" && entry.Name != "voice_metrics_task_execution" {
+			continue
+		}
+		var params map[string]any
+		if err := json.Unmarshal([]byte(entry.Params), &params); err != nil {
+			t.Fatal(err)
+		}
+		if entry.Name == "sensing_metrics_task_started" {
+			startedRun, _ = params["run_id"].(string)
+			continue
+		}
+		failures++
+		if startedRun == "" || params["run_id"] != startedRun || params["outcome"] != "failed" || params["evidence"] != "dispatch_error" {
+			t.Fatalf("wrong terminal correlation/verdict: %v", params)
+		}
+	}
+	if failures != 1 || len(s.pendingEvents) != 0 {
+		t.Fatalf("want one failed execution with no retry, failures=%d queue=%+v", failures, s.pendingEvents)
+	}
+}

--- a/scripts/report_voice_task_metrics.py
+++ b/scripts/report_voice_task_metrics.py
@@ -15,6 +15,11 @@ import time
 from collections import Counter
 
 
+TASK_START_EVENTS = {group: f"{group}_metrics_task_started"
+                     for group in ("voice", "chat", "sensing")}
+SYNTHETIC_PREFIXES = ("vi-smoke-", "chat-smoke-", "sensing-smoke-")
+
+
 LOSS_COUNTERS = ("hal_dropped_total", "hal_failed_total", "telemetry_dropped_total",
                  "telemetry_failed_total", "unknown_owner_playbacks")
 
@@ -85,7 +90,14 @@ def normalize(row, default_device=None):
             "event_id": row.get("event_id", params.get("event_id", ""))}
 
 
-def report(rows, now_ms, settle_seconds=0, default_device=None, include_synthetic=False):
+def report(rows, now_ms, settle_seconds=0, default_device=None, include_synthetic=False,
+           group="voice"):
+    if group not in TASK_START_EVENTS:
+        raise ValueError(f"unsupported task group: {group}")
+    start_event = TASK_START_EVENTS[group]
+    cohort_events = {start_event, "voice_metrics_task_execution"}
+    if group == "voice":
+        cohort_events.add("voice_metrics_interaction")
     interactions = {}
     executions = []
     starts = {}
@@ -126,10 +138,10 @@ def report(rows, now_ms, settle_seconds=0, default_device=None, include_syntheti
         device_losses = losses.setdefault(device, Counter())
         for field in LOSS_COUNTERS:
             device_losses[field] = max(device_losses[field], params.get(field) or 0)
-        if event["event_name"] not in ("voice_metrics_interaction", "voice_metrics_task_started", "voice_metrics_task_execution"):
+        if event["event_name"] not in cohort_events:
             continue
         interaction_id = params.get("interaction_id")
-        if not include_synthetic and str(interaction_id or "").startswith("vi-smoke-"):
+        if not include_synthetic and str(interaction_id or "").startswith(SYNTHETIC_PREFIXES):
             coverage["synthetic_events_excluded"] += 1
             continue
         if event["event_name"] == "voice_metrics_task_execution":
@@ -143,7 +155,7 @@ def report(rows, now_ms, settle_seconds=0, default_device=None, include_syntheti
             coverage["missing_interaction_id_events"] += 1
             continue
         key = (device, str(interaction_id))
-        if event["event_name"] == "voice_metrics_task_started":
+        if event["event_name"] == start_event:
             if str(params.get("schema_version")) != "1":
                 continue
             if params.get("task_started_at_ms") is None:
@@ -202,9 +214,9 @@ def report(rows, now_ms, settle_seconds=0, default_device=None, include_syntheti
     for index, record in enumerate(records):
         groups.setdefault(root(index), []).append(record)
     cohort = []
-    for group in groups.values():
-        device = group[0][0]
-        turns = [turn for _, turn in group]
+    for records_group in groups.values():
+        device = records_group[0][0]
+        turns = [turn for _, turn in records_group]
         # Preserve realtime evidence restrictions even when an OS memory-sync
         # request shares its run. Otherwise prefer a proven accepted task.
         turn = dict(max(turns, key=lambda item: (
@@ -291,6 +303,7 @@ def report(rows, now_ms, settle_seconds=0, default_device=None, include_syntheti
             result.setdefault(key, 0)
         denominator = result["eligible_mature_turns"]
         result["kpi3_pct"] = result["completed_turns"] * 100 / denominator if denominator else None
+        result["completion_pct"] = result["kpi3_pct"]
         result["target_pct"] = 85
         result["meets_target"] = result["completed_turns"] * 100 >= denominator * 85 if denominator else None
         return result
@@ -300,7 +313,7 @@ def report(rows, now_ms, settle_seconds=0, default_device=None, include_syntheti
         devices.setdefault(device, Counter()).update(counters)
     for counts in devices.values():
         aggregate.update(counts)
-    return {"now_ms": now_ms, "settle_seconds": settle_seconds,
+    return {"group": group, "now_ms": now_ms, "settle_seconds": settle_seconds,
             "definition": "Execution finished without observed terminal errors; semantic correctness is not assessed.",
             "aggregate": summarize(aggregate),
             "devices": {key: summarize(value) for key, value in sorted(devices.items())},
@@ -326,6 +339,8 @@ def read_rows(filenames):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("files", nargs="*", help="JSONL exports (stdin when omitted)")
+    parser.add_argument("--group", choices=tuple(TASK_START_EVENTS), default="voice",
+                        help="Task cohort to report (default: voice)")
     parser.add_argument("--device", help="Fallback identity for rows without a device/hostname")
     parser.add_argument("--now-ms", type=int, default=int(time.time() * 1000))
     parser.add_argument("--settle-seconds", type=int, default=0)
@@ -335,7 +350,7 @@ def main():
         parser.error("--settle-seconds must be nonnegative")
     try:
         result = report(read_rows(args.files), args.now_ms, args.settle_seconds,
-                        args.device, args.include_synthetic)
+                        args.device, args.include_synthetic, args.group)
     except (OSError, ValueError) as error:
         parser.error(str(error))
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/tests/test_report_voice_task_metrics.py
+++ b/scripts/tests/test_report_voice_task_metrics.py
@@ -286,5 +286,91 @@ class ReportTests(unittest.TestCase):
         self.assertEqual(report["aggregate"]["hal_dropped_total"], 8)
 
 
+class GroupReportTests(unittest.TestCase):
+    @staticmethod
+    def start(group, identifier, **overrides):
+        event = started(identifier, **overrides)
+        event["event_name"] = f"{group}_metrics_task_started"
+        return event
+
+    def test_mixed_cohorts_keep_independent_denominators_and_results(self):
+        rows = [turn("hal"), execution("hal")]
+        for group, outcome in (("voice", "completed"), ("chat", "failed"),
+                               ("sensing", "unknown")):
+            rows += [self.start(group, group), execution(group, outcome=outcome)]
+        expected = {"voice": (2, 2, 0, 0), "chat": (1, 0, 1, 0),
+                    "sensing": (1, 0, 0, 1)}
+        for group, counts in expected.items():
+            with self.subTest(group=group):
+                result = metrics.report(rows, 2000000, group=group)
+                self.assertEqual(result["group"], group)
+                aggregate = result["aggregate"]
+                self.assertEqual(tuple(aggregate[key] for key in
+                                       ("eligible_mature_turns", "completed_turns",
+                                        "failed_turns", "unknown_turns")), counts)
+                self.assertEqual(aggregate["completion_pct"], aggregate["kpi3_pct"])
+        self.assertEqual(metrics.report(rows, 2000000),
+                         metrics.report(rows, 2000000, group="voice"))
+
+    def test_each_group_hundred_starts_eighty_five_completed(self):
+        rows = []
+        for group in ("voice", "chat", "sensing"):
+            rows += [self.start(group, f"{group}-{i}") for i in range(100)]
+            rows += [execution(f"{group}-{i}") for i in range(85)]
+        for group in ("voice", "chat", "sensing"):
+            with self.subTest(group=group):
+                result = metrics.report(rows, 2000000, group=group)["aggregate"]
+                self.assertEqual(result["eligible_mature_turns"], 100)
+                self.assertEqual(result["completed_turns"], 85)
+                self.assertEqual(result["incomplete_turns"], 15)
+                self.assertEqual(result["completion_pct"], 85)
+                self.assertTrue(result["meets_target"])
+
+    def test_queue_binding_duplicates_and_terminal_error_for_each_group(self):
+        for group in ("voice", "chat", "sensing"):
+            with self.subTest(group=group):
+                queued = self.start(group, "queued", run_id="")
+                bound = self.start(group, "queued", run_id="actual-run")
+                done = execution("other", run_id="actual-run")
+                result = metrics.report([queued, queued], 2000000, group=group)["aggregate"]
+                self.assertEqual(result["eligible_mature_turns"], 1)
+                self.assertEqual(result["incomplete_turns"], 1)
+                rows = [queued, bound, bound, done, done]
+                result = metrics.report(rows, 2000000, group=group)["aggregate"]
+                self.assertEqual(result["eligible_mature_turns"], 1)
+                self.assertEqual(result["completed_turns"], 1)
+                failure = execution("other", run_id="actual-run", outcome="failed",
+                                    evidence="lifecycle_error", execution_at_ms=10000)
+                result = metrics.report(rows + [failure], 2000000, group=group)["aggregate"]
+                self.assertEqual(result["failed_turns"], 1)
+                self.assertEqual(result["completed_turns"], 0)
+
+    def test_synthetic_prefixes_excluded_unless_requested(self):
+        for group, prefix in (("voice", "vi-smoke-"), ("chat", "chat-smoke-"),
+                              ("sensing", "sensing-smoke-")):
+            with self.subTest(group=group):
+                identifier = prefix + "test"
+                rows = [self.start(group, identifier), execution(identifier)]
+                result = metrics.report(rows, 2000000, group=group)["aggregate"]
+                self.assertEqual(result["eligible_mature_turns"], 0)
+                self.assertIsNone(result["completion_pct"])
+                result = metrics.report(rows, 2000000, include_synthetic=True,
+                                        group=group)["aggregate"]
+                self.assertEqual(result["completed_turns"], 1)
+
+    def test_cli_group_selects_cohort_and_rejects_invalid_group(self):
+        row = self.start("chat", "web")
+        output = io.StringIO()
+        with patch.object(metrics.sys, "argv", ["report", "--group", "chat", "--now-ms", "2000000"]), \
+                patch.object(metrics.sys, "stdin", io.StringIO(json.dumps(row))), \
+                patch.object(metrics.sys, "stdout", output):
+            metrics.main()
+        result = json.loads(output.getvalue())
+        self.assertEqual(result["group"], "chat")
+        self.assertEqual(result["aggregate"]["incomplete_turns"], 1)
+        with self.assertRaisesRegex(ValueError, "unsupported task group"):
+            metrics.report([], 2000000, group="invalid")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/system/server/sensing/delivery/http/handler.go
+++ b/system/server/sensing/delivery/http/handler.go
@@ -97,9 +97,9 @@ type SensingEventRequest struct {
 	// downstream already carries `attachments[]`, so nothing here has to choose
 	// which photo survives.
 	Images []string `json:"images,omitempty"`
-	// InteractionID is HAL's voice-metrics id for the utterance behind this event
-	// (measurement only, empty for non-voice sources). It is echoed back as
-	// the owner of any audio os-server starts for this turn — the opening
+	// InteractionID correlates task metrics. HAL supplies it for voice; OS
+	// generates one for chat or selected sensing when absent. For voice it is
+	// echoed back as the owner of audio os-server starts for this turn. The opening
 	// filler fires before this request's response reaches HAL, so HAL's own
 	// run-id binding cannot cover it.
 	InteractionID string `json:"interaction_id,omitempty"`
@@ -221,9 +221,12 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 		return
 	}
 
-	// Record receipt before execution or routing can fail. Preserve HAL ownership
-	// when present, and create one for direct API voice requests otherwise.
-	req.InteractionID = telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, "")
+	// User tasks enter the cohort at receipt, including queued chat. Sensor
+	// notifications enter only once routing selects an actual dispatch below.
+	taskGroup := telemetry.TaskGroup(req.Type)
+	if taskGroup == "voice" || taskGroup == "chat" {
+		req.InteractionID = telemetry.ReportTaskStarted(req.Type, req.InteractionID, "")
+	}
 	startPayload := map[string]any{"type": req.Type, "message": req.Message, "interaction_id": req.InteractionID}
 
 	// look.capture is MONITOR-ONLY. The realtime `look` tool already sent the
@@ -272,7 +275,7 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 			// Generate a dedicated local-intent trace ID so this turn doesn't
 			// share the global trace of an in-flight agent turn.
 			localRunID := fmt.Sprintf("local-intent-%d", time.Now().UnixMilli())
-			telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, localRunID)
+			telemetry.ReportTaskStarted(req.Type, req.InteractionID, localRunID)
 			turnStart := flow.Start("sensing_input", startPayload, localRunID)
 			flow.Log("intent_match", map[string]any{"message": req.Message, "tts": result.TTSText, "rule": result.Rule, "actions": result.Actions}, localRunID)
 			if result.TTSText != "" {
@@ -606,7 +609,7 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 			var queuedRunID string
 			if isChat || isVoice {
 				_, queuedRunID = h.agentGateway.NextChatRunID()
-				telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, queuedRunID)
+				telemetry.ReportTaskStarted(req.Type, req.InteractionID, queuedRunID)
 				if isChat {
 					h.agentGateway.MarkWebChatRun(queuedRunID)
 				}
@@ -666,8 +669,9 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 	// No local match — forward to OpenClaw agent
 	if !h.agentGateway.IsReady() {
 		notReadyRunID := fmt.Sprintf("not-ready-%d", time.Now().UnixMilli())
-		telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, notReadyRunID)
-		if isVoice {
+		req.InteractionID = telemetry.ReportTaskStarted(req.Type, req.InteractionID, notReadyRunID)
+		startPayload["interaction_id"] = req.InteractionID
+		if taskGroup != "" {
 			telemetry.ReportTaskExecution(notReadyRunID, req.InteractionID, "failed", "dispatch_error")
 		}
 		turnStart := flow.Start("sensing_input", startPayload, notReadyRunID)
@@ -694,7 +698,8 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 
 	// Same run_id as chat.send / JSONL: SetTrace before flow.Start so enter matches this turn (not previous).
 	reqID, runID := h.agentGateway.NextChatRunID()
-	telemetry.ReportVoiceTaskStarted(req.Type, req.InteractionID, runID)
+	req.InteractionID = telemetry.ReportTaskStarted(req.Type, req.InteractionID, runID)
+	startPayload["interaction_id"] = req.InteractionID
 	flow.SetTrace(runID)
 
 	// Mark this run as guard-active so SSE handler broadcasts the agent response via Telegram.
@@ -864,7 +869,7 @@ func (h *SensingHandler) PostEvent(c *gin.Context) {
 	}
 
 	if err != nil {
-		if isVoice {
+		if taskGroup != "" {
 			telemetry.ReportTaskExecution(runID, req.InteractionID, "failed", "dispatch_error")
 		}
 		// Forward failed — drop the voice mark so we don't keep state

--- a/system/server/sensing/delivery/http/voice_task_metrics_test.go
+++ b/system/server/sensing/delivery/http/voice_task_metrics_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -82,5 +83,70 @@ func TestVoiceTaskMetricSurvivesMissingHALAndQueuedReplay(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func (g *queuedVoiceGateway) MarkWebChatRun(string) {}
+
+func TestChatAndSensingTaskCohortsAtRoutingBoundaries(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, eventType := range []string{"web_chat", "mqtt_chat", "motion.activity"} {
+		for _, queued := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/queued=%t", eventType, queued), func(t *testing.T) {
+				var logs bytes.Buffer
+				previous := slog.Default()
+				slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+				defer slog.SetDefault(previous)
+				h := &SensingHandler{monitorBus: monitor.ProvideBus(), config: &config.Config{}}
+				gw := &queuedVoiceGateway{}
+				if queued {
+					h.agentGateway = gw
+				} else {
+					h.agentGateway = &idleGateway{}
+				}
+				rec := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(rec)
+				body := fmt.Sprintf(`{"type":%q,"message":"test source task"}`, eventType)
+				c.Request = httptest.NewRequest(http.MethodPost, "/api/sensing/event", strings.NewReader(body))
+				c.Request.Header.Set("Content-Type", "application/json")
+				h.PostEvent(c)
+				var starts, failures int
+				group := "chat"
+				if eventType == "motion.activity" {
+					group = "sensing"
+				}
+				for _, line := range bytes.Split(logs.Bytes(), []byte("\n")) {
+					var row map[string]any
+					if json.Unmarshal(line, &row) != nil || row["msg"] != "[telemetry] event" {
+						continue
+					}
+					if row["event_name"] == "voice_metrics_task_started" {
+						t.Fatal("non-voice source contaminated voice cohort")
+					}
+					if row["event_name"] == group+"_metrics_task_started" {
+						starts++
+					}
+					if row["event_name"] == "voice_metrics_task_execution" {
+						failures++
+					}
+				}
+				wantStarts, wantFailures := 2, 1
+				if queued {
+					wantFailures = 0
+				}
+				if group == "sensing" {
+					wantStarts = 1
+					if queued {
+						wantStarts = 0
+					}
+				}
+				if starts != wantStarts || failures != wantFailures {
+					t.Fatalf("starts=%d failures=%d; want %d/%d; response=%s", starts, failures, wantStarts, wantFailures, rec.Body.String())
+				}
+				if queued && group == "chat" && gw.fixedRun == "" {
+					t.Fatal("chat queue must retain run binding")
+				}
+			})
+		}
 	}
 }

--- a/system/telemetry/telemetry.go
+++ b/system/telemetry/telemetry.go
@@ -204,8 +204,8 @@ func (r *reporter) send(ctx context.Context, ev Event) {
 		return
 	}
 	level := slog.LevelDebug
-	if strings.HasPrefix(ev.Name, "voice_metrics_") {
-		// Voice KPI verification needs an observable AA acceptance receipt.
+	if strings.HasPrefix(ev.Name, "voice_metrics_") || strings.HasPrefix(ev.Name, "chat_metrics_") || strings.HasPrefix(ev.Name, "sensing_metrics_") {
+		// Task KPI verification needs an observable AA acceptance receipt.
 		level = slog.LevelInfo
 	}
 	slog.Log(ctx, level, logPrefix+" delivered", "component", "telemetry",

--- a/system/telemetry/voice_task.go
+++ b/system/telemetry/voice_task.go
@@ -15,20 +15,41 @@ func ReportTaskLifecycleEnd(runID string, aborted, hasError bool) {
 	ReportTaskExecution(runID, "", "completed", "lifecycle_end")
 }
 
-// ReportVoiceTaskStarted records the denominator independently of HAL delivery.
-// Repeating it with the assigned run ID binds the same turn without adding a turn.
-// Non-task events, including realtime memory sync, never enter this cohort.
-func ReportVoiceTaskStarted(eventType, interactionID, runID string) string {
+// TaskGroup classifies task sources, excluding internal notifications that do
+// not request execution. Other sensing types are eligible only after routing
+// policy selects them for dispatch; callers enforce that acceptance boundary.
+func TaskGroup(eventType string) string {
 	switch eventType {
 	case "voice", "voice_command", "voice_followup":
+		return "voice"
+	case "web_chat", "mqtt_chat":
+		return "chat"
+	case "", "voice_agent_handled", "voice_listening", "voice_listening_end", "look.capture":
+		return ""
 	default:
+		return "sensing"
+	}
+}
+
+// ReportTaskStarted records a source-specific denominator. Repeating it with
+// the assigned run ID binds the same turn without adding another turn.
+// Voice/chat receipt is measured immediately; sensing is measured only once
+// selected for dispatch, after filtering and queued-event coalescing.
+func ReportTaskStarted(eventType, interactionID, runID string) string {
+	group := TaskGroup(eventType)
+	if group == "" {
 		return interactionID
 	}
 	if interactionID == "" {
-		interactionID = "os-voice-" + rand.Text()
+		if group == "sensing" && runID != "" {
+			// A requeued dispatch attempt retains the same cohort identity.
+			interactionID = "os-sensing-" + runID
+		} else {
+			interactionID = "os-" + group + "-" + rand.Text()
+		}
 	}
 	Report(Event{
-		Name: "voice_metrics_task_started",
+		Name: group + "_metrics_task_started",
 		ID:   "vts-" + rand.Text(),
 		Params: map[string]any{
 			"schema_version":     1,
@@ -42,8 +63,9 @@ func ReportVoiceTaskStarted(eventType, interactionID, runID string) string {
 }
 
 // ReportTaskExecution records an execution boundary, not answer correctness.
-// These observations may include non-voice runs; consumers must join them to
-// an eligible voice task by run_id or interaction_id before scoring it.
+// The legacy event name is shared by voice, chat and sensing to avoid emitting
+// duplicate terminal events. Consumers join to their source-specific start
+// cohort by run_id or interaction_id; standalone backend runs are not scored.
 func ReportTaskExecution(runID, interactionID, outcome, evidence string) {
 	if runID == "" && interactionID == "" {
 		return

--- a/system/telemetry/voice_task_test.go
+++ b/system/telemetry/voice_task_test.go
@@ -98,16 +98,16 @@ func TestTaskExecutionRejectsUncorrelatedAndUnboundedValues(t *testing.T) {
 func TestVoiceTaskStartsPreserveOwnershipAndExcludeNonTasks(t *testing.T) {
 	m := newMock(nil, 3)
 	withPipe(t, m)
-	id := ReportVoiceTaskStarted("voice_followup", "", "")
+	id := ReportTaskStarted("voice_followup", "", "")
 	if id == "" {
 		t.Fatal("direct voice request must receive an interaction ID")
 	}
-	if got := ReportVoiceTaskStarted("voice_followup", id, "main-run"); got != id {
+	if got := ReportTaskStarted("voice_followup", id, "main-run"); got != id {
 		t.Fatal("binding changed the turn identity")
 	}
-	ReportVoiceTaskStarted("voice_command", "vi-from-hal", "local-run")
-	for _, typ := range []string{"voice_agent_handled", "voice_listening", "web_chat", "motion"} {
-		ReportVoiceTaskStarted(typ, "", "background-run")
+	ReportTaskStarted("voice_command", "vi-from-hal", "local-run")
+	for _, typ := range []string{"voice_agent_handled", "voice_listening", "voice_listening_end", "look.capture"} {
+		ReportTaskStarted(typ, "", "background-run")
 	}
 	m.wait(t, 3)
 	if len(m.events) != 3 {
@@ -130,5 +130,29 @@ func TestVoiceTaskStartsPreserveOwnershipAndExcludeNonTasks(t *testing.T) {
 	}
 	if m.events[1].params["run_id"] != "main-run" {
 		t.Fatal("missing main-agent correlation")
+	}
+}
+
+func TestTaskStartsSeparateChatSensingAndVoice(t *testing.T) {
+	m := newMock(nil, 5)
+	withPipe(t, m)
+	cases := []struct{ eventType, group string }{
+		{"voice_followup", "voice"}, {"web_chat", "chat"}, {"mqtt_chat", "chat"},
+		{"motion.activity", "sensing"}, {"presence.enter", "sensing"},
+	}
+	for _, tc := range cases {
+		if got := TaskGroup(tc.eventType); got != tc.group {
+			t.Fatalf("%s grouped as %s", tc.eventType, got)
+		}
+		ReportTaskStarted(tc.eventType, "", "run-"+tc.eventType)
+	}
+	m.wait(t, len(cases))
+	for i, tc := range cases {
+		if m.events[i].name != tc.group+"_metrics_task_started" {
+			t.Fatalf("wrong source event: %+v", m.events[i])
+		}
+		if tc.group == "sensing" && m.events[i].params["interaction_id"] != "os-sensing-run-"+tc.eventType {
+			t.Fatalf("sensing retry identity must be deterministic: %+v", m.events[i].params)
+		}
 	}
 }


### PR DESCRIPTION
Add separate technical task-completion KPIs for web/MQTT chat and sensing, using the same completion rules and default 85% target as voice. Reports previously had no start cohort for these sources, so their runtime completion events could not produce a source-specific completion rate.

Chat starts are recorded at receipt and bound to the assigned run even when queued. Sensing starts are recorded only for selected dispatches after policy filtering, expiry and coalescing; a merged Hermes ambient batch counts as one task. Queue instrumentation covers all six runtimes, preserves retry correlation where applicable, and records terminal dispatch failures without treating known-unsent retries as failures.

Reuse the existing `voice_metrics_task_execution` event as shared terminal evidence instead of emitting duplicate events. Add `chat_metrics_task_started` and `sensing_metrics_task_started`, INFO AA delivery receipts, and `--group voice|chat|sensing` in the existing reporter. Each group reports completed / eligible independently with unfinished tasks retained at the default zero-second horizon. English and Vietnamese runbooks include AA export queries and reporting commands.

Validation:
- `go test ./system/telemetry ./system/server/sensing/delivery/http ./system/server/agent/delivery/http ./system/server/device/delivery/mqtt ./runtimes/openclaw ./runtimes/hermes ./runtimes/picoclaw ./runtimes/codex ./runtimes/claudecode ./runtimes/opencode` passed.
- Reporter unittest discovery: 34 tests passed, including mixed-group separation, 85/100 for every group, duplicate events, queued binding and sticky failure.
- PicoClaw integration tests verify sensing expiry/coalescing exclusions, stable identity through an unsent retry, and failed socket dispatch.
- Linux ARM64 os-server build and diff whitespace checks passed.

Limits: completion measures technical execution, not answer correctness. Hermes queued sensing is recorded after dispatch acceptance/nonretryable failure to avoid conflicting identities when unsent batches regroup; a crash during that send remains a coverage gap. Queue sensing diagnostics must exclude their known test run IDs because replay does not retain the ingress smoke interaction ID. This change has not been deployed to a device.
