### PR TITLE
hal: configure Lamp button and TTP223 wiring per device

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -66,6 +66,18 @@ HAL; moving physical wires is not detected automatically. Malformed
 configuration is rejected before GPIO is claimed. Simulation skips the
 hardware button.
 
+TTP223 touch wiring is device-owned in `robots/lamp/ttp223.json`. Intern v2
+has no TTP223 hardware and does not ship this file. `hal/board/ttp223.py` resolves the detected
+board's `chip`, `lines` and optional `axis` from `boards` and passes a
+`TouchConfig` to the shared driver. Missing file/board falls back to legacy
+`touch` in `hal/board/boards.json`; `enabled: false` disables TTP223 explicitly.
+Malformed configuration is rejected before GPIO is claimed. Restart HAL after
+editing the selected device's configuration; simulation skips hardware input.
+Lamp's new button pin (gpiochip0 line 100, physical pin 37 / PD4) overlaps the
+legacy touch mapping; its replacement touch pin still needs confirmation.
+Intern v2 retains its existing button wiring. The legacy board fallback remains
+unchanged; absence of a JSON file alone does not disable the driver.
+
 Optional MPR121 touch wiring currently belongs to Lamp only, in
 `robots/lamp/mpr121.json`; Intern v2 has no MPR121 declaration. It follows the
 same device-directory selection, validated by `hal/board/mpr121.py`. Lamp

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -64,6 +64,17 @@ thiếu file hoặc entry của board thì dùng lại mặc định `button` tr
 ứng và khởi động lại HAL; hệ thống không tự phát hiện việc đổi dây cắm.
 Config sai bị từ chối trước khi claim GPIO. Chế độ mô phỏng bỏ qua nút phần cứng.
 
+Wiring TTP223 do device quản lý trong `robots/lamp/ttp223.json`. Intern v2
+không có phần cứng TTP223 nên không kèm file này. `hal/board/ttp223.py` chọn `chip`, `lines` và
+`axis` tùy chọn của board đã detect từ `boards`, truyền `TouchConfig` cho driver
+dùng chung. Thiếu file/board thì fallback về `touch` cũ trong
+`hal/board/boards.json`; `enabled: false` tắt TTP223 rõ ràng. Config sai bị từ
+chối trước khi claim GPIO. Restart HAL sau khi sửa config của device được
+chọn; mô phỏng bỏ qua input phần cứng. Nút mới của Lamp (gpiochip0 line 100,
+pin vật lý 37 / PD4) trùng mapping touch cũ; chân touch thay thế vẫn cần xác
+nhận. Intern v2 giữ wiring nút hiện có. Fallback board cũ vẫn giữ nguyên;
+chỉ thiếu file JSON không có nghĩa là driver bị tắt.
+
 Wiring cảm ứng MPR121 tùy chọn hiện chỉ thuộc Lamp, trong
 `robots/lamp/mpr121.json`; Intern v2 không có khai báo MPR121. Cấu hình dùng
 cùng cách chọn thư mục device và được `hal/board/mpr121.py` kiểm tra. Lamp

--- a/hal/board/ttp223.py
+++ b/hal/board/ttp223.py
@@ -1,0 +1,50 @@
+"""Load device-owned TTP223 wiring with legacy board defaults."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from hal.board.board import PROFILES, TouchConfig
+
+
+def _lines(value, name):
+    if (not isinstance(value, list) or not value or len(value) > 64
+            or any(type(line) is not int or line < 0 for line in value)
+            or len(set(value)) != len(value)):
+        raise ValueError(f"{name} must contain 1..64 unique non-negative GPIO line numbers")
+    return value
+
+
+def load_touch_config(device_dir: str, board_id: str) -> Optional[TouchConfig]:
+    """Absent file/board uses boards.json; enabled:false explicitly disables touch."""
+    fallback = PROFILES[board_id].touch
+    path = Path(device_dir) / "ttp223.json"
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        return fallback
+    try:
+        data = json.loads(text)
+        if not isinstance(data, dict) or set(data) != {"boards"} or not isinstance(data["boards"], dict):
+            raise ValueError("expected an object containing a 'boards' map")
+        configs = {}
+        for board, entry in data["boards"].items():
+            if not isinstance(entry, dict) or set(entry) - {"enabled", "chip", "lines", "axis"}:
+                raise ValueError(f"{board}: invalid TTP223 fields")
+            enabled = entry.get("enabled", True)
+            if type(enabled) is not bool:
+                raise ValueError(f"{board}: enabled must be a boolean")
+            if not enabled:
+                configs[board] = None
+                continue
+            chip = entry.get("chip")
+            if type(chip) is not int or chip < 0:
+                raise ValueError(f"{board}: chip must be a non-negative integer")
+            lines = _lines(entry.get("lines"), "lines")
+            axis = entry.get("axis")
+            if axis is not None and set(_lines(axis, "axis")) != set(lines):
+                raise ValueError(f"{board}: axis must be a permutation of lines")
+            configs[board] = TouchConfig(chip=chip, lines=lines, axis=axis)
+        return configs.get(board_id, fallback)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid TTP223 wiring at {path}: {exc}") from exc

--- a/hal/drivers/ttp223.py
+++ b/hal/drivers/ttp223.py
@@ -1,9 +1,8 @@
 """TTP223 capacitive touchpad handler (dog-head touch surface).
 
