### PR TITLE
hal: allow device GPIO button wiring with board fallback

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -54,6 +54,18 @@ skills/                           — Built-in SKILL.md files for agent runtime,
 integrations/                     — Off-device: companions/, chat-bridges/, perception-service/
 ```
 
+Mechanical GPIO button wiring is owned by each device in
+`robots/lamp/gpio_button.json` and `robots/intern-v2/gpio_button.json`.
+HAL resolves the device directory through `DEVICES_DIR` and `DEVICE_TYPE`,
+selects the detected board's `chip`, `line`, and `debounce_ns` from the `boards`
+map, and passes that configuration to the shared `hal/drivers/gpio_button.py`
+driver. Device configuration takes priority; a missing file or board entry
+falls back to the existing `button` defaults in `hal/board/boards.json`.
+Changing a device's button pins requires updating its JSON file and restarting
+HAL; moving physical wires is not detected automatically. Malformed
+configuration is rejected before GPIO is claimed. Simulation skips the
+hardware button.
+
 ## Principles
 
 - **Hardware is a plugin** — plug in and it works, unplug and it's skipped

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -54,6 +54,16 @@ skills/                           — Built-in SKILL.md cho agent runtime, gồm
 integrations/                     — Off-device: companions/, chat-bridges/, perception-service/
 ```
 
+Wiring nút GPIO cơ học thuộc về từng device trong
+`robots/lamp/gpio_button.json` và `robots/intern-v2/gpio_button.json`.
+HAL xác định thư mục device qua `DEVICES_DIR` và `DEVICE_TYPE`, chọn `chip`,
+`line`, `debounce_ns` của board đã detect từ map `boards`, rồi truyền cấu hình
+vào driver dùng chung `hal/drivers/gpio_button.py`. Cấu hình device được ưu tiên;
+thiếu file hoặc entry của board thì dùng lại mặc định `button` trong
+`hal/board/boards.json`. Khi đổi chân nút của device, cần sửa file JSON tương
+ứng và khởi động lại HAL; hệ thống không tự phát hiện việc đổi dây cắm.
+Config sai bị từ chối trước khi claim GPIO. Chế độ mô phỏng bỏ qua nút phần cứng.
+
 ## Nguyên Tắc
 
 - **Hardware là plugin** — cắm vào thì play, không cắm thì skip

--- a/hal/board/gpio_button.py
+++ b/hal/board/gpio_button.py
@@ -1,0 +1,37 @@
+"""Load mechanical button wiring owned by a device, keyed by board ID."""
+
+import json
+from pathlib import Path
+
+from hal.board.board import ButtonConfig, PROFILES
+
+
+def load_button_config(device_dir: str, board_id: str) -> ButtonConfig:
+    """Absent file/board uses legacy board wiring; invalid declarations are boot errors.
+
+    GPIO lines are chip-relative offsets, not physical header pin numbers.
+    The shared driver uses pull-up and active-low wiring.
+    """
+    fallback = PROFILES[board_id].button
+    path = Path(device_dir) / "gpio_button.json"
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        return fallback
+    try:
+        data = json.loads(text)
+        if not isinstance(data, dict) or set(data) != {"boards"}:
+            raise ValueError("expected an object containing only 'boards'")
+        boards = data["boards"]
+        if not isinstance(boards, dict):
+            raise ValueError("'boards' must be an object")
+        configs = {}
+        for name, values in boards.items():
+            if not isinstance(values, dict) or set(values) != {"chip", "line", "debounce_ns"}:
+                raise ValueError(f"{name}: expected chip, line and debounce_ns")
+            if any(type(value) is not int or value < 0 for value in values.values()):
+                raise ValueError(f"{name}: wiring values must be non-negative integers")
+            configs[name] = ButtonConfig(**values)
+        return configs.get(board_id, fallback)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid GPIO button wiring at {path}: {exc}") from exc

--- a/hal/drivers/gpio_button.py
+++ b/hal/drivers/gpio_button.py
@@ -1,4 +1,4 @@
-"""GPIO button handler for pin 17.
+"""GPIO button handler with device-declared wiring.
 
 Supports five actions on a single button:
 - Single click: stop speaker / unmute mic (fires immediately on release)
@@ -33,7 +33,7 @@ from hal.presets import (
     BUTTON_LED_PRESETS,
     RGB_CMD_SOLID,
 )
