### PR TITLE
fix: check Node compatibility before Hermes updates

### DIFF
--- a/docs/bootstrap-ota.md
+++ b/docs/bootstrap-ota.md
@@ -588,6 +588,14 @@ for repair. After restart, success requires an authenticated
 systemd considers the process active. Package/state changes are not
 automatically rolled back on migration or readiness failure.
 
+Manual `software-update hermes` checks Node before running `hermes update`.
+The supported build range follows the upstream Hermes installer: Node 22.22+
+within 22.x, 24.11+ within 24.x, or stable 26+. Incompatible Node is upgraded to
+system Node 24.x with the same helper used for OpenClaw, then rechecked.
+Compatibility-check or upgrade failures abort before `hermes update`.
+Hermes's update command resolves existing npm and refreshes dependencies;
+it does not run the installer's Node provisioning step.
+
 **Why the agent CLIs are gated on `agent_runtime`, not on the binary:**
 `scripts/imager/build-orangepi.sh` bakes every agent CLI onto every lamp /
 intern-v2 image regardless of `DEFAULT_AGENT`, so `inPath("codex")` is true even

--- a/docs/vi/bootstrap-ota.md
+++ b/docs/vi/bootstrap-ota.md
@@ -572,6 +572,14 @@ cách nhau 5 giây). Hết lượt probe sẽ báo cập nhật thất bại dù
 process còn active. Package/state không tự rollback khi migration hoặc
 kiểm tra readiness thất bại.
 
+`software-update hermes` thủ công kiểm tra Node trước khi chạy `hermes update`.
+Dải phiên bản dùng để build theo installer upstream Hermes: Node 22.22+ trong
+nhánh 22.x, 24.11+ trong nhánh 24.x, hoặc bản stable 26+. Nếu chưa tương thích,
+updater dùng chung helper với OpenClaw để nâng Node hệ thống lên nhánh 24.x,
+rồi kiểm tra lại. Lỗi kiểm tra hoặc nâng Node sẽ dừng trước `hermes update`.
+Lệnh update của Hermes chọn npm sẵn có và cập nhật dependencies; nó không
+chạy bước cài Node của installer.
+
 **Vì sao CLI của agent gate theo `agent_runtime` chứ không theo binary:**
 `scripts/imager/build-orangepi.sh` bake CLI của MỌI agent lên mọi image lamp /
 intern-v2 bất kể `DEFAULT_AGENT`, nên `inPath("codex")` vẫn đúng trên máy đang

