### PR TITLE
hal: add Lamp MPR121 touch input and single-click action

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -66,6 +66,29 @@ HAL; moving physical wires is not detected automatically. Malformed
 configuration is rejected before GPIO is claimed. Simulation skips the
 hardware button.
 
+Optional MPR121 touch wiring currently belongs to Lamp only, in
+`robots/lamp/mpr121.json`; Intern v2 has no MPR121 declaration. It follows the
+same device-directory selection, validated by `hal/board/mpr121.py`. Lamp
+ships an enabled `orangepi_sun60` entry using bus 0 and address 0x5A, verified
+for initialization and polling on Lamp `lamp-0c4e`. The hardware script uses
+pins 3/5 (TWI0); verify the actual wiring and enable the
+correct I²C controller externally. HAL does not change boot overlays. Missing
+`/dev/i2c-0` logs an initialization failure and leaves existing inputs running.
+Its `boards` entry requires an explicit I²C `bus`; there is no scan or guessed MPR121 fallback. Missing
+file/board or `enabled: false` skips MPR121 and preserves existing GPIO/TTP223
+inputs; simulation also skips it. Malformed enabled configuration rejects
+startup. Restart HAL after changing wiring configuration. The shared
+`hal/drivers/mpr121.py` driver groups selected electrodes into one debounced
+touch-and-release session, then calls `single_click_action(source="MPR121")`
+once, with no double-tap or destructive hold mapping. Defaults are address
+`0x5A`, electrodes 0–11, touch/release thresholds 2/1, autoconfiguration enabled,
+10 ms polling and 30 ms debounce, with 100 ms startup settling. An I²C failure
+or overcurrent fault stops only this driver. Logger `hal.drivers.mpr121` records
+configuration, electrode changes, debounced taps, action dispatch and lifecycle
+in the normal HAL log/journal; unchanged polls do not emit INFO logs.
+See [physical controls](../robots/lamp/docs/physical-controls.md) for configuration
+and gesture details.
+
 ## Principles
 
 - **Hardware is a plugin** — plug in and it works, unplug and it's skipped

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -64,6 +64,29 @@ thiếu file hoặc entry của board thì dùng lại mặc định `button` tr
 ứng và khởi động lại HAL; hệ thống không tự phát hiện việc đổi dây cắm.
 Config sai bị từ chối trước khi claim GPIO. Chế độ mô phỏng bỏ qua nút phần cứng.
 
+Wiring cảm ứng MPR121 tùy chọn hiện chỉ thuộc Lamp, trong
+`robots/lamp/mpr121.json`; Intern v2 không có khai báo MPR121. Cấu hình dùng
+cùng cách chọn thư mục device và được `hal/board/mpr121.py` kiểm tra. Lamp
+có sẵn entry bật cho `orangepi_sun60`, dùng bus 0 và địa chỉ 0x5A, đã kiểm tra
+khởi tạo và polling trên Lamp `lamp-0c4e`. Script phần cứng dùng chân 3/5
+(TWI0); cần xác minh wiring thực tế và bật
+đúng controller I²C bên ngoài HAL. HAL không sửa boot overlay. Thiếu
+`/dev/i2c-0` thì log lỗi khởi tạo và giữ các input hiện có hoạt động.
+Entry trong `boards` bắt buộc có `bus` I²C cụ thể; không quét hay đoán bus MPR121 để fallback. Thiếu
+file/board hoặc `enabled: false` thì bỏ qua MPR121, giữ input GPIO/TTP223
+hiện có; chế độ mô phỏng cũng bỏ qua. Cấu hình bật nhưng sai bị từ chối khi
+startup. Restart HAL sau khi đổi cấu hình wiring. Driver dùng chung
+`hal/drivers/mpr121.py` gom các electrode được chọn thành một phiên chạm rồi
+nhả đã debounce, sau đó gọi `single_click_action(source="MPR121")` một lần,
+không map double-tap hay giữ để thực hiện hành động destructive. Mặc định:
+địa chỉ `0x5A`, electrode 0–11, ngưỡng chạm/nhả 2/1, bật autoconfig,
+polling 10 ms và debounce 30 ms, chờ ổn định 100 ms lúc startup. Lỗi I²C hoặc
+cờ quá dòng chỉ dừng driver này. Logger `hal.drivers.mpr121` ghi cấu hình,
+thay đổi electrode, tap đã debounce, thực thi action và vòng đời driver trong
+log/journal HAL thường dùng; poll không đổi trạng thái không tạo log INFO.
+Xem [điều khiển vật lý](../../robots/lamp/docs/vi/physical-controls_vi.md) để
+biết cấu hình và chi tiết cử chỉ.
+
 ## Nguyên Tắc
 
 - **Hardware là plugin** — cắm vào thì play, không cắm thì skip

--- a/hal/board/mpr121.py
+++ b/hal/board/mpr121.py
@@ -1,0 +1,66 @@
+"""Device-owned MPR121 wiring; absent declarations preserve existing inputs."""
+
+import json
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class MPR121Config:
+    bus: int
+    address: int = 0x5A
+    electrodes: tuple[int, ...] = tuple(range(12))
+    touch_threshold: int = 2
+    release_threshold: int = 1
+    autoconfig: bool = True
+    poll_ms: int = 10
+    debounce_ms: int = 30
+
+    def __post_init__(self):
+        for name in ("bus", "address", "touch_threshold", "release_threshold", "poll_ms", "debounce_ms"):
+            if type(getattr(self, name)) is not int:
+                raise ValueError(f"{name} must be an integer")
+        if self.bus < 0:
+            raise ValueError("bus must be non-negative")
+        if not 0x5A <= self.address <= 0x5D:
+            raise ValueError("address must be between 90 (0x5A) and 93 (0x5D)")
+        if not 0 <= self.release_threshold < self.touch_threshold <= 255:
+            raise ValueError("thresholds must satisfy 0 <= release < touch <= 255")
+        if type(self.autoconfig) is not bool:
+            raise ValueError("autoconfig must be a boolean")
+        if not 1 <= self.poll_ms <= 1000 or not 0 <= self.debounce_ms <= 1000:
+            raise ValueError("poll_ms must be 1..1000; debounce_ms must be 0..1000")
+        if not isinstance(self.electrodes, (list, tuple)) or not self.electrodes:
+            raise ValueError("electrodes must be a non-empty list")
+        if any(type(i) is not int or not 0 <= i < 12 for i in self.electrodes):
+            raise ValueError("electrodes must contain integers 0..11")
+        if len(set(self.electrodes)) != len(self.electrodes):
+            raise ValueError("electrodes must not contain duplicates")
+        object.__setattr__(self, "electrodes", tuple(self.electrodes))
+
+
+def load_mpr121_config(device_dir: str, board_id: str) -> Optional[MPR121Config]:
+    """Load mpr121.json boards map; no legacy MPR121 wiring is assumed."""
+    path = Path(device_dir) / "mpr121.json"
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        return None
+    try:
+        data = json.loads(text)
+        if not isinstance(data, dict) or set(data) != {"boards"} or not isinstance(data["boards"], dict):
+            raise ValueError("expected an object containing a 'boards' map")
+        configs = {}
+        allowed = {field.name for field in fields(MPR121Config)} | {"enabled"}
+        for board, entry in data["boards"].items():
+            if not isinstance(entry, dict) or set(entry) - allowed:
+                raise ValueError(f"{board}: invalid MPR121 configuration fields")
+            values = dict(entry)
+            enabled = values.pop("enabled", True)
+            if type(enabled) is not bool:
+                raise ValueError(f"{board}: enabled must be a boolean")
+            configs[board] = MPR121Config(**values) if enabled else None
+        return configs.get(board_id)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid MPR121 wiring at {path}: {exc}") from exc