-How many pads and which lines is board data, not a constant here — see the
-`touch` entry in hal/board/boards.json. It has changed twice (the pads were
-relocated to escape LED/servo/audio coupling), so any count written into this
-docstring goes stale; ask the board profile.
+Pad wiring is supplied by the device configuration loader from ttp223.json,
+with legacy board defaults when absent. The driver owns gesture detection;
+device declarations own chip, lines and optional spatial order.
 
 Destructive gestures (reboot / shutdown) are intentionally OFF on TTP223
 because the IC on this board runs in FastMode: output drops LOW within
@@ -59,7 +58,7 @@ import threading
 import time
 
 import hal.app_state as state
-from hal.board.board import board_profile
+from hal.board.board import TouchConfig
 from hal.drivers import touch_debug
 from hal.drivers.button_actions import (
     head_pat_action,
@@ -71,8 +70,7 @@ from hal.drivers.button_actions import (
 
 logger = logging.getLogger(__name__)
 
-# TTP223 pad wiring (chip / lines) lives in the board platform layer —
-# hal/board/board.py (BoardProfile.touch).
+# TTP223 wiring is injected from hal/board/ttp223.py at startup.
 
 # Session gap: edges within this window of the previous edge belong to
 # the same session. 200ms comfortably exceeds the observed burst length
@@ -191,18 +189,9 @@ SWIPE_MAX_GAP_MS = float(os.environ.get("HAL_TOUCH_SWIPE_MAX_GAP_MS", "150"))
 PRESS_MIN_EMPTY_MS = float(os.environ.get("HAL_TOUCH_PRESS_MIN_EMPTY_MS", "15"))
 
 
-def _board_label() -> str:
-    return board_profile().id
-
-
-def _resolve_board_config():
-    """Return (chip, lines, axis) or None if TTP223 isn't wired on this board."""
-    touch = board_profile().touch
-    return (touch.chip, touch.lines, touch.axis) if touch else None
-
-
 class TTP223Handler:
-    def __init__(self):
+    def __init__(self, config: TouchConfig | None):
+        self._config = config
         self._lgpio = None
         self._handle = None
         self._callbacks = []
@@ -246,17 +235,16 @@ class TTP223Handler:
         self._ignore_edges_until = 0.0
 
     def start(self):
-        config = _resolve_board_config()
+        config = self._config
         if config is None:
-            logger.info(
-                "TTP223 disabled: board is %s (only wired on orangepi-sun60)",
-                _board_label(),
-            )
+            logger.info("TTP223 disabled: no active device/board touch wiring")
             return
 
         import lgpio
 
-        self._chip, self._lines, self._axis = config
+        self._chip = config.chip
+        self._lines = list(config.lines)
+        self._axis = list(config.axis) if config.axis is not None else None
         self._lgpio = lgpio
 
         # Arm the settle window now, before claiming: the callback registration

--- a/hal/server.py
+++ b/hal/server.py
@@ -932,7 +932,7 @@ async def lifespan(app: FastAPI):
     try:
         from hal.drivers.ttp223 import TTP223Handler
 
-        _ttp223_handler = TTP223Handler()
+        _ttp223_handler = TTP223Handler(_ttp223_config)
         _ttp223_handler.start()
     except Exception as e:
         logger.warning(f"TTP223 init failed: {e}")
@@ -1311,6 +1311,12 @@ from hal.board.mpr121 import load_mpr121_config
 
 _mpr121_config = (
     None if _board_id == "sim" else load_mpr121_config(_device_dir, _board_id)
+)
+
+from hal.board.ttp223 import load_touch_config
+
+_ttp223_config = (
+    None if _board_id == "sim" else load_touch_config(_device_dir, _board_id)
 )
 
 from hal.board.device import plan_mounts

--- a/hal/test/test_gpio_button_config.py
+++ b/hal/test/test_gpio_button_config.py
@@ -24,13 +24,14 @@ class TestButtonConfig(unittest.TestCase):
         )
         self.assertEqual(handler._debounce_ns, 10_000_000)
 
-    def test_shipped_devices_preserve_wiring(self):
+    def test_shipped_devices_select_their_wiring(self):
         root = Path(__file__).resolve().parents[2] / "robots"
         for device in ("lamp", "intern-v2"):
             for board, chip, line in (
                 ("raspberry_pi_4", 0, 17),
                 ("raspberry_pi_5", 0, 17),
-                ("orangepi_sun60", 1, 9),
+                ("orangepi_sun60", 0 if device == "lamp" else 1,
+                 100 if device == "lamp" else 9),
             ):
                 with self.subTest(device=device, board=board):
                     self.assertEqual(

--- a/hal/test/test_ttp223.py
+++ b/hal/test/test_ttp223.py
@@ -42,7 +42,7 @@ class _Harness:
 
     def __init__(self, mod, lines=(96, 100), axis=None):
         self.mod = mod
-        self.h = mod.TTP223Handler()
+        self.h = mod.TTP223Handler(mod.TouchConfig(chip=0, lines=list(lines), axis=axis))
         self.h._chip, self.h._lines, self.h._axis = 0, list(lines), axis
         self.h._ignore_edges_until = 0.0  # settle window already elapsed
         self.fired = []

--- a/hal/test/test_ttp223_config.py
+++ b/hal/test/test_ttp223_config.py
@@ -1,0 +1,85 @@
+"""Device-specific touch wiring selection without GPIO hardware."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from hal.board.board import TouchConfig
+from hal.board.ttp223 import load_touch_config
+
+
+class TestTouchConfig(unittest.TestCase):
+    def test_missing_file_and_board_preserve_defaults(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(load_touch_config(directory, "orangepi_sun60"),
+                             TouchConfig(0, [96, 100]))
+            self.assertIsNone(load_touch_config(directory, "raspberry_pi_5"))
+            (Path(directory) / "ttp223.json").write_text('{"boards": {}}')
+            self.assertEqual(load_touch_config(directory, "orangepi_sun60"),
+                             TouchConfig(0, [96, 100]))
+
+    def test_device_override_axis_and_explicit_disable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            (Path(directory) / "ttp223.json").write_text(json.dumps({"boards": {
+                "orangepi_sun60": {"chip": 2, "lines": [3, 7], "axis": [7, 3]},
+                "raspberry_pi_5": {"enabled": False},
+            }}))
+            self.assertEqual(load_touch_config(directory, "orangepi_sun60"),
+                             TouchConfig(2, [3, 7], [7, 3]))
+            self.assertIsNone(load_touch_config(directory, "raspberry_pi_5"))
+
+    def test_malformed_configuration_is_not_silently_ignored(self):
+        entries = [
+            {"chip": 0, "lines": []}, {"chip": 0, "lines": [1, 1]},
+            {"chip": 0, "lines": [True]}, {"chip": -1, "lines": [1]},
+            {"chip": False, "lines": [1]}, {"chip": 0, "lines": [1], "axis": [2]},
+            {"chip": 0, "lines": [1], "axis": [1, 1]},
+            {"enabled": "false"}, {"chip": 0, "line": 1},
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ttp223.json"
+            values = ['{', 'null', '{"boards": []}'] + [
+                json.dumps({"boards": {"orangepi_sun60": entry}}) for entry in entries
+            ]
+            for value in values:
+                with self.subTest(value=value):
+                    path.write_text(value)
+                    with self.assertRaisesRegex(ValueError, "ttp223.json"):
+                        load_touch_config(directory, "orangepi_sun60")
+
+    def test_driver_claims_injected_lines_and_copies_axis(self):
+        from hal.drivers.ttp223 import TTP223Handler
+
+        config = TouchConfig(2, [3, 7], [7, 3])
+        gpio = mock.Mock()
+        with mock.patch.dict("sys.modules", {"lgpio": gpio}):
+            handler = TTP223Handler(config)
+            handler.start()
+        gpio.gpiochip_open.assert_called_once_with(2)
+        self.assertEqual(gpio.gpio_claim_alert.call_args_list, [
+            mock.call(gpio.gpiochip_open.return_value, line, gpio.BOTH_EDGES, gpio.SET_PULL_UP)
+            for line in (3, 7)
+        ])
+        self.assertEqual(handler._axis, [7, 3])
+        self.assertIsNot(handler._axis, config.axis)
+
+    def test_disabled_driver_never_imports_or_claims_gpio(self):
+        from hal.drivers.ttp223 import TTP223Handler
+
+        with mock.patch.dict("sys.modules", {"lgpio": None}):
+            TTP223Handler(None).start()
+
+    def test_probe_uses_device_override(self):
+        from hal.test_ttp223_probe_orangepi import _wiring
+
+        with tempfile.TemporaryDirectory() as directory:
+            device = Path(directory) / "test-body"
+            device.mkdir()
+            (device / "ttp223.json").write_text(json.dumps({"boards": {
+                "orangepi_sun60": {"chip": 2, "lines": [3, 7]},
+            }}))
+            with mock.patch("hal.board.board.board_profile") as profile:
+                profile.return_value.id = "orangepi_sun60"
+                self.assertEqual(_wiring("test-body", directory), (2, [3, 7]))

--- a/hal/test_ttp223_probe_orangepi.py
+++ b/hal/test_ttp223_probe_orangepi.py
@@ -14,21 +14,23 @@ Two modes:
                      hal.service to be stopped: it holds its lines and the
                      kernel refuses a second claim.
 
-With no line arguments both modes read the wiring from the board profile
-(`board_profile().touch`), so this cannot drift from boards.json the way the
-previous hardcoded [96, 97, 99] did — those were the pads' pre-relocation lines
-and had been dead for two months.
+With no line arguments, read the selected device's ttp223.json through the
+same loader as HAL, falling back to legacy board wiring when absent.
+Select --device-type (or DEVICE_TYPE) and --devices-dir (or DEVICES_DIR).
 
 Why stdlib ioctl rather than gpiod: gpiod is not installed on the lamp images,
 and HAL's venv lives under /root where the orangepi user cannot execute it. A
 diagnostic that cannot run on the device it diagnoses is not a diagnostic.
 
 Usage on the device:
-    python3 hal/test_ttp223_probe_orangepi.py info
-    sudo systemctl stop hal && python3 hal/test_ttp223_probe_orangepi.py watch
+    python3 hal/test_ttp223_probe_orangepi.py info --device-type lamp --devices-dir /opt/devices
+    sudo systemctl stop hal && python3 hal/test_ttp223_probe_orangepi.py watch --device-type lamp --devices-dir /opt/devices
 """
 
 from __future__ import annotations
+
+import argparse
+from pathlib import Path
 
 import fcntl
 import os
@@ -96,19 +98,14 @@ def _decode_flags(flags: int) -> str:
     return ",".join(on) if on else "-"
 
 
-def _wiring() -> tuple[int, list[int]]:
-    """(chip, lines) from the board profile. The whole point of this script's
-    rewrite: one source of truth with boards.json."""
-    try:
-        from hal.board.board import board_profile
-    except ImportError:
-        sys.exit(
-            "cannot import hal.board.board — run from the repo root, e.g.\n"
-            "    PYTHONPATH=/opt python3 hal/test_ttp223_probe_orangepi.py info"
-        )
-    touch = board_profile().touch
+def _wiring(device_type: str, devices_dir: str) -> tuple[int, list[int]]:
+    """Resolve the same device override and board fallback as HAL."""
+    from hal.board.board import board_profile
+    from hal.board.ttp223 import load_touch_config
+
+    touch = load_touch_config(str(Path(devices_dir) / device_type), board_profile().id)
     if touch is None:
-        sys.exit(f"board {board_profile().id!r} declares no `touch` wiring")
+        sys.exit(f"device {device_type!r} has no active TTP223 wiring on this board")
     return touch.chip, list(touch.lines)
 
 
@@ -131,7 +128,7 @@ def cmd_info(chip: int, lines: list[int]) -> None:
             print(f"{line:>5}  {consumer:<16} {_decode_flags(flags)}")
     print(
         "\nA line held by consumer 'lg' is one HAL claimed. A free line that "
-        "should be a pad\nmeans boards.json and the hardware disagree."
+        "should be a pad\nmeans the selected wiring configuration and the hardware disagree."
     )
 
 
@@ -182,16 +179,20 @@ def cmd_watch(chip: int, lines: list[int]) -> None:
 
 
 def main() -> None:
-    argv = sys.argv[1:]
-    mode = argv[0] if argv else "info"
-    if mode not in ("info", "watch"):
-        sys.exit(__doc__)
-    chip, lines = _wiring()
-    if len(argv) > 1:
-        # Explicit lines override the profile — for asking about pads the
-        # driver does NOT claim, e.g. whether an abandoned line is still wired.
-        lines = [int(a) for a in argv[1:]]
-    cmd_info(chip, lines) if mode == "info" else cmd_watch(chip, lines)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("info", "watch"), nargs="?", default="info")
+    parser.add_argument("lines", nargs="*", type=int)
+    parser.add_argument("--device-type", default=os.environ.get("DEVICE_TYPE"))
+    parser.add_argument("--devices-dir", default=os.environ.get("DEVICES_DIR") or
+                        str(Path(__file__).resolve().parents[1] / "robots"))
+    args = parser.parse_args()
+    if not args.device_type:
+        parser.error("--device-type or DEVICE_TYPE is required to select device wiring")
+    chip, lines = _wiring(args.device_type, args.devices_dir)
+    if args.lines:
+        lines = args.lines
+    cmd_info(chip, lines) if args.mode == "info" else cmd_watch(chip, lines)
+
 
 
 if __name__ == "__main__":

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -14,15 +14,15 @@ Lamp supports a mechanical button, TTP223 touchpads and an optional MPR121 capac
 
 | Device | Pi 4/5 | OrangePi sun60 |
 |---|---|---|
-| GPIO button | gpiochip0 BCM 17 (pull-up, active-LOW) | gpiochip1 line 9 (pull-up, active-LOW) |
+| GPIO button | gpiochip0 BCM 17 (pull-up, active-LOW) | Physical pin 37 / PD4 / gpiochip0 line 100 (pull-up, active-LOW) |
 | TTP223 | not wired | gpiochip0 lines 96 / 100, **pull-up, active-LOW** (pads rest HIGH; a touch is the falling edge). The middle pad on line 98 was removed 2026-08-28. |
 
 Mechanical button wiring belongs to the device: `robots/lamp/gpio_button.json`
 and `robots/intern-v2/gpio_button.json` each declare a `boards` map keyed by
 `raspberry_pi_4`, `raspberry_pi_5`, and `orangepi_sun60`. Each entry has `chip`,
-`line`, and `debounce_ns` (currently `200000000`, or 200 ms). Both devices ship
-the button pins shown above; change the selected device's file when its wiring
-changes, then restart HAL; moving physical wires is not detected automatically.
+`line`, and `debounce_ns` (currently `200000000`, or 200 ms). Lamp uses the
+button pins shown above; Intern v2 retains gpiochip1 line 9 on OrangePi.
+Change the selected device's file when its wiring changes, then restart HAL; moving physical wires is not detected automatically.
 HAL resolves the directory using `DEVICES_DIR` and `DEVICE_TYPE`, then passes
 the detected board's `ButtonConfig` to the shared driver. Device configuration
 takes priority. A missing file or board entry falls back to the existing
@@ -30,7 +30,22 @@ takes priority. A missing file or board entry falls back to the existing
 CM4 and sim; chip 1 / line 9 for OrangePi sun60; all with 200 ms debounce.
 Malformed configuration is rejected before claiming GPIO. Simulation skips
 the hardware button. Pull-up, active-LOW input and gesture behavior remain in
-the shared driver. TTP223 wiring remains in `hal/board/boards.json`.
+the shared driver.
+
+TTP223 wiring is also device-owned: `robots/lamp/ttp223.json` declares a
+`boards` map. Intern v2 has no TTP223 hardware and does not ship this file. Each enabled entry has
+`chip`, `lines` and optional `axis` (the same lines in physical left-to-right
+order). `hal/board/ttp223.py` selects the detected board and passes its
+`TouchConfig` to the shared driver. Missing file or board entry falls back to
+that board's legacy `touch` in `hal/board/boards.json` (OrangePi: chip 0,
+lines 96/100); `"enabled": false` explicitly disables TTP223. Malformed
+configuration is rejected before GPIO is claimed. Restart HAL after editing
+the selected device's JSON. Pull-up, active-LOW behavior and gesture detection
+remain in the shared driver; simulation skips the hardware.
+
+Lamp's new mechanical button uses line 100, which also appears in the legacy
+TTP223 wiring. The replacement pad pin is pending confirmation; do not treat
+that overlapping mapping as verified wiring.
 
 Board detection reads `/proc/device-tree/model`:
 - `"sun60iw2"` → OrangePi 4 Pro / A733
