### PR TITLE
fix: migrate OpenClaw state before restarting updates

### DIFF
--- a/docs/bootstrap-ota.md
+++ b/docs/bootstrap-ota.md
@@ -576,6 +576,18 @@ the OpenClaw install and restart. Node is a shared system dependency; a
 successful Node upgrade is not rolled back if the later OpenClaw install fails.
 This prerequisite handling does not change the automatic-update gate above.
 
+After the OpenClaw package and plugin updates, the updater stops
+`openclaw.service` and runs `openclaw doctor --fix --non-interactive
+--no-workspace-suggestions` with `HOME=/root` and OpenClaw home/state set to
+`/root/.openclaw`. This migrates legacy workspace/state stores before the new
+gateway starts. If stopping the service or running doctor fails, the updater
+exits without restarting it; a failed migration leaves the gateway stopped
+for repair. After restart, success requires an authenticated
+`gateway status --require-rpc --timeout 5000` probe (up to 12 attempts,
+5 seconds between attempts). Exhausted probes report update failure, even if
+systemd considers the process active. Package/state changes are not
+automatically rolled back on migration or readiness failure.
+
 **Why the agent CLIs are gated on `agent_runtime`, not on the binary:**
 `scripts/imager/build-orangepi.sh` bakes every agent CLI onto every lamp /
 intern-v2 image regardless of `DEFAULT_AGENT`, so `inPath("codex")` is true even

--- a/docs/vi/bootstrap-ota.md
+++ b/docs/vi/bootstrap-ota.md
@@ -561,6 +561,17 @@ chung của hệ thống; nếu đã nâng Node thành công nhưng cài OpenCla
 updater không rollback Node. Xử lý prerequisite này không thay đổi gate cập
 nhật tự động ở trên.
 
+Sau khi cập nhật package OpenClaw và plugin, updater dừng `openclaw.service`
+rồi chạy `openclaw doctor --fix --non-interactive --no-workspace-suggestions`
+với `HOME=/root` và OpenClaw home/state là `/root/.openclaw`, để migrate
+workspace/state cũ trước khi khởi động gateway mới. Nếu dừng service hoặc
+chạy doctor thất bại, updater thoát và không restart; migration thất bại sẽ
+để gateway dừng chờ sửa. Sau restart, chỉ báo thành công khi probe có xác thực
+`gateway status --require-rpc --timeout 5000` thành công (tối đa 12 lần,
+cách nhau 5 giây). Hết lượt probe sẽ báo cập nhật thất bại dù systemd thấy
+process còn active. Package/state không tự rollback khi migration hoặc
+kiểm tra readiness thất bại.
+
 **Vì sao CLI của agent gate theo `agent_runtime` chứ không theo binary:**
 `scripts/imager/build-orangepi.sh` bake CLI của MỌI agent lên mọi image lamp /
 intern-v2 bất kể `DEFAULT_AGENT`, nên `inPath("codex")` vẫn đúng trên máy đang

--- a/scripts/provision/software-update
+++ b/scripts/provision/software-update
@@ -61,13 +61,30 @@ ensure_openclaw_node() {
 }
 
 update_openclaw() {
-  local version="$1"
+  local version="$1" attempt
   ensure_openclaw_node "$version" || return 1
   npm install -g "openclaw@$version" || { echo "npm install openclaw failed"; return 1; }
   openclaw plugins install "@openclaw/discord@$version" --force 2>&1 || echo "[software-update] WARN: discord plugin install failed (non-fatal)"
   openclaw plugins install "@openclaw/slack@$version" --force 2>&1 || echo "[software-update] WARN: slack plugin install failed (non-fatal)"
+  # Doctor must own maintenance while migrating legacy workspace/state stores.
+  # Use the same state paths as the system-owned gateway, not the SSH user's.
+  systemctl stop openclaw || return 1
+  if ! HOME=/root OPENCLAW_HOME=/root/.openclaw OPENCLAW_STATE_DIR=/root/.openclaw \
+    openclaw doctor --fix --non-interactive --no-workspace-suggestions; then
+    echo "[software-update] OpenClaw migration failed; gateway left stopped. Resolve doctor errors before starting openclaw.service." >&2
+    return 1
+  fi
   systemctl restart openclaw || return 1
-  echo "openclaw updated to $version"
+  for attempt in {1..12}; do
+    if HOME=/root OPENCLAW_HOME=/root/.openclaw OPENCLAW_STATE_DIR=/root/.openclaw \
+      openclaw gateway status --require-rpc --timeout 5000; then
+      echo "openclaw updated to $version"
+      return 0
+    fi
+    [ "$attempt" -eq 12 ] || sleep 5
+  done
+  echo "[software-update] OpenClaw gateway did not become ready after migration; check journalctl -u openclaw" >&2
+  return 1
 }
 
 # Web is a directory install, so retain the complete prior bundle and whether

--- a/scripts/provision/tests/test_software_update_openclaw.py
+++ b/scripts/provision/tests/test_software_update_openclaw.py
@@ -57,13 +57,28 @@ apt-get() {
   [ "$FAIL" != apt ] || return 1
   touch "$UPGRADED"
 }