--- a/hal/drivers/mpr121.py
+++ b/hal/drivers/mpr121.py
@@ -1,0 +1,264 @@
+"""Optional MPR121 capacitive input: a complete touch maps to single click.
+
+I2C transport and register setup adapted from the user-supplied
+mpr121_opi_test.py. Only the device-declared bus/address is accessed.
+"""
+
+import ctypes
+import logging
+import os
+import queue
+import threading
+import time
+
+from hal.board.mpr121 import MPR121Config
+
+logger = logging.getLogger(__name__)
+
+
+class _I2CMsg(ctypes.Structure):
+    _fields_ = [
+        ("addr", ctypes.c_uint16), ("flags", ctypes.c_uint16),
+        ("len", ctypes.c_uint16), ("buf", ctypes.POINTER(ctypes.c_uint8)),
+    ]
+
+
+class _I2CData(ctypes.Structure):
+    _fields_ = [("msgs", ctypes.POINTER(_I2CMsg)), ("nmsgs", ctypes.c_uint32)]
+
+
+class I2CBus:
+    """Linux repeated-start I2C transport; importing this module needs no hardware."""
+
+    def __init__(self, bus):
+        self._libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        self._libc.ioctl.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_void_p]
+        self._libc.ioctl.restype = ctypes.c_int
+        self.fd = os.open(f"/dev/i2c-{bus}", os.O_RDWR | os.O_CLOEXEC)
+
+    def close(self):
+        if self.fd is not None:
+            fd, self.fd = self.fd, None
+            os.close(fd)
+
+    def _transfer(self, messages):
+        array = (_I2CMsg * len(messages))(*messages)
+        data = _I2CData(msgs=array, nmsgs=len(messages))
+        result = self._libc.ioctl(self.fd, 0x0707, ctypes.byref(data))
+        if result < 0:
+            error = ctypes.get_errno()
+            raise OSError(error, os.strerror(error))
+        if result != len(messages):
+            raise OSError("Incomplete MPR121 I2C transfer")
+
+    def read_regs(self, address, register, length):
+        pointer = (ctypes.c_uint8 * 1)(register)
+        buffer = (ctypes.c_uint8 * length)()
+        self._transfer([
+            _I2CMsg(address, 0, 1, pointer),
+            _I2CMsg(address, 1, length, buffer),
+        ])
+        return bytes(buffer)
+
+    def write_reg(self, address, register, value):
+        buffer = (ctypes.c_uint8 * 2)(register, value)
+        self._transfer([_I2CMsg(address, 0, 2, buffer)])
+
+
+class _TapDetector:
+    """Debounce the union of selected electrodes; ignore a boot-time hold."""
+
+    def __init__(self, debounce_ms):
+        self._delay = debounce_ms / 1000
+        self._stable = None
+        self._candidate = None
+        self._since = 0.0
+        self._armed = False
+        self._pressed = False
+
+    def update(self, touched, now):
+        if self._stable is None:
+            self._stable = self._candidate = touched
+            self._since = now
+            self._armed = not touched
+            logger.info("MPR121 event=detector_seed touched=%s armed=%s startup_hold_suppressed=%s", touched, self._armed, touched)
+            return False
+        if touched != self._candidate:
+            self._candidate = touched
+            self._since = now
+            logger.debug("MPR121 event=debounce_candidate touched=%s", touched)
+        if touched == self._stable or now - self._since < self._delay:
+            return False
+        self._stable = touched
+        if touched:
+            self._pressed = self._armed
+            logger.info("MPR121 event=stable_touch armed=%s", self._armed)
+            return False
+        clicked = self._pressed
+        self._pressed = False
+        self._armed = True
+        logger.info("MPR121 event=stable_release tap_accepted=%s startup_hold_suppressed=%s", clicked, not clicked)
+        return clicked
+
+
+def single_click_action(*, source):
+    # Keep platform/audio dependencies out of transport initialization.
+    from hal.drivers.button_actions import single_click_action as action
+    action(source=source)
+
+
+class MPR121Handler:
+    def __init__(self, config: MPR121Config):
+        self._config = config
+        self._mask = sum(1 << electrode for electrode in set(config.electrodes))
+        self._bus = None
+        self._stop = threading.Event()
+        self._pending = queue.Queue(maxsize=1)
+        self._poll_thread = None
+        self._action_thread = None
+        self._detector = _TapDetector(config.debounce_ms)
+        self._last_raw_mask = None
+        self._tap_id = 0
+
+    def _initialize(self):
+        config = self._config
+        bus = self._bus
+
+        def write(register, value):
+            bus.write_reg(config.address, register, value)
+
+        write(0x80, 0x63)
+        time.sleep(0.001)
+        write(0x5E, 0x00)
+        if bus.read_regs(config.address, 0x5D, 1) != b"\x24":
+            raise RuntimeError("MPR121 CONFIG2 reset value is not 0x24")
+        for electrode in range(12):
+            write(0x41 + 2 * electrode, config.touch_threshold)
+            write(0x42 + 2 * electrode, config.release_threshold)
+        for register, value in (
+            (0x2B, 1), (0x2C, 1), (0x2D, 14), (0x2E, 0),
+            (0x2F, 1), (0x30, 5), (0x31, 1), (0x32, 0),
+            (0x33, 0), (0x34, 0), (0x35, 0),
+            (0x5B, 0), (0x5C, 0x10), (0x5D, 0x20),
+        ):
+            write(register, value)
+        if config.autoconfig:
+            for register, value in ((0x7D, 200), (0x7F, 180), (0x7E, 130), (0x7B, 0x0B)):
+                write(register, value)
+        write(0x5E, 0x8F)
+
+    def _read_touched(self):
+        data = self._bus.read_regs(self._config.address, 0x00, 2)
+        if len(data) != 2:
+            raise OSError("Incomplete MPR121 touch status")
+        status = int.from_bytes(data, "little")
+        if status & 0x8000:
+            raise OSError("MPR121 over-current fault")
+        raw_mask = status & 0x0FFF
+        if raw_mask != self._last_raw_mask:
+            previous = self._last_raw_mask or 0
+            touched = [i for i in range(12) if raw_mask & ~previous & (1 << i)]
+            released = [i for i in range(12) if previous & ~raw_mask & (1 << i)]
+            logger.info(
+                "MPR121 event=electrodes initial=%s raw_mask=0x%03x selected_mask=0x%03x selected_active=0x%03x touched=%s released=%s",
+                self._last_raw_mask is None, raw_mask, self._mask,
+                raw_mask & self._mask, touched, released,
+            )
+            self._last_raw_mask = raw_mask
+        return bool(raw_mask & self._mask)
+
+    def start(self):
+        if any(thread and thread.is_alive() for thread in (self._poll_thread, self._action_thread)):
+            raise RuntimeError("MPR121 handler already running or stopping")
+        logger.info(
+            "MPR121 event=start bus=%d address=0x%02x electrodes=%s touch_threshold=%d release_threshold=%d autoconfig=%s poll_ms=%d debounce_ms=%d settle_ms=100 pending_capacity=1",
+            self._config.bus, self._config.address, self._config.electrodes,
+            self._config.touch_threshold, self._config.release_threshold,
+            self._config.autoconfig, self._config.poll_ms, self._config.debounce_ms,
+        )
+        self._last_raw_mask = None
+        self._stop.clear()
+        self._pending = queue.Queue(maxsize=1)
+        self._detector = _TapDetector(self._config.debounce_ms)
+        try:
+            self._bus = I2CBus(self._config.bus)
+            self._initialize()
+            # Allow conversions/autoconfiguration to settle before seeding the
+            # boot-held suppression from the first reported electrode state.
+            time.sleep(0.1)
+            self._detector.update(self._read_touched(), time.monotonic())
+            self._action_thread = threading.Thread(target=self._dispatch, daemon=True, name="mpr121-actions")
+            self._poll_thread = threading.Thread(target=self._poll, daemon=True, name="mpr121-poll")
+            self._action_thread.start()
+            self._poll_thread.start()
+        except Exception:
+            logger.exception("MPR121 event=start_failed")
+            self._stop.set()
+            self._close_bus()
+            raise
+        logger.info("MPR121 ready on i2c-%d address 0x%02x electrodes %s", self._config.bus, self._config.address, self._config.electrodes)
+
+    def _close_bus(self):
+        if self._bus is not None:
+            bus, self._bus = self._bus, None
+            try:
+                bus.close()
+                logger.info("MPR121 event=bus_closed bus=%d", self._config.bus)
+            except OSError:
+                logger.exception("MPR121 bus close failed")
+
+    def _poll(self):
+        logger.info("MPR121 event=worker_started worker=poll")
+        try:
+            while not self._stop.wait(self._config.poll_ms / 1000):
+                if self._detector.update(self._read_touched(), time.monotonic()):
+                    self._tap_id += 1
+                    logger.info("MPR121 event=tap_accepted tap_id=%d", self._tap_id)
+                    try:
+                        self._pending.put_nowait(self._tap_id)
+                        logger.info("MPR121 event=action_queued tap_id=%d", self._tap_id)
+                    except queue.Full:
+                        logger.info("MPR121 event=action_coalesced tap_id=%d reason=pending_queue_full", self._tap_id)
+        except Exception:
+            logger.exception("MPR121 polling stopped after hardware error")
+            self._stop.set()
+        finally:
+            self._close_bus()
+            logger.info("MPR121 event=worker_stopped worker=poll")
+
+    def _dispatch(self):
+        logger.info("MPR121 event=worker_started worker=action")
+        try:
+            while not self._stop.is_set():
+                try:
+                    tap_id = self._pending.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                if self._stop.is_set():
+                    logger.info("MPR121 event=action_discarded tap_id=%s reason=stopping", tap_id)
+                    return
+                try:
+                    logger.info("MPR121 event=action_begin tap_id=%s action=single_click", tap_id)
+                    single_click_action(source="MPR121")
+                    logger.info("MPR121 event=action_complete tap_id=%s action=single_click", tap_id)
+                except Exception:
+                    logger.exception("MPR121 event=action_failed tap_id=%s action=single_click", tap_id)
+        finally:
+            while True:
+                try:
+                    tap_id = self._pending.get_nowait()
+                except queue.Empty:
+                    break
+                logger.info("MPR121 event=action_discarded tap_id=%s reason=stopping", tap_id)
+            logger.info("MPR121 event=worker_stopped worker=action")
+
+    def stop(self):
+        logger.info("MPR121 event=stop_requested")
+        self._stop.set()
+        for thread in (self._poll_thread, self._action_thread):
+            if thread is not None and thread.ident is not None:
+                thread.join(timeout=2)
+                if thread.is_alive():
+                    logger.warning("MPR121 worker %s still stopping", thread.name)
+        # The polling thread owns the bus after start, so never close its fd
+        # underneath an in-flight ioctl. Its finally block closes it on exit.