@@ -303,7 +318,7 @@ Resolution order, first match wins:
 | `HAL_TOUCH_SWIPE` | **`true`** | Master switch for rules 1–3. Set `false` to restore the two-gesture behaviour exactly — the rollback path. |
 | `HAL_TOUCH_SWIPE_MIN_GAP_MS` | 40 | The movement floor, and the one number every rule derives from: gaps at or above it mean the hand travelled, below it mean fingers arrived together. Sits inside the measured 23–53 ms empty band. **Load-bearing now that the classifier ships enabled** — raise it if firm taps read as swipes, lower it if real swipes are missed. `HAL_TOUCH_DEBUG` records the gaps it is measured against. |
 
-`boards.json` gains an optional `axis` on the `touch` entry — lines in physical left-to-right order, e.g. `"axis": [96, 100, 98]`. It is **absent** today: line order is not spatial order on this board, and only a labelled press-one-pad-at-a-time run can establish it. Absent, classification falls back to declared line order. A wrong axis costs only the swipe *direction*, which the driver deliberately does not use.
+`ttp223.json` accepts an optional `axis` in each board entry — the configured `lines` in physical left-to-right order. Legacy fallback reads `axis` from the `touch` entry in `boards.json`. It is **absent** today: line order is not spatial order on this board, and only a labelled press-one-pad-at-a-time run can establish it. Absent, classification falls back to declared line order. A wrong axis costs only the swipe *direction*, which the driver deliberately does not use.
 
 ### Constants (`ttp223.py`)
 