-openclaw() { event "openclaw $*"; }
-systemctl() { event "systemctl $*"; }
+openclaw() {
+  event "openclaw $*"
+  case "$1" in
+    doctor)
+      event "doctor-env $HOME $OPENCLAW_HOME $OPENCLAW_STATE_DIR"
+      [ "$FAIL" != doctor ] ;;
+    gateway)
+      event "gateway-env $HOME $OPENCLAW_HOME $OPENCLAW_STATE_DIR"
+      PROBES=$((PROBES + 1))
+      [ "$PROBES" -gt "$READINESS_FAILURES" ] ;;
+  esac
+}
+systemctl() {
+  event "systemctl $*"
+  [ "$FAIL" != "$1" ]
+}
+sleep() { event "sleep $*"; }
 '''
 
 
 class OpenClawUpdateTests(unittest.TestCase):
-    def run_update(self, scenario="incompatible", failure=""):
+    def run_update(self, scenario="incompatible", failure="", readiness_failures=0):
         functions = "\n".join(
             shell_function(name)
             for name in ("ensure_openclaw_node", "update_openclaw")
@@ -81,6 +96,11 @@ class OpenClawUpdateTests(unittest.TestCase):
                     "TMPDIR": temporary,
                     "SCENARIO": scenario,
                     "FAIL": failure,
+                    "PROBES": "0",
+                    "READINESS_FAILURES": str(readiness_failures),
+                    "HOME": str(directory / "ssh-home"),
+                    "OPENCLAW_HOME": str(directory / "ssh-openclaw"),
+                    "OPENCLAW_STATE_DIR": str(directory / "ssh-state"),
                 },
                 capture_output=True,
                 text=True,
@@ -130,6 +150,53 @@ class OpenClawUpdateTests(unittest.TestCase):
         self.assertIn("npm install -g openclaw@2026.9.3", events)
         self.assertFalse(any(line.startswith(("systemctl ", "openclaw "))
                              for line in events), events)
+
+    def test_migration_runs_stopped_with_system_state_before_readiness(self):
+        result, events = self.run_update(scenario="compatible")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        ordered = [
+            "npm install -g openclaw@2026.9.3",
+            "openclaw plugins install @openclaw/discord@2026.9.3 --force",
+            "openclaw plugins install @openclaw/slack@2026.9.3 --force",
+            "systemctl stop openclaw",
+            "openclaw doctor --fix --non-interactive --no-workspace-suggestions",
+            "doctor-env /root /root/.openclaw /root/.openclaw",
+            "systemctl restart openclaw",
+            "openclaw gateway status --require-rpc --timeout 5000",
+            "gateway-env /root /root/.openclaw /root/.openclaw",
+        ]
+        positions = [events.index(event) for event in ordered]
+        self.assertEqual(positions, sorted(positions), events)
+        self.assertIn("openclaw updated to 2026.9.3", result.stdout)
+
+    def test_migration_service_failures_abort_following_steps(self):
+        for failure, forbidden in (
+            ("stop", ("openclaw doctor", "systemctl restart", "openclaw gateway")),
+            ("doctor", ("systemctl restart", "openclaw gateway")),
+            ("restart", ("openclaw gateway",)),
+        ):
+            with self.subTest(failure=failure):
+                result, events = self.run_update(scenario="compatible", failure=failure)
+                self.assertNotEqual(result.returncode, 0, events)
+                self.assertFalse(any(event.startswith(forbidden) for event in events), events)
+                self.assertNotIn("openclaw updated to", result.stdout)
+                if failure == "doctor":
+                    self.assertIn("gateway left stopped", result.stderr)
+
+    def test_readiness_retries_until_gateway_responds(self):
+        result, events = self.run_update(scenario="compatible", readiness_failures=2)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(events.count("openclaw gateway status --require-rpc --timeout 5000"), 3)
+        self.assertEqual(events.count("sleep 5"), 2)
+        self.assertIn("openclaw updated to 2026.9.3", result.stdout)
+
+    def test_readiness_exhaustion_fails_without_success_message(self):
+        result, events = self.run_update(scenario="compatible", readiness_failures=12)
+        self.assertNotEqual(result.returncode, 0, events)
+        self.assertEqual(events.count("openclaw gateway status --require-rpc --timeout 5000"), 12)
+        self.assertEqual(events.count("sleep 5"), 11)
+        self.assertNotIn("openclaw updated to", result.stdout)
+        self.assertIn("did not become ready", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Upgrading OpenClaw from 2026.6.10 to 2026.9.3 can leave the gateway exiting with CONFIG/78 because legacy workspace setup state must be migrated offline. The updater now stops the system-owned gateway after package/plugin installation and runs doctor --fix --non-interactive --no-workspace-suggestions against /root/.openclaw before restarting.

Stop or doctor failures abort without restart. After restart, the updater requires an authenticated gateway status probe, retrying up to 12 times with a 5-second delay, before reporting success. Migration failures leave the gateway stopped for repair; package/state changes are not automatically rolled back. English and Vietnamese OTA docs cover this behavior.

Validation: bash -n scripts/provision/software-update; python3 -m unittest discover -s scripts/provision/tests -v; git diff --check. Tests mock service/package commands and exercise ordering, state environment, failures, and readiness retries. The same doctor command was successfully used on lamp-0c89 to migrate its workspace and restore the Hermes-to-OpenClaw switch; the complete updater was not deployed or run on-device.