--- a/hal/server.py
+++ b/hal/server.py
@@ -297,6 +297,7 @@ if "display" in _declared:
 
 _gpio_button_handler = None
 _ttp223_handler = None
+_mpr121_handler = None
 
 # Set the moment lifespan shutdown begins — late async initializers (sensing-init)
 # check it so they don't start services nobody will stop.
@@ -363,7 +364,7 @@ def _sim_audio_probe(sd_module) -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global _gpio_button_handler, _ttp223_handler
+    global _gpio_button_handler, _ttp223_handler, _mpr121_handler
 
     # --- Phase 0: Borrow the hardware from whoever owns it ---
     # Empty unless ROBOT.md declares an `owner:`. Where one exists it holds
@@ -910,6 +911,22 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("GPIO button skipped — mock board has no hardware")
 
+    # MPR121 is opt-in per device/board; absent hardware leaves other inputs running.
+    if _mpr121_config is not None:
+        try:
+            from hal.drivers.mpr121 import MPR121Handler
+
+            _mpr121_handler = MPR121Handler(_mpr121_config)
+            _mpr121_handler.start()
+        except Exception as e:
+            logger.warning(
+                "MPR121 init failed on i2c-%d address 0x%02x: %s",
+                _mpr121_config.bus, _mpr121_config.address, e,
+            )
+            _mpr121_handler = None
+    else:
+        logger.info("MPR121 skipped — no enabled device wiring or simulated board")
+
     # TTP223 capacitive touchpad (OrangePi sun60 only — same gestures as
     # GPIO button, runs independently. Skips silently on other boards.)
     try:
@@ -1001,6 +1018,8 @@ async def lifespan(app: FastAPI):
 
     _lifespan_stopping.set()
     _thermal_stop.set()
+    if _mpr121_handler is not None:
+        _mpr121_handler.stop()
 
     # Voice/sensing stops (~3s) run concurrently with the announce+park below —
     # they only tear down mic/STT/perception threads, never the TTS output the
@@ -1286,6 +1305,12 @@ from hal.board.gpio_button import load_button_config
 
 _gpio_button_config = (
     None if _board_id == "sim" else load_button_config(_device_dir, _board_id)
+)
+
+from hal.board.mpr121 import load_mpr121_config
+
+_mpr121_config = (
+    None if _board_id == "sim" else load_mpr121_config(_device_dir, _board_id)
 )
 
 from hal.board.device import plan_mounts