@@ -424,12 +439,13 @@ Phrases are intentionally short — they fire mid-stroke and need to feel respon
 | Path | Purpose |
 |---|---|
 | `hal/drivers/gpio_button.py` | GPIO button handler (mechanical, both boards) |
+| `hal/board/ttp223.py` | Device-owned TTP223 configuration loader with legacy fallback |
 | `hal/drivers/ttp223.py` | TTP223 capacitive touchpad handler (OrangePi sun60 only) |
 | `hal/board/mpr121.py` | Device-owned MPR121 configuration loader and validation |
 | `hal/drivers/mpr121.py` | Optional I²C MPR121 touch-and-release handler |
 | `hal/drivers/button_actions.py` | Shared action functions + localized phrase pools |
 | `hal/presets.py` | Language code constants (`LANG_EN`, etc.) |
-| `hal/test_ttp223_probe_orangepi.py` | Standalone pad probe (stdlib ioctl, no gpiod). `info` reads line state with HAL running; `watch` maps pad→line and needs `hal.service` stopped. Lines come from the board profile. |
+| `hal/test_ttp223_probe_orangepi.py` | Standalone pad probe (stdlib ioctl, no gpiod). `info` reads line state with HAL running; `watch` maps pad→line and needs `hal.service` stopped. Lines come from the selected device’s `ttp223.json`, with the same legacy board-profile fallback as HAL. Select the device with `--device-type`. |
 | `hal/test_gpio.py` | Standalone probe for verifying GPIO button line |
 
 Input handlers are started in `hal/server.py` lifespan startup. Missing optional MPR121 configuration skips that driver; malformed enabled configuration rejects startup. Hardware driver failures are logged without stopping the other handlers.

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -14,23 +14,35 @@ Lamp hỗ trợ nút cơ học, touchpad TTP223 và bộ điều khiển cảm �
 
 | Thiết bị | Pi 4/5 | OrangePi sun60 |
 |---|---|---|