--- a/scripts/provision/software-update
+++ b/scripts/provision/software-update
@@ -12,8 +12,8 @@ HAL_DIR="/opt/hal"
 # and upper bounds, so a major-version comparison is not sufficient.
 node_satisfies_engine() {
   node - "$1" "$(command -v npm)" <<'NODE'
-const fs = require('node:fs');
-const path = require('node:path');
+const fs = require('fs');
+const path = require('path');
 try {
   const npmDir = path.dirname(fs.realpathSync(process.argv[3]));
   const semver = require(require.resolve('semver', { paths: [npmDir] }));
@@ -27,13 +27,8 @@ try {
 NODE
 }
 
-ensure_openclaw_node() {
-  local version="$1" engine_json engine status setup_script
-  engine_json=$(npm view "openclaw@$version" engines.node --json) || return 1
-  engine=$(printf '%s' "$engine_json" | jq -er 'select(type == "string" and length > 0)') || {
-    echo "[software-update] Missing Node requirement for openclaw@$version" >&2
-    return 1
-  }
+ensure_node_engine() {
+  local engine="$1" component="$2" status setup_script
   if node_satisfies_engine "$engine"; then
     return 0
   else
@@ -41,7 +36,7 @@ ensure_openclaw_node() {
     # A broken checker must not trigger a system package upgrade.
     [ "$status" -eq 1 ] || return "$status"
   fi
-  echo "[software-update] openclaw@$version requires Node $engine; upgrading system Node to 24.x"
+  echo "[software-update] $component requires Node $engine; upgrading system Node to 24.x"
   setup_script=$(mktemp) || return 1
   if ! curl -fsSL https://deb.nodesource.com/setup_24.x -o "$setup_script"; then
     rm -f "$setup_script"
@@ -55,9 +50,26 @@ ensure_openclaw_node() {
   apt-get install -y nodejs || return 1
   hash -r
   node_satisfies_engine "$engine" || {
-    echo "[software-update] Node still does not satisfy $engine; refusing OpenClaw install (check Node version and PATH)" >&2
+    echo "[software-update] Node still does not satisfy $engine; refusing $component update (check Node version and PATH)" >&2
     return 1
   }
+}
+
+ensure_openclaw_node() {
+  local version="$1" engine_json engine
+  engine_json=$(npm view "openclaw@$version" engines.node --json) || return 1
+  engine=$(printf '%s' "$engine_json" | jq -er 'select(type == "string" and length > 0)') || {
+    echo "[software-update] Missing Node requirement for openclaw@$version" >&2
+    return 1
+  }
+  ensure_node_engine "$engine" "openclaw@$version"
+}
+
+update_hermes_package() {
+  # Match upstream scripts/install.sh node_satisfies_build. The update command
+  # only resolves an existing npm; it does not run the installer's Node setup.
+  ensure_node_engine '>=22.22.0 <23 || >=24.11.0 <25 || >=26.0.0' hermes || return 1
+  hermes update
 }
 
 update_openclaw() {
@@ -833,7 +845,7 @@ elif [ "$APP" = "hermes" ]; then
   # /usr/local/lib/os-runtimes/hermes/service).
   command -v hermes >/dev/null 2>&1 || { echo "hermes is not installed on this device — switch the runtime to hermes first"; exit 1; }
   export HOME=/root
-  hermes update || { echo "hermes update failed"; exit 1; }
+  update_hermes_package || { echo "hermes update failed"; exit 1; }
   HERMES_NOW=$(hermes --version 2>/dev/null | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+([-.+_][0-9A-Za-z.-]+)?).*/\1/p' | head -1)
   [ -n "$HERMES_NOW" ] || { echo "hermes not runnable after update"; exit 1; }
   if [ "$HERMES_NOW" != "$VERSION" ]; then

--- a/scripts/provision/tests/test_software_update_openclaw.py
+++ b/scripts/provision/tests/test_software_update_openclaw.py
@@ -1,4 +1,4 @@
-"""Exercise the OpenClaw updater without network, package, or service changes."""
+"""Exercise agent updaters without network, package, or service changes."""
 
 import os
 from pathlib import Path
@@ -74,21 +74,29 @@ systemctl() {
   [ "$FAIL" != "$1" ]
 }
 sleep() { event "sleep $*"; }
+hermes() {
+  event "hermes $*"
+  [ "$FAIL" != hermes ]
+}
 '''
 
 
 class OpenClawUpdateTests(unittest.TestCase):
-    def run_update(self, scenario="incompatible", failure="", readiness_failures=0):
+    def run_update(self, scenario="incompatible", failure="", readiness_failures=0,
+                   component="openclaw"):
         functions = "\n".join(
             shell_function(name)
-            for name in ("ensure_openclaw_node", "update_openclaw")
+            for name in ("ensure_node_engine", "ensure_openclaw_node",
+                         "update_openclaw", "update_hermes_package")
         )
+        command = ('update_openclaw "2026.9.3"' if component == "openclaw"
+                   else "update_hermes_package")
         with tempfile.TemporaryDirectory() as temporary:
             directory = Path(temporary)
             events = directory / "events"
             result = subprocess.run(
                 ["/bin/bash", "-c", "set -e\n" + functions + MOCKS
-                 + '\nupdate_openclaw "2026.9.3"\n'],
+                 + "\n" + command + "\n"],
                 env={
                     **os.environ,
                     "EVENTS": str(events),
@@ -197,6 +205,42 @@ class OpenClawUpdateTests(unittest.TestCase):
         self.assertEqual(events.count("sleep 5"), 11)
         self.assertNotIn("openclaw updated to", result.stdout)
         self.assertIn("did not become ready", result.stderr)
+
+    def test_hermes_compatible_node_updates_without_upgrade(self):
+        result, events = self.run_update(scenario="compatible", component="hermes")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(events, [
+            "engine >=22.22.0 <23 || >=24.11.0 <25 || >=26.0.0",
+            "hermes update",
+        ])
+
+    def test_hermes_incompatible_node_upgrades_and_rechecks_before_update(self):
+        result, events = self.run_update(component="hermes")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(any("setup_24.x" in event for event in events), events)
+        checks = [index for index, event in enumerate(events)
+                  if event.startswith("engine ")]
+        self.assertEqual(len(checks), 2, events)
+        upgrade = events.index("apt-get install -y nodejs")
+        self.assertLess(checks[0], upgrade)
+        self.assertLess(upgrade, checks[1])
+        self.assertLess(checks[1], events.index("hermes update"))
+
+    def test_hermes_node_setup_failures_prevent_update(self):
+        for failure in ("download", "setup", "apt", "checker", "incompatible"):
+            with self.subTest(failure=failure):
+                result, events = self.run_update(component="hermes", failure=failure)
+                self.assertNotEqual(result.returncode, 0, events)
+                self.assertNotIn("hermes update", events)
+                if failure == "checker":
+                    self.assertFalse(any(event.startswith(("curl ", "bash ", "apt-get "))
+                                         for event in events), events)
+
+    def test_hermes_update_failure_is_propagated(self):
+        result, events = self.run_update(scenario="compatible", component="hermes",
+                                         failure="hermes")
+        self.assertNotEqual(result.returncode, 0, events)
+        self.assertIn("hermes update", events)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hermes updates refresh Node dependencies using an existing npm without running the installer’s Node provisioning step. Devices with old Node can therefore fail during the update. The updater now validates Hermes’s supported build range (22.22+ within 22.x, 24.11+ within 24.x, or stable 26+) before invoking hermes update, using the shared NodeSource 24.x upgrade/recheck helper already used for OpenClaw.

Compatible Node stays unchanged. Checker or upgrade failures abort before Hermes runs. The checker uses unprefixed Node core module names so Node 12 can perform the compatibility check. English and Vietnamese OTA docs are updated.

Validation: 12 mocked updater tests passed via python3 -m unittest discover -s scripts/provision/tests -v; bash -n scripts/provision/software-update; git diff --check. Actual npm semver was checked against Node 12, 22, 24, 25, 26 and prerelease version inputs. No on-device package upgrade or deployment of this script was performed.