--- a/hal/test/test_mpr121.py
+++ b/hal/test/test_mpr121.py
@@ -1,0 +1,189 @@
+"""MPR121 register setup, touch grouping, and worker lifecycle without hardware."""
+
+import threading
+import unittest
+from unittest import mock
+
+from hal.board.mpr121 import MPR121Config
+from hal.drivers.mpr121 import I2CBus, MPR121Handler, _TapDetector
+
+
+class TestTapDetector(unittest.TestCase):
+    def test_one_release_one_click_even_after_long_hold(self):
+        detector = _TapDetector(30)
+        samples = [(False, 0), (True, 1), (True, 1.04), (True, 20),
+                   (False, 21), (False, 21.04), (False, 22)]
+        self.assertEqual([detector.update(*sample) for sample in samples],
+                         [False, False, False, False, False, True, False])
+
+    def test_chatter_does_not_click_or_split_touch(self):
+        detector = _TapDetector(30)
+        samples = [(False, 0), (True, 1), (False, 1.01), (False, 1.1),
+                   (True, 2), (True, 2.04), (False, 3), (True, 3.01),
+                   (True, 3.1), (False, 4), (False, 4.04)]
+        self.assertEqual(sum(detector.update(*sample) for sample in samples), 1)
+
+    def test_boot_hold_is_suppressed_until_stable_release(self):
+        detector = _TapDetector(30)
+        samples = [(True, 0), (True, 10), (False, 11), (True, 11.01),
+                   (False, 12), (False, 12.04), (True, 13), (True, 13.04),
+                   (False, 14), (False, 14.04)]
+        results = [detector.update(*sample) for sample in samples]
+        self.assertEqual(results, [False] * 9 + [True])
+
+    def test_rapid_separate_taps_remain_single_clicks(self):
+        detector = _TapDetector(30)
+        samples = [(False, 0), (True, .1), (True, .14), (False, .2),
+                   (False, .24), (True, .3), (True, .34), (False, .4), (False, .44)]
+        self.assertEqual(sum(detector.update(*sample) for sample in samples), 2)
+
+
+class TestMPR121(unittest.TestCase):
+    def make_handler(self, **kwargs):
+        return MPR121Handler(MPR121Config(bus=5, **kwargs))
+
+    def test_register_initialization(self):
+        handler = self.make_handler()
+        handler._bus = bus = mock.Mock()
+        bus.read_regs.return_value = b'\x24'
+        handler._initialize()
+        calls = bus.write_reg.call_args_list
+        self.assertEqual(calls[:2], [mock.call(0x5A, 0x80, 0x63), mock.call(0x5A, 0x5E, 0)])
+        for electrode in range(12):
+            self.assertIn(mock.call(0x5A, 0x41 + electrode * 2, 2), calls)
+            self.assertIn(mock.call(0x5A, 0x42 + electrode * 2, 1), calls)
+        for register, value in ((0x5B, 0), (0x5C, 0x10), (0x5D, 0x20),
+                                (0x7D, 200), (0x7F, 180), (0x7E, 130), (0x7B, 0x0B)):
+            self.assertIn(mock.call(0x5A, register, value), calls)
+        self.assertEqual(calls[-1], mock.call(0x5A, 0x5E, 0x8F))
+
+    def test_autoconfig_disabled(self):
+        handler = self.make_handler(autoconfig=False)
+        handler._bus = mock.Mock()
+        handler._bus.read_regs.return_value = b'\x24'
+        handler._initialize()
+        self.assertFalse(any(call.args[1] == 0x7B for call in handler._bus.write_reg.call_args_list))
+
+    def test_selected_electrodes_overlap_form_one_touch(self):
+        handler = self.make_handler(electrodes=(0, 1))
+        handler._bus = mock.Mock()
+        # Electrode 2 is excluded. Overlapping 0 and 1 must not split the tap.
+        masks = [4, 1, 1, 3, 2, 2, 4, 4]
+        handler._bus.read_regs.side_effect = [mask.to_bytes(2, 'little') for mask in masks]
+        times = [0, 1, 1.04, 2, 3, 3.04, 4, 4.04]
+        self.assertEqual(sum(handler._detector.update(handler._read_touched(), now) for now in times), 1)
+
+    def test_electrode_logs_include_changes_without_repeating_samples(self):
+        handler = self.make_handler(electrodes=(0,))
+        handler._bus = mock.Mock()
+        handler._bus.read_regs.side_effect = [mask.to_bytes(2, 'little') for mask in (0, 1, 1, 3, 2)]
+        with self.assertLogs('hal.drivers.mpr121', level='INFO') as logs:
+            results = [handler._read_touched() for _ in range(5)]
+        self.assertEqual(results, [False, True, True, True, False])
+        self.assertEqual(len(logs.output), 4)
+        self.assertIn('raw_mask=0x003 selected_mask=0x001 selected_active=0x001 touched=[1] released=[]', logs.output[2])
+        self.assertIn('raw_mask=0x002 selected_mask=0x001 selected_active=0x000 touched=[] released=[0]', logs.output[3])
+
+    def test_overcurrent_is_fault_not_release(self):
+        handler = self.make_handler()
+        handler._bus = mock.Mock()
+        handler._bus.read_regs.return_value = b"\x00\x80"
+        with self.assertRaisesRegex(OSError, "over-current"):
+            handler._read_touched()
+
+    def test_init_failure_closes_bus(self):
+        handler = self.make_handler()
+        bus = mock.Mock()
+        bus.read_regs.return_value = b'\x00'
+        with mock.patch('hal.drivers.mpr121.I2CBus', return_value=bus) as factory:
+            with self.assertRaises(RuntimeError):
+                handler.start()
+        factory.assert_called_once_with(5)
+        bus.close.assert_called_once()
+        handler.stop()
+        bus.close.assert_called_once()
+
+    def test_initial_touch_read_failure_closes_bus(self):
+        handler = self.make_handler()
+        bus = mock.Mock()
+        bus.read_regs.side_effect = [b'\x24', OSError('touch read failed')]
+        with mock.patch('hal.drivers.mpr121.I2CBus', return_value=bus), mock.patch('hal.drivers.mpr121.time.sleep'):
+            with self.assertRaises(OSError):
+                handler.start()
+        bus.close.assert_called_once()
+
+    def test_poll_delivers_tap_to_shared_single_click(self):
+        handler = self.make_handler(poll_ms=1)
+        bus = mock.Mock()
+        statuses = iter([0, 1, 1, 0, 0])
+        times = iter([0, 1, 1.04, 2, 2.04])
+        bus.read_regs.side_effect = lambda address, register, length: (
+            b'\x24' if register == 0x5D else next(statuses, 0).to_bytes(2, 'little')
+        )
+        called = threading.Event()
+        with mock.patch('hal.drivers.mpr121.I2CBus', return_value=bus), \
+                mock.patch('hal.drivers.mpr121.time.sleep'), \
+                mock.patch('hal.drivers.mpr121.time.monotonic', side_effect=lambda: next(times, 3)), \
+                mock.patch('hal.drivers.mpr121.single_click_action', side_effect=lambda **kwargs: called.set()) as action, \
+                self.assertLogs('hal.drivers.mpr121', level='INFO') as logs:
+            handler.start()
+            try:
+                self.assertTrue(called.wait(1))
+            finally:
+                handler.stop()
+            action.assert_called_once_with(source='MPR121')
+        output = '\n'.join(logs.output)
+        for event in ('tap_accepted', 'action_queued', 'action_begin', 'action_complete'):
+            self.assertIn(f'event={event} tap_id=1', output)
+        self.assertIn('event=worker_stopped worker=action', output)
+
+    def test_poll_failure_closes_bus_and_stops_dispatch(self):
+        handler = self.make_handler(poll_ms=1)
+        bus = mock.Mock()
+        bus.read_regs.side_effect = [b'\x24', b'\x00\x00', OSError('disconnected')]
+        with mock.patch('hal.drivers.mpr121.I2CBus', return_value=bus):
+            handler.start()
+            self.assertTrue(handler._stop.wait(1))
+            handler.stop()
+        bus.close.assert_called_once()
+        self.assertFalse(handler._poll_thread.is_alive())
+        self.assertFalse(handler._action_thread.is_alive())
+
+    def test_stop_closes_bus_once(self):
+        handler = self.make_handler()
+        bus = mock.Mock()
+        bus.read_regs.side_effect = lambda address, register, length: b'\x24' if register == 0x5D else b'\x00\x00'
+        with mock.patch('hal.drivers.mpr121.I2CBus', return_value=bus):
+            handler.start()
+            handler.stop()
+            handler.stop()
+        bus.close.assert_called_once()
+
+    def test_action_dispatch_is_bounded_and_discards_pending_on_stop(self):
+        handler = self.make_handler()
+        entered = threading.Event()
+        release = threading.Event()
+
+        def action(**kwargs):
+            entered.set()
+            release.wait(1)
+
+        with mock.patch('hal.drivers.mpr121.single_click_action', side_effect=action) as callback:
+            handler._action_thread = threading.Thread(target=handler._dispatch)
+            handler._action_thread.start()
+            handler._pending.put_nowait(True)
+            self.assertTrue(entered.wait(1))
+            handler._pending.put_nowait(True)
+            self.assertTrue(handler._pending.full())
+            handler._stop.set()
+            release.set()
+            handler.stop()
+        callback.assert_called_once_with(source='MPR121')
+
+    def test_transport_close_is_idempotent(self):
+        bus = I2CBus.__new__(I2CBus)
+        bus.fd = 42
+        with mock.patch('hal.drivers.mpr121.os.close') as close:
+            bus.close()
+            bus.close()
+        close.assert_called_once_with(42)