-| Nút GPIO | gpiochip0 BCM 17 (pull-up, active-LOW) | gpiochip1 line 9 (pull-up, active-LOW) |
+| Nút GPIO | gpiochip0 BCM 17 (pull-up, active-LOW) | Pin vật lý 37 / PD4 / gpiochip0 line 100 (pull-up, active-LOW) |
 | TTP223 | không wire | gpiochip0 line 96 / 100, **pull-up, active-LOW** (pad nghỉ ở mức HIGH; chạm là edge xuống). Pad giữa trên line 98 đã bị bỏ ngày 2026-08-28. |
 
 Wiring nút cơ thuộc về từng device: `robots/lamp/gpio_button.json` và
 `robots/intern-v2/gpio_button.json` đều khai báo map `boards` với các key
 `raspberry_pi_4`, `raspberry_pi_5`, `orangepi_sun60`. Mỗi entry có `chip`, `line`
-và `debounce_ns` (hiện là `200000000`, tức 200 ms). Cả hai device dùng chân nút
-trong bảng trên; khi đổi wiring, sửa file của device tương ứng rồi khởi động
-lại HAL; hệ thống không tự phát hiện việc đổi dây cắm. HAL xác định thư mục
+và `debounce_ns` (hiện là `200000000`, tức 200 ms). Lamp dùng chân nút trong
+bảng trên; Intern v2 vẫn dùng gpiochip1 line 9 trên OrangePi. Khi đổi wiring,
+sửa file của device tương ứng rồi khởi động lại HAL; hệ thống không tự phát hiện việc đổi dây cắm. HAL xác định thư mục
 qua `DEVICES_DIR` và `DEVICE_TYPE`, rồi truyền `ButtonConfig` của board đã
 detect vào driver dùng chung. Cấu hình device được ưu tiên. Thiếu file hoặc
 entry của board thì dùng lại mặc định `button` trong `hal/board/boards.json`:
 chip 0 / line 17 cho Pi 4, Pi 5, CM4 và sim; chip 1 / line 9 cho OrangePi
 sun60; tất cả có debounce 200 ms. Config sai bị từ chối trước khi claim GPIO.
 Chế độ mô phỏng bỏ qua nút phần cứng. Pull-up, active-LOW và hành vi cử chỉ