-from hal.board.board import board_profile
+from hal.board.gpio_button import ButtonConfig
 from hal.drivers.base import Priority
 from hal.drivers.button_actions import (
     DOUBLE_CLICK_WINDOW,
@@ -68,21 +68,8 @@ def _warn_color(tier: str):
 # Blink: 0.25 s on + 0.25 s off = 2 Hz full cycle.
 LED_BLINK_HALF_PERIOD_S = 0.25
 
-# Per-board button wiring (chip / line / debounce_ns) lives in the board
-# platform layer — hal/board/board.py — the single source of truth
-# shared across drivers. lgpio.callback tick is nanoseconds; both per-board
-# debounce values stay well under DOUBLE_CLICK_WINDOW so triple click is
-# still detectable.
-
-
-def _resolve_board_config() -> tuple[int, int, int]:
-    """Return (chip, line, debounce_ns) for the wake button on this board."""
-    b = board_profile().button
-    return b.chip, b.line, b.debounce_ns
-
-
 class GPIOButtonHandler:
-    def __init__(self):
+    def __init__(self, config: ButtonConfig):
         self._lgpio = None
         self._handle = None
         self._callback = None
@@ -96,9 +83,9 @@ class GPIOButtonHandler:
         # (per-watcher stop) so the previous watcher exits cleanly without
         # racing the new one. None when no hold is active.
         self._hold_watcher_stop = None
-        self._chip = 0
-        self._pin = 0
-        self._debounce_ns = 0  # placeholder; overwritten in start() from board_profile().button.debounce_ns
+        self._chip = config.chip
+        self._pin = config.line
+        self._debounce_ns = config.debounce_ns
         self._last_press_tick = 0
         self._last_release_tick = 0
 
@@ -153,7 +140,6 @@ class GPIOButtonHandler:
     def start(self):
         import lgpio
 
-        self._chip, self._pin, self._debounce_ns = _resolve_board_config()
         self._lgpio = lgpio
         self._handle = lgpio.gpiochip_open(self._chip)
         lgpio.gpio_claim_alert(

--- a/hal/server.py
+++ b/hal/server.py
@@ -898,13 +898,12 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("TrackerService skipped — needs servo+camera routes mounted")
 
-    # GPIO17 button (single=stop/unmute, triple=reboot, long=shutdown). The
-    # mock board carries parser-required placeholder pins, never GPIO hardware.
-    if _board_id != "sim":
+    # Device wiring overrides the legacy board defaults. Simulation skips GPIO.
+    if _gpio_button_config is not None:
         try:
             from hal.drivers.gpio_button import GPIOButtonHandler
 
-            _gpio_button_handler = GPIOButtonHandler()
+            _gpio_button_handler = GPIOButtonHandler(_gpio_button_config)
             _gpio_button_handler.start()
         except Exception as e:
             logger.warning(f"GPIO button init failed: {e}")
@@ -1282,6 +1281,12 @@ from hal.board.board import assert_board_supported
 # HAL_SIMULATE is set.
 _board_id = assert_board_supported([] if _simulation else _profile.boards)
 logger.info("Board gate: device=%s board=%s declared=%s", _resolve_device_type(), _board_id, _profile.boards)
+
+from hal.board.gpio_button import load_button_config
+
+_gpio_button_config = (
+    None if _board_id == "sim" else load_button_config(_device_dir, _board_id)
+)
 
 from hal.board.device import plan_mounts
 

--- a/hal/test/test_gpio_button_config.py
+++ b/hal/test/test_gpio_button_config.py
@@ -1,0 +1,75 @@
+"""Device button selection and malformed wiring checks, without GPIO access."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from hal.board.gpio_button import ButtonConfig, load_button_config
+
+
+class TestButtonConfig(unittest.TestCase):
+    def test_driver_claims_device_override(self):
+        from hal.drivers.gpio_button import GPIOButtonHandler
+
+        gpio = mock.Mock()
+        config = ButtonConfig(2, 31, 10_000_000)
+        with mock.patch.dict("sys.modules", {"lgpio": gpio}):
+            handler = GPIOButtonHandler(config)
+            handler.start()
+        gpio.gpiochip_open.assert_called_once_with(2)
+        gpio.gpio_claim_alert.assert_called_once_with(
+            gpio.gpiochip_open.return_value, 31, gpio.BOTH_EDGES, gpio.SET_PULL_UP,
+        )
+        self.assertEqual(handler._debounce_ns, 10_000_000)
+
+    def test_shipped_devices_preserve_wiring(self):
+        root = Path(__file__).resolve().parents[2] / "robots"
+        for device in ("lamp", "intern-v2"):
+            for board, chip, line in (
+                ("raspberry_pi_4", 0, 17),
+                ("raspberry_pi_5", 0, 17),
+                ("orangepi_sun60", 1, 9),
+            ):
+                with self.subTest(device=device, board=board):
+                    self.assertEqual(
+                        load_button_config(root / device, board),
+                        ButtonConfig(chip, line, 200_000_000),
+                    )
+            self.assertEqual(load_button_config(root / device, "sim"),
+                             ButtonConfig(0, 17, 200_000_000))
+
+    def test_device_specific_pin_and_missing_declarations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(load_button_config(directory, "orangepi_sun60"),
+                             ButtonConfig(1, 9, 200_000_000))
+            path = Path(directory) / "gpio_button.json"
+            path.write_text(json.dumps({"boards": {"orangepi_sun60": {
+                "chip": 2, "line": 31, "debounce_ns": 10_000_000,
+            }}}))
+            self.assertEqual(load_button_config(directory, "orangepi_sun60"),
+                             ButtonConfig(2, 31, 10_000_000))
+            self.assertEqual(load_button_config(directory, "raspberry_pi_4"),
+                             ButtonConfig(0, 17, 200_000_000))
+
+    def test_invalid_config_rejected_with_path(self):
+        cases = ["{", "null", '{"boards": []}']
+        for values in (
+            {"chip": 0, "line": -1, "debounce_ns": 200},
+            {"chip": False, "line": 17, "debounce_ns": 200},
+            {"chip": 0, "line": "17", "debounce_ns": 200},
+            {"chip": 0, "line": 17},
+        ):
+            cases.append(json.dumps({"boards": {"orangepi_sun60": values}}))
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "gpio_button.json"
+            for text in cases:
+                with self.subTest(text=text):
+                    path.write_text(text)
+                    with self.assertRaisesRegex(ValueError, "gpio_button.json"):
+                        load_button_config(directory, "orangepi_sun60")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/robots/intern-v2/gpio_button.json
+++ b/robots/intern-v2/gpio_button.json
@@ -1,0 +1,19 @@
+{
+  "boards": {
+    "raspberry_pi_4": {
+      "chip": 0,
+      "line": 17,
+      "debounce_ns": 200000000
+    },
+    "raspberry_pi_5": {
+      "chip": 0,
+      "line": 17,
+      "debounce_ns": 200000000
+    },
+    "orangepi_sun60": {
+      "chip": 1,
+      "line": 9,
+      "debounce_ns": 200000000
+    }
+  }
+}

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -16,11 +16,26 @@ Lamp has two physical input devices the user can touch directly. They share the 
 | GPIO button | gpiochip0 BCM 17 (pull-up, active-LOW) | gpiochip1 line 9 (pull-up, active-LOW) |
 | TTP223 | not wired | gpiochip0 lines 96 / 100, **pull-up, active-LOW** (pads rest HIGH; a touch is the falling edge). The middle pad on line 98 was removed 2026-08-28. |
 
-Board detection in both handlers reads `/proc/device-tree/model`:
+Mechanical button wiring belongs to the device: `robots/lamp/gpio_button.json`
+and `robots/intern-v2/gpio_button.json` each declare a `boards` map keyed by
+`raspberry_pi_4`, `raspberry_pi_5`, and `orangepi_sun60`. Each entry has `chip`,
+`line`, and `debounce_ns` (currently `200000000`, or 200 ms). Both devices ship
+the button pins shown above; change the selected device's file when its wiring
+changes, then restart HAL; moving physical wires is not detected automatically.
+HAL resolves the directory using `DEVICES_DIR` and `DEVICE_TYPE`, then passes
+the detected board's `ButtonConfig` to the shared driver. Device configuration
+takes priority. A missing file or board entry falls back to the existing
+`button` defaults in `hal/board/boards.json`: chip 0 / line 17 for Pi 4, Pi 5,
+CM4 and sim; chip 1 / line 9 for OrangePi sun60; all with 200 ms debounce.
+Malformed configuration is rejected before claiming GPIO. Simulation skips
+the hardware button. Pull-up, active-LOW input and gesture behavior remain in
+the shared driver. TTP223 wiring remains in `hal/board/boards.json`.
+
+Board detection reads `/proc/device-tree/model`:
 - `"sun60iw2"` → OrangePi 4 Pro / A733
 - `"raspberry pi 5"` → Pi 5
 - `"raspberry pi 4"` → Pi 4
-- else → unknown, both handlers skip claiming GPIO lines
+- unknown or unsupported hardware → rejected by the HAL startup board gate
 
 ## Gesture map
 

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -16,11 +16,26 @@ Lamp có hai thiết bị input vật lý mà user có thể chạm trực tiế
 | Nút GPIO | gpiochip0 BCM 17 (pull-up, active-LOW) | gpiochip1 line 9 (pull-up, active-LOW) |
 | TTP223 | không wire | gpiochip0 line 96 / 100, **pull-up, active-LOW** (pad nghỉ ở mức HIGH; chạm là edge xuống). Pad giữa trên line 98 đã bị bỏ ngày 2026-08-28. |
 
-Cả hai handler đều detect board qua `/proc/device-tree/model`:
+Wiring nút cơ thuộc về từng device: `robots/lamp/gpio_button.json` và
+`robots/intern-v2/gpio_button.json` đều khai báo map `boards` với các key
+`raspberry_pi_4`, `raspberry_pi_5`, `orangepi_sun60`. Mỗi entry có `chip`, `line`
+và `debounce_ns` (hiện là `200000000`, tức 200 ms). Cả hai device dùng chân nút
+trong bảng trên; khi đổi wiring, sửa file của device tương ứng rồi khởi động
+lại HAL; hệ thống không tự phát hiện việc đổi dây cắm. HAL xác định thư mục
+qua `DEVICES_DIR` và `DEVICE_TYPE`, rồi truyền `ButtonConfig` của board đã
+detect vào driver dùng chung. Cấu hình device được ưu tiên. Thiếu file hoặc
+entry của board thì dùng lại mặc định `button` trong `hal/board/boards.json`:
+chip 0 / line 17 cho Pi 4, Pi 5, CM4 và sim; chip 1 / line 9 cho OrangePi
+sun60; tất cả có debounce 200 ms. Config sai bị từ chối trước khi claim GPIO.
+Chế độ mô phỏng bỏ qua nút phần cứng. Pull-up, active-LOW và hành vi cử chỉ
+vẫn nằm trong driver dùng chung. Wiring TTP223 vẫn nằm trong
+`hal/board/boards.json`.
+
+Board được detect qua `/proc/device-tree/model`:
 - `"sun60iw2"` → OrangePi 4 Pro / A733
 - `"raspberry pi 5"` → Pi 5
 - `"raspberry pi 4"` → Pi 4
-- khác → unknown, cả hai handler bỏ qua không claim GPIO
+- phần cứng không nhận diện được hoặc không được hỗ trợ → bị board gate từ chối khi HAL khởi động
 
 ## Bảng cử chỉ
 

--- a/robots/lamp/gpio_button.json
+++ b/robots/lamp/gpio_button.json
@@ -1,0 +1,19 @@
+{
+  "boards": {
+    "raspberry_pi_4": {
+      "chip": 0,
+      "line": 17,
+      "debounce_ns": 200000000
+    },
+    "raspberry_pi_5": {
+      "chip": 0,
+      "line": 17,
+      "debounce_ns": 200000000
+    },
+    "orangepi_sun60": {
+      "chip": 1,
+      "line": 9,
+      "debounce_ns": 200000000
+    }
+  }
+}


### PR DESCRIPTION
GPIO button wiring currently comes only from the board profile, so Lamp and Intern v2 cannot choose different pins on the same board. Add device-owned `gpio_button.json` files and pass the selected wiring to the shared driver.

Device entries take priority. A missing file or board entry falls back to the existing `boards.json` pins and debounce values. Invalid declarations are rejected before the button claims GPIO. The shipped configurations preserve existing wiring and gestures; simulation still skips the hardware button. Pin changes require a HAL restart. English and Vietnamese docs describe the configuration and fallback.

Validation:
- `uv run --no-project --with pytest --with requests --with fastapi --with numpy python -m pytest hal/test/test_board.py hal/test/test_gpio_button_config.py hal/test/test_button_actions.py -q` — 35 passed, 13 subtests passed.
- `uv run --no-project --with pyflakes python hal/scripts/lint.py` — passed.
- `git diff --check` — passed.

No on-device validation or deployment performed.