--- a/hal/test/test_mpr121_config.py
+++ b/hal/test/test_mpr121_config.py
@@ -1,0 +1,58 @@
+"""MPR121 device declarations and legacy-input fallback without hardware."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from hal.board.mpr121 import MPR121Config, load_mpr121_config
+
+
+class TestMPR121Config(unittest.TestCase):
+    def test_only_lamp_declares_hardware(self):
+        root = Path(__file__).resolve().parents[2] / "robots"
+        config = load_mpr121_config(root / "lamp", "orangepi_sun60")
+        self.assertIsInstance(config, MPR121Config)
+        self.assertIsNone(load_mpr121_config(root / "intern-v2", "orangepi_sun60"))
+        self.assertIsNone(load_mpr121_config(root / "lamp", "raspberry_pi_5"))
+
+    def test_defaults_match_supplied_script(self):
+        config = MPR121Config(bus=5)
+        self.assertEqual(config.address, 0x5A)
+        self.assertEqual((config.touch_threshold, config.release_threshold), (2, 1))
+        self.assertEqual(config.electrodes, tuple(range(12)))
+
+    def test_device_selection_and_absence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertIsNone(load_mpr121_config(directory, "orangepi_sun60"))
+            path = Path(directory) / "mpr121.json"
+            path.write_text(json.dumps({"boards": {
+                "orangepi_sun60": {"bus": 5, "address": 91, "electrodes": [2, 4]},
+                "raspberry_pi_4": {"enabled": False},
+            }}))
+            self.assertEqual(load_mpr121_config(directory, "orangepi_sun60"),
+                             MPR121Config(bus=5, address=91, electrodes=(2, 4)))
+            self.assertIsNone(load_mpr121_config(directory, "raspberry_pi_4"))
+            self.assertIsNone(load_mpr121_config(directory, "sim"))
+
+    def test_invalid_values(self):
+        for overrides in (
+            {"bus": -1}, {"bus": True}, {"address": 0x40},
+            {"electrodes": []}, {"electrodes": [12]}, {"electrodes": [1, 1]},
+            {"electrodes": [True]}, {"touch_threshold": 256},
+            {"release_threshold": 2}, {"autoconfig": "true"},
+            {"poll_ms": 0}, {"debounce_ms": -1},
+        ):
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                MPR121Config(**({"bus": 5} | overrides))
+
+    def test_invalid_file_never_silently_falls_back(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mpr121.json"
+            for value in ("{", "null", '{"boards": []}',
+                          '{"boards": {"orangepi_sun60": {}}}',
+                          '{"boards": {"orangepi_sun60": {"bus": 5, "adress": 90}}}'):
+                with self.subTest(value=value):
+                    path.write_text(value)
+                    with self.assertRaisesRegex(ValueError, "mpr121.json"):
+                        load_mpr121_config(directory, "orangepi_sun60")

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -1,13 +1,14 @@
-# Physical Controls — GPIO Button + TTP223 Touchpad
+# Physical Controls — GPIO Button, TTP223 and MPR121
 
-Lamp has two physical input devices the user can touch directly. They share the same action library (`hal/drivers/button_actions.py`) so any gesture mapped to "single click" behaves identically whether it came from the mechanical button or the capacitive touchpad.
+Lamp supports a mechanical button, TTP223 touchpads and an optional MPR121 capacitive touch controller. They share the same action library (`hal/drivers/button_actions.py`) so any gesture mapped to "single click" behaves identically whether it came from the mechanical button or the capacitive touchpad.
 
-## Why two devices
+## Input devices
 
 | Device | Role | Where |
 |---|---|---|
 | **GPIO button** | One mechanical button. Used for decisive actions including destructive ones (reboot / shutdown / factory-reset). The mechanical feel and long-hold detection make accidental destructive actions unlikely. | Both Pi 4/5 and OrangePi sun60 |
 | **TTP223 capacitive touchpad** | Two touch pads arranged as a "dog head" surface for petting + soft stop/unmute. No destructive gestures because the IC's FastMode prevents reliable hold detection. | OrangePi sun60 only (4 Pro / A733) |
+| **MPR121 capacitive touch controller** | Up to 12 electrodes; one touch-and-release session calls the shared single-click action. No double-tap or destructive hold mapping. | Lamp with an explicit I²C configuration in `mpr121.json` |
 
 ## Wiring
 
@@ -126,7 +127,7 @@ Degradation is by omission in both directions. On a device with **no camera** ne
 **Relocating, not merely writing.** Two states write the servos continuously without moving the head anywhere: the idle loop breathing, and a tracking session pursuing the user's face. Treating either as a move means `last_servo_write` is never stale and nearly every frame is refused — measured, idle: 0.3 samples/s recorded against 4.9/s blocked; measured, tracking: 0.7/s against 4.5/s, refusing a user at yaw 0.9° with a 130 px face dead centre for having one sample in the window instead of two. Tracking matters most: it is the lamp following this user's face, so refusing to notice they are addressing it precisely then is the most broken-looking moment available — which is why the settling test must not become `_tracking_active` by the back door. Both are small continuous corrections and the yaw survives them. The `[gaze] sampling at N/s; blocked: …` line breaks the blocked count down by reason, because the two gates are fixed in different places.
 
 End-to-end chain:
-1. `gpio_button.py` / `ttp223.py` detect single click → call `single_click_action(source)` in `button_actions.py`
+1. `gpio_button.py` / `ttp223.py` / `mpr121.py` detect single click → call `single_click_action(source)` in `button_actions.py`
 2. `single_click_action` → `_cancel_agent_speech()` (fire-and-forget thread) + active `tracker_service.stop()` + `stop_tts()` (routes/voice.py) + `audio_stop()` (routes/music.py) + deferred `_announce_listening()` thread
 2a. `_cancel_agent_speech()` → `POST /api/agent/speech/cancel` on the OS server. Needed because `stop_tts()` only silences what HAL already holds: the sentence playing plus the pre-synthesised queue. The OS server streams a reply sentence by sentence, so without this call the device goes quiet for one sentence and then talks on. The OS server mutes every turn in flight (see `docs/os-server.md`) while letting turns started after the click speak — so the user can tap and immediately say something new even with a backlog of older turns still draining. The turns are not aborted, only unspoken — which is why the same call also drops those turns' pending dead-air fillers: they speak straight to HAL rather than through the muted reply path, so a still-running cancelled turn kept announcing "one moment" for an answer it would never give. Dispatched on its own thread and fired on both branches (mic-unmute and stop-speaker), since either way the tap means the user is taking the floor.
 2b. `state.note_music_cancel()` → stamps a HAL-side music cancel watermark, and `audio_stop()` runs on **both** branches (mic-unmute and stop-speaker), not just the stop-speaker one. Needed because the OS server's cancel is TTS-only: the cancelled turn keeps running and its pending music tool call still reaches `POST /audio/play` a moment later, where a fresh `music-play` thread clears its own `_stop_event` — so a point-in-time stop always loses that race and the user hears music they just cancelled once `yt-dlp` finishes resolving (1–5 s). While the watermark is fresh (`app_state.MUSIC_CANCEL_GUARD_S`, 3 s) `/audio/play` answers `{"status": "suppressed"}` instead of playing. The window is sized to cover the in-flight tool call but stay under the floor of a genuinely new request (speak → STT → LLM → tool is never under ~3 s), so "tap, then ask for a song" still works.
@@ -176,6 +177,78 @@ Purple identifies the sleep tier; red blink vs red solid differentiates shutdown
 The three colors are presets, not constants baked into the driver: `BUTTON_LED_PRESETS` in `hal/presets.py` (`sleep_warn` / `shutdown_warn` / `factory_reset`), overridable per device through the `button_led` section of `robots/<id>/presets.json` like every other LED table. The driver owns the staging — when to blink, when to go solid — and reads the color at the moment it paints, because the overlay merges the table in place at boot.
 
 Per-edge debounce is 200 ms (press and release ticks tracked independently so a quick tap isn't dropped while bouncy repeats of the same edge are filtered).
+
+## MPR121 detection (`hal/drivers/mpr121.py`)
+
+MPR121 wiring follows the device-owned GPIO configuration flow: HAL reads
+`mpr121.json` in the directory selected by `DEVICES_DIR` and `DEVICE_TYPE`
+(currently `robots/lamp/`), then selects the detected board from its `boards`
+map. Only Lamp currently has this hardware; Intern v2 has no MPR121
+declaration. Configure the verified I²C bus explicitly; the
+driver does not scan buses or guess wiring. Lamp ships the configuration below
+for `orangepi_sun60`: bus **0**, address **0x5A**. Initialization and polling
+were verified on Lamp `lamp-0c4e` on 2026-09-11, including startup in the live
+HAL service. Three touch-and-release sessions also produced distinct tap IDs
+and completed the real single-click action in that service. The hardware
+script specifies header pins 3/5 (TWI0). Verify
+the wiring and enable its correct I²C controller externally before use; HAL
+does not modify boot overlays automatically:
+
+```json
+{
+  "boards": {
+    "orangepi_sun60": {
+      "enabled": true,
+      "bus": 0,
+      "address": 90,
+      "electrodes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      "touch_threshold": 2,
+      "release_threshold": 1,
+      "autoconfig": true,
+      "poll_ms": 10,
+      "debounce_ms": 30
+    }
+  }
+}
+```
+
+`bus` is required for an enabled entry. The other values above are defaults;
+address 90 means `0x5A` (allowed addresses: 90–93). Selected electrodes must be
+unique numbers from 0–11, with at least one selected. Thresholds must satisfy
+`0 <= release_threshold < touch_threshold <= 255`. Polling accepts 1–1000 ms;
+debounce accepts 0–1000 ms. Tune thresholds against the installed electrodes
+and motor noise. Configuration is loaded at boot; restart HAL after changes.
+
+A missing file or board entry, or `"enabled": false`, skips MPR121 and retains
+the existing GPIO/TTP223 handlers. There is no legacy MPR121 bus fallback.
+Malformed enabled configuration rejects startup; simulation skips the hardware.
+If `/dev/i2c-0` is missing, initialization logs the failure and MPR121 remains
+unavailable while GPIO/TTP223 continue. Change `bus` if verified wiring uses
+a different controller, then restart HAL.
+
+After initialization, the driver allows 100 ms for sensing to settle before
+reading the initial touch state. It then polls touch status every 10 ms by default. A stable touch followed
+by a stable release of **all selected electrodes** produces one
+`single_click_action(source="MPR121")`; both transitions use the 30 ms default
+debounce. Overlapping touches across electrodes form one session. An electrode
+held at startup is ignored until release. Holding longer does not trigger
+sleep, reboot, shutdown or reset, and there is no double-tap action. The shared
+single-click behavior described above applies after release, without a
+multi-click decision window. A bounded asynchronous action worker prevents
+polling from blocking; excess taps while busy may be coalesced or dropped
+instead of accumulating a backlog. An I²C failure or MPR121 overcurrent fault
+(`OVCF`) is logged and stops this driver while the existing input handlers
+continue.
+
+Operation logs use logger `hal.drivers.mpr121` in the normal HAL log/journal;
+there is no separate raw trace file. INFO entries cover initialization and
+configuration (bus, address, electrodes, thresholds and timing), per-electrode
+raw touch/release changes, debounced transitions, suppressed startup touches,
+tap queueing/coalescing, action begin/end and lifecycle. `tap_id` correlates
+accepted taps with queued, coalesced or executed actions. Failures include
+error logs. Unchanged 10 ms polls produce no INFO entry, so idle operation does not
+flood the log. Follow the service log with `journalctl -u hal.service -f` and
+filter for `hal.drivers.mpr121` when investigating a missed or duplicate tap.
 
 ## TTP223 detection (`hal/drivers/ttp223.py`)
 
@@ -261,7 +334,7 @@ It never logs to journald, deliberately: HAL is chatty enough that the `hal.serv
 
 ## Shared action library (`hal/drivers/button_actions.py`)
 
-The actions live in one place so the GPIO button, TTP223, and any future input (touchpad, remote) get identical behavior:
+The actions live in one place so the GPIO button, TTP223, MPR121, and any future input (touchpad, remote) get identical behavior:
 
 | Function | What it does | Interrupts in-flight TTS? |
 |---|---|---|
@@ -352,9 +425,11 @@ Phrases are intentionally short — they fire mid-stroke and need to feel respon
 |---|---|
 | `hal/drivers/gpio_button.py` | GPIO button handler (mechanical, both boards) |
 | `hal/drivers/ttp223.py` | TTP223 capacitive touchpad handler (OrangePi sun60 only) |
+| `hal/board/mpr121.py` | Device-owned MPR121 configuration loader and validation |
+| `hal/drivers/mpr121.py` | Optional I²C MPR121 touch-and-release handler |
 | `hal/drivers/button_actions.py` | Shared action functions + localized phrase pools |
 | `hal/presets.py` | Language code constants (`LANG_EN`, etc.) |
 | `hal/test_ttp223_probe_orangepi.py` | Standalone pad probe (stdlib ioctl, no gpiod). `info` reads line state with HAL running; `watch` maps pad→line and needs `hal.service` stopped. Lines come from the board profile. |
 | `hal/test_gpio.py` | Standalone probe for verifying GPIO button line |
 
-Both handlers are spawned in `hal/server.py` lifespan startup — failures are logged but never crash the runtime (a board without the hardware just skips silently).
+Input handlers are started in `hal/server.py` lifespan startup. Missing optional MPR121 configuration skips that driver; malformed enabled configuration rejects startup. Hardware driver failures are logged without stopping the other handlers.

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -1,13 +1,14 @@
-# Điều khiển vật lý — Nút GPIO + Touchpad TTP223
+# Điều khiển vật lý — Nút GPIO, TTP223 và MPR121
 
-Lamp có hai thiết bị input vật lý mà user có thể chạm trực tiếp. Chúng dùng chung thư viện action (`hal/drivers/button_actions.py`) nên cùng một cử chỉ "single click" sẽ hành xử giống nhau dù đến từ nút bấm cơ học hay touchpad cảm ứng.
+Lamp hỗ trợ nút cơ học, touchpad TTP223 và bộ điều khiển cảm ứng điện dung MPR121 tùy chọn. Chúng dùng chung thư viện action (`hal/drivers/button_actions.py`) nên cùng một cử chỉ "single click" sẽ hành xử giống nhau dù đến từ nút bấm cơ học hay touchpad cảm ứng.
 
-## Tại sao có hai thiết bị
+## Thiết bị đầu vào
 
 | Thiết bị | Vai trò | Có ở |
 |---|---|---|
 | **Nút GPIO** | Một nút bấm cơ. Dùng cho các hành động dứt khoát kể cả destructive (reboot / shutdown / factory-reset). Cảm giác cơ + detect giữ lâu khiến destructive action khó xảy ra do vô tình. | Pi 4/5 và OrangePi sun60 |
 | **Touchpad cảm ứng TTP223** | Hai pad chạm xếp như "đầu cún" để vuốt ve + stop/unmute nhẹ. Không có destructive gesture vì FastMode của IC không cho detect giữ lâu tin cậy. | Chỉ OrangePi sun60 (4 Pro / A733) |
+| **Bộ điều khiển cảm ứng MPR121** | Tối đa 12 electrode; một phiên chạm rồi nhả gọi action single-click dùng chung. Không map double-tap hay giữ để thực hiện hành động destructive. | Lamp khai báo cấu hình I²C cụ thể trong `mpr121.json` |
 
 ## Wiring
 
@@ -126,7 +127,7 @@ Suy biến sạch theo cả hai chiều. Máy **không có camera** thì gaze l�
 **Đổi chỗ, chứ không phải chỉ đang ghi servo.** Có hai trạng thái ghi servo liên tục mà không đưa đầu đi đâu cả: vòng idle đang thở, và một phiên tracking đang bám mặt user. Coi hai thứ đó là "đang di chuyển" thì `last_servo_write` không bao giờ cũ và gần như mọi frame đều bị từ chối — đo thật, idle: ghi được 0.3 mẫu/s trên 4.9/s bị chặn; đo thật, tracking: 0.7/s trên 4.5/s, từ chối một user ở yaw 0.9° với mặt 130px ngay giữa khung chỉ vì cửa sổ có 1 mẫu thay vì 2. Tracking là trường hợp quan trọng nhất: đó chính là lúc đèn đang bám theo mặt user, nên từ chối nhận ra người ta đang nói với nó đúng lúc đó là khoảnh khắc trông hỏng nhất có thể — vì vậy test settle không được phép biến thành `_tracking_active` qua cửa sau. Cả hai đều là chỉnh nhỏ liên tục, góc yaw sống sót qua chúng. Dòng `[gaze] sampling at N/s; blocked: …` tách số frame bị chặn theo từng lý do, vì hai cổng đó sửa ở hai chỗ khác nhau.
 
 Chuỗi end-to-end:
-1. `gpio_button.py` / `ttp223.py` detect single click → gọi `single_click_action(source)` trong `button_actions.py`
+1. `gpio_button.py` / `ttp223.py` / `mpr121.py` detect single click → gọi `single_click_action(source)` trong `button_actions.py`
 2. `single_click_action` → `_cancel_agent_speech()` (thread fire-and-forget) + `tracker_service.stop()` nếu đang tracking + `stop_tts()` (routes/voice.py) + `audio_stop()` (routes/music.py) + thread deferred `_announce_listening()`
 2a. `_cancel_agent_speech()` → `POST /api/agent/speech/cancel` lên OS server. Cần vì `stop_tts()` chỉ bịt được thứ HAL đang giữ: câu đang phát cộng hàng đợi đã pre-synth. OS server đẩy câu trả lời theo từng câu, nên không có call này thì thiết bị im đúng một câu rồi nói tiếp. OS server bịt miệng mọi turn đang chạy (xem `docs/os-server.md`) nhưng vẫn cho turn bắt đầu sau cú click nói — nên user chạm xong nói câu mới được ngay kể cả khi còn backlog turn cũ đang chạy nốt. Turn không bị abort, chỉ là không được nói — cũng vì thế mà call này bỏ luôn filler dead-air còn treo của những turn đó: filler nói thẳng xuống HAL chứ không đi qua đường reply bị bịt, nên một turn đã huỷ mà vẫn chạy cứ tiếp tục rao "một giây nhé" cho câu trả lời nó sẽ không bao giờ nói. Chạy trên thread riêng và fire ở cả hai nhánh (unmute mic và stop loa), vì kiểu gì cú chạm cũng có nghĩa là user đang giành lượt nói.
 2b. `state.note_music_cancel()` → đóng dấu watermark huỷ nhạc ở phía HAL, và `audio_stop()` chạy ở **cả hai** nhánh (unmute mic và stop loa), không chỉ nhánh stop loa. Cần vì cancel ở OS server chỉ tác động lên TTS: turn bị huỷ vẫn chạy tiếp và tool call nhạc còn treo của nó vẫn tới `POST /audio/play` ngay sau đó, nơi một thread `music-play` mới tự `_stop_event.clear()` — nên một cú stop tại một thời điểm luôn thua cuộc đua này, và user nghe đúng bài nhạc mình vừa huỷ sau khi `yt-dlp` resolve xong (1–5 s). Trong lúc watermark còn tươi (`app_state.MUSIC_CANCEL_GUARD_S`, 3 s), `/audio/play` trả `{"status": "suppressed"}` thay vì phát. Cửa sổ được chọn đủ phủ tool call đang bay nhưng vẫn dưới sàn của một yêu cầu mới thật sự (nói → STT → LLM → tool không bao giờ dưới ~3 s), nên "chạm xong xin bài hát" vẫn chạy bình thường.
@@ -176,6 +177,75 @@ Màu tím nhận diện mức sleep; đỏ nháy vs đỏ đứng phân biệt s
 Ba màu này là preset chứ không phải hằng nhúng cứng trong driver: `BUTTON_LED_PRESETS` trong `hal/presets.py` (`sleep_warn` / `shutdown_warn` / `factory_reset`), device override được qua section `button_led` của `robots/<id>/presets.json` giống mọi bảng LED khác. Driver giữ phần staging — lúc nào nháy, lúc nào để đứng — và đọc màu ngay lúc paint, vì overlay merge bảng tại chỗ lúc boot.
 
 Debounce mỗi edge là 200 ms (tick nhấn và nhả track độc lập để tap nhanh không bị drop trong khi bounce lặp của cùng một edge bị lọc).
+
+## Detect MPR121 (`hal/drivers/mpr121.py`)
+
+Wiring MPR121 theo flow cấu hình GPIO do từng device quản lý: HAL đọc
+`mpr121.json` trong thư mục được chọn qua `DEVICES_DIR` và `DEVICE_TYPE`
+(hiện là `robots/lamp/`), rồi chọn board đã detect từ map `boards`. Hiện chỉ
+Lamp có phần cứng này; Intern v2 không có khai báo MPR121. Phải khai báo
+bus I²C đã xác minh; driver không quét bus hay đoán wiring. Cấu hình Lamp
+`orangepi_sun60` dùng bus **0**, địa chỉ **0x5A**. Đã xác minh khởi tạo và
+polling trên Lamp `lamp-0c4e` ngày 2026-09-11, gồm khởi động trong HAL thật.
+Ba phiên chạm rồi nhả cũng tạo tap ID riêng và hoàn tất action single-click
+thật trong service đó. Script phần cứng chỉ định chân header 3/5 (TWI0).
+Kiểm tra wiring và bật đúng controller I²C bên ngoài HAL
+trước khi dùng; HAL không tự sửa boot overlay:
+
+```json
+{
+  "boards": {
+    "orangepi_sun60": {
+      "enabled": true,
+      "bus": 0,
+      "address": 90,
+      "electrodes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      "touch_threshold": 2,
+      "release_threshold": 1,
+      "autoconfig": true,
+      "poll_ms": 10,
+      "debounce_ms": 30
+    }
+  }
+}
+```
+
+`bus` bắt buộc với entry bật. Các giá trị còn lại ở trên là mặc định;
+địa chỉ 90 nghĩa là `0x5A` (cho phép 90–93). Electrode được chọn phải là
+các số không trùng từ 0–11, có ít nhất một electrode. Ngưỡng phải thỏa
+`0 <= release_threshold < touch_threshold <= 255`. Polling cho phép 1–1000 ms;
+debounce cho phép 0–1000 ms. Cần chỉnh ngưỡng theo electrode đã lắp và nhiễu
+motor. Cấu hình được đọc lúc khởi động; sửa xong phải restart HAL.
+
+Thiếu file, thiếu entry board, hoặc `"enabled": false` thì bỏ qua MPR121 và
+giữ các handler GPIO/TTP223 hiện có. Không có bus MPR121 cũ để fallback.
+Cấu hình bật nhưng sai bị từ chối khi startup; chế độ mô phỏng bỏ qua phần cứng.
+Nếu thiếu `/dev/i2c-0`, khởi tạo log lỗi và MPR121 không hoạt động, còn
+GPIO/TTP223 tiếp tục chạy. Sửa `bus` nếu wiring đã xác minh dùng controller
+khác, rồi restart HAL.
+
+Sau khởi tạo, driver chờ 100 ms cho cảm biến ổn định trước khi đọc trạng thái
+chạm ban đầu. Sau đó driver đọc touch status mỗi 10 ms theo mặc định. Chạm ổn định rồi nhả ổn định
+**toàn bộ electrode được chọn** tạo một lần
+`single_click_action(source="MPR121")`; cả hai chuyển trạng thái dùng debounce
+mặc định 30 ms. Các lần chạm chồng nhau trên nhiều electrode tính là một
+phiên. Electrode đang bị giữ khi startup bị bỏ qua đến khi nhả. Giữ lâu không
+kích hoạt sleep, reboot, shutdown hay reset, và không có action double-tap.
+Hành vi single-click dùng chung mô tả ở trên chạy sau khi nhả, không chờ cửa
+sổ phân loại nhiều lần click. Worker action bất đồng bộ có giới hạn giúp
+polling không bị chặn; tap dư khi worker bận có thể được gộp hoặc bỏ để tránh
+tích tụ hàng đợi. Lỗi I²C hoặc cờ quá dòng MPR121 (`OVCF`) được log và dừng
+driver này, các handler đầu vào hiện có tiếp tục chạy.
+
+Log hoạt động dùng logger `hal.drivers.mpr121` trong log/journal HAL thông
+thường; không tạo file raw trace riêng. Log INFO gồm khởi tạo và cấu hình
+(bus, địa chỉ, electrode, ngưỡng và thời gian), thay đổi chạm/nhả thô trên từng
+electrode, chuyển trạng thái đã debounce, chạm lúc startup bị bỏ qua, xếp hàng
+hoặc gộp tap, bắt đầu/kết thúc action và vòng đời driver. `tap_id` liên kết
+tap được nhận với action đã xếp hàng, gộp hoặc thực thi. Khi lỗi có log lỗi.
+Các lần poll 10 ms không đổi trạng thái không tạo log INFO, tránh tràn log
+khi không chạm. Theo dõi bằng `journalctl -u hal.service -f` và lọc
+`hal.drivers.mpr121` khi cần tìm nguyên nhân mất hoặc lặp tap.
 
 ## Detect TTP223 (`hal/drivers/ttp223.py`)
 
@@ -261,7 +331,7 @@ Nó cố ý không bao giờ log vào journald: HAL log nhiều đến mức c�
 
 ## Thư viện action chung (`hal/drivers/button_actions.py`)
 
-Các action sống ở một chỗ để nút GPIO, TTP223, và mọi input tương lai (touchpad, remote) hành xử giống nhau:
+Các action sống ở một chỗ để nút GPIO, TTP223, MPR121, và mọi input tương lai (touchpad, remote) hành xử giống nhau:
 
 | Hàm | Làm gì | Cắt TTS đang phát? |
 |---|---|---|
@@ -351,9 +421,11 @@ Phrase cố tình ngắn — chúng fire giữa lúc vuốt nên cần cảm gi�
 |---|---|
 | `hal/drivers/gpio_button.py` | Handler nút GPIO (cơ học, cả hai board) |
 | `hal/drivers/ttp223.py` | Handler touchpad cảm ứng TTP223 (chỉ OrangePi sun60) |
+| `hal/board/mpr121.py` | Đọc và kiểm tra cấu hình MPR121 do device quản lý |
+| `hal/drivers/mpr121.py` | Handler I²C MPR121 tùy chọn, detect chạm rồi nhả |
 | `hal/drivers/button_actions.py` | Hàm action chung + pool phrase local |
 | `hal/presets.py` | Hằng số mã ngôn ngữ (`LANG_EN`, v.v.) |
 | `hal/test_ttp223_probe_orangepi.py` | Probe pad độc lập (ioctl thuần stdlib, không cần gpiod). `info` đọc trạng thái line khi HAL vẫn chạy; `watch` map pad→line và cần dừng `hal.service`. Line lấy từ board profile. |
 | `hal/test_gpio.py` | Probe độc lập để verify line nút GPIO |
 
-Cả hai handler được spawn trong startup lifespan `hal/server.py` — fail thì log nhưng không crash runtime (board không có phần cứng tự skip im lặng).
+Các handler đầu vào được khởi động trong startup lifespan `hal/server.py`. Thiếu cấu hình MPR121 tùy chọn thì bỏ qua driver đó; cấu hình bật nhưng sai bị từ chối khi startup. Lỗi driver phần cứng được log mà không dừng các handler còn lại.

--- a/robots/lamp/mpr121.json
+++ b/robots/lamp/mpr121.json
@@ -1,0 +1,28 @@
+{
+  "boards": {
+    "orangepi_sun60": {
+      "enabled": true,
+      "bus": 0,
+      "address": 90,
+      "electrodes": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "touch_threshold": 2,
+      "release_threshold": 1,
+      "autoconfig": true,
+      "poll_ms": 10,
+      "debounce_ms": 30
+    }
+  }
+}


### PR DESCRIPTION
Add MPR121 capacitive touch support for Lamp: one debounced touch-and-release session calls the existing `single_click_action(source="MPR121")`. Overlapping electrodes count as one session, startup-held touches are suppressed, and no destructive hold or double-tap gestures are introduced.

Lamp owns its wiring in `robots/lamp/mpr121.json` (OrangePi I2C bus 0, address 0x5A). Missing or disabled declarations preserve the existing GPIO/TTP223 inputs; Intern v2 has no MPR121 declaration. The driver uses stdlib Linux I2C, a bounded action worker, fault cleanup, and detailed electrode/tap/action lifecycle logs with `tap_id`. English and Vietnamese docs cover configuration, behavior, and verification.

Validation:
- `uv run --no-project --with pytest --with requests --with fastapi --with numpy python -m pytest hal/test/test_board.py hal/test/test_gpio_button_config.py hal/test/test_mpr121_config.py hal/test/test_mpr121.py hal/test/test_button_actions.py -q` — 56 passed, 30 subtests passed.
- `uv run --no-project --with pyflakes python hal/scripts/lint.py` — passed.
- `git diff --check` — passed.
- On Lamp `lamp-0c4e`: 16 driver unit tests passed; hardware initialization and polling passed on I2C-0 / 0x5A. Integrated into the running HAL service and observed three separate tap IDs complete the real single-click action; user confirmed the test worked.

I2C must already be enabled on the device. HAL does not modify boot overlays automatically. Excess taps while the action worker is busy may be coalesced to avoid a backlog.