-vẫn nằm trong driver dùng chung. Wiring TTP223 vẫn nằm trong
-`hal/board/boards.json`.
+vẫn nằm trong driver dùng chung.
+
+Wiring TTP223 cũng do device quản lý: `robots/lamp/ttp223.json` khai báo
+map `boards`. Intern v2 không có phần cứng TTP223 nên không kèm file này. Mỗi entry bật có `chip`,
+`lines` và `axis` tùy chọn (cùng các line đó theo thứ tự vật lý trái sang phải).
+`hal/board/ttp223.py` chọn board đã detect và truyền `TouchConfig` cho driver
+dùng chung. Thiếu file hoặc entry board thì fallback về `touch` cũ của board
+trong `hal/board/boards.json` (OrangePi: chip 0, line 96/100);
+`"enabled": false` tắt TTP223 rõ ràng. Config sai bị từ chối trước khi claim
+GPIO. Restart HAL sau khi sửa JSON của device được chọn. Pull-up, active-LOW
+và nhận diện cử chỉ vẫn ở driver dùng chung; mô phỏng bỏ qua phần cứng.
+
+Nút cơ mới của Lamp dùng line 100, cũng có trong wiring TTP223 cũ. Chân pad
+thay thế đang chờ xác nhận; mapping trùng chân này chưa phải wiring đã xác minh.
 
 Board được detect qua `/proc/device-tree/model`:
 - `"sun60iw2"` → OrangePi 4 Pro / A733
@@ -300,7 +312,7 @@ Thứ tự phân giải, khớp cái nào trước thì thắng:
 | `HAL_TOUCH_SWIPE` | **`true`** | Công tắc chính cho luật 1–3. Đặt `false` để khôi phục đúng hành vi hai-cử-chỉ — đường lùi. |
 | `HAL_TOUCH_SWIPE_MIN_GAP_MS` | 40 | Ngưỡng di chuyển, và là con số duy nhất mà mọi luật đều rút ra từ đó: khoảng cách từ mức này trở lên nghĩa là bàn tay đã di chuyển, dưới mức này nghĩa là các ngón đặt xuống cùng lúc. Nằm trong dải trống 23–53 ms đã đo. **Giờ mang tính then chốt vì bộ phân loại đã ship ở trạng thái bật** — nâng lên nếu tap dứt khoát bị đọc thành swipe, hạ xuống nếu swipe thật bị bỏ sót. `HAL_TOUCH_DEBUG` ghi lại chính các khoảng dùng để đo. |
 
-`boards.json` có thêm trường tùy chọn `axis` trong mục `touch` — các line theo thứ tự vật lý trái sang phải, ví dụ `"axis": [96, 100, 98]`. Hiện tại nó **vắng mặt**: thứ tự line không phải thứ tự không gian trên board này, và chỉ một đợt chạy có nhãn nhấn từng pad một mới xác định được. Khi vắng, phân loại lùi về thứ tự line khai báo. Một axis sai chỉ làm sai **hướng** swipe, thứ mà driver cố ý không dùng.
+`ttp223.json` nhận `axis` tùy chọn trong mỗi entry board — cùng các `lines` đã cấu hình, theo thứ tự vật lý trái sang phải. Fallback cũ đọc `axis` từ mục `touch` trong `boards.json`. Hiện tại nó **vắng mặt**: thứ tự line không phải thứ tự không gian trên board này, và chỉ một đợt chạy có nhãn nhấn từng pad một mới xác định được. Khi vắng, phân loại lùi về thứ tự line khai báo. Một axis sai chỉ làm sai **hướng** swipe, thứ mà driver cố ý không dùng.
 
 ### Hằng số (`ttp223.py`)
 
@@ -420,12 +432,13 @@ Phrase cố tình ngắn — chúng fire giữa lúc vuốt nên cần cảm gi�
 | Đường dẫn | Mục đích |
 |---|---|
 | `hal/drivers/gpio_button.py` | Handler nút GPIO (cơ học, cả hai board) |
+| `hal/board/ttp223.py` | Đọc cấu hình TTP223 theo device, có fallback cũ |
 | `hal/drivers/ttp223.py` | Handler touchpad cảm ứng TTP223 (chỉ OrangePi sun60) |
 | `hal/board/mpr121.py` | Đọc và kiểm tra cấu hình MPR121 do device quản lý |
 | `hal/drivers/mpr121.py` | Handler I²C MPR121 tùy chọn, detect chạm rồi nhả |
 | `hal/drivers/button_actions.py` | Hàm action chung + pool phrase local |
 | `hal/presets.py` | Hằng số mã ngôn ngữ (`LANG_EN`, v.v.) |
-| `hal/test_ttp223_probe_orangepi.py` | Probe pad độc lập (ioctl thuần stdlib, không cần gpiod). `info` đọc trạng thái line khi HAL vẫn chạy; `watch` map pad→line và cần dừng `hal.service`. Line lấy từ board profile. |
+| `hal/test_ttp223_probe_orangepi.py` | Probe pad độc lập (ioctl thuần stdlib, không cần gpiod). `info` đọc trạng thái line khi HAL vẫn chạy; `watch` map pad→line và cần dừng `hal.service`. Line lấy từ `ttp223.json` của device được chọn, fallback về board profile cũ giống HAL. Chọn device bằng `--device-type`. |
 | `hal/test_gpio.py` | Probe độc lập để verify line nút GPIO |
 
 Các handler đầu vào được khởi động trong startup lifespan `hal/server.py`. Thiếu cấu hình MPR121 tùy chọn thì bỏ qua driver đó; cấu hình bật nhưng sai bị từ chối khi startup. Lỗi driver phần cứng được log mà không dừng các handler còn lại.

--- a/robots/lamp/gpio_button.json
+++ b/robots/lamp/gpio_button.json
@@ -11,8 +11,8 @@
       "debounce_ns": 200000000
     },
     "orangepi_sun60": {
-      "chip": 1,
-      "line": 9,
+      "chip": 0,
+      "line": 100,
       "debounce_ns": 200000000
     }
   }

--- a/robots/lamp/ttp223.json
+++ b/robots/lamp/ttp223.json
@@ -1,0 +1,11 @@
+{
+  "boards": {
+    "orangepi_sun60": {
+      "chip": 0,
+      "lines": [
+        96,
+        100
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Move TTP223 wiring into the device-owned `ttp223.json` so pin changes do not require editing the shared driver. HAL and the standalone probe use the same loader; missing file/board entries retain the existing board fallback, while `enabled: false` explicitly disables the input. Only Lamp ships a TTP223 JSON file. Update English and Vietnamese documentation and focused tests.

Also move Lamp's OrangePi mechanical button to physical pin 37 (PD4, gpiochip0 line 100), preserving its 200 ms debounce. Intern v2's button wiring and legacy board defaults remain unchanged.

Pending hardware mapping: Lamp's TTP223 JSON intentionally retains its previous lines 96/100 until the replacement pad pin is supplied. Line 100 currently overlaps the new mechanical-button pin; resolve this before deployment. Removing Intern v2's JSON does not disable its inherited board fallback. This PR is a draft pending the final touchpad wiring.

Validation:
- `uv run --no-project --with pytest --with requests --with fastapi --with numpy python -m pytest hal/test/test_ttp223.py hal/test/test_ttp223_config.py hal/test/test_gpio_button_config.py hal/test/test_board.py hal/test/test_button_actions.py -q` — 95 passed, 25 subtests passed.
- `uv run --no-project --with pyflakes python hal/scripts/lint.py` — passed.
- `python3 hal/test_ttp223_probe_orangepi.py --help` and `git diff --check` — passed.

These changes have not been deployed to a device.
