### PR TITLE
hal: add MPR121 reboot and hold power gestures

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -91,8 +91,13 @@ file/board or `enabled: false` skips MPR121 and preserves existing GPIO/TTP223
 inputs; simulation also skips it. Malformed enabled configuration rejects
 startup. Restart HAL after changing wiring configuration. The shared
 `hal/drivers/mpr121.py` driver groups selected electrodes into one debounced
-touch-and-release session, then calls `single_click_action(source="MPR121")`
-once, with no double-tap or destructive hold mapping. Defaults are address
+contact. It shares GPIO gesture thresholds in `hal/drivers/button_gestures.py`:
+the first short release immediately calls single-click with `announce=False`;
+a 0.4 s quiet window produces the listening cue for 1/2/4+ clicks or reboot
+for exactly 3. Holds commit only on release: 2–<5 s sleepy, 5–<10 s shutdown,
+≥10 s factory reset. Boot-held contacts are suppressed; MPR121 has no hold-tier
+LED feedback. New click/hold mappings have mocked local verification only;
+the earlier live test covered single-click. Defaults are address
 `0x5A`, electrodes 0–11, touch/release thresholds 2/1, autoconfiguration enabled,
 10 ms polling and 30 ms debounce, with 100 ms startup settling. An I²C failure
 or overcurrent fault stops only this driver. Logger `hal.drivers.mpr121` records

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -88,8 +88,13 @@ file/board hoặc `enabled: false` thì bỏ qua MPR121, giữ input GPIO/TTP223
 hiện có; chế độ mô phỏng cũng bỏ qua. Cấu hình bật nhưng sai bị từ chối khi
 startup. Restart HAL sau khi đổi cấu hình wiring. Driver dùng chung
 `hal/drivers/mpr121.py` gom các electrode được chọn thành một phiên chạm rồi
-nhả đã debounce, sau đó gọi `single_click_action(source="MPR121")` một lần,
-không map double-tap hay giữ để thực hiện hành động destructive. Mặc định:
+nhả đã debounce. Ngưỡng cử chỉ dùng chung GPIO trong
+`hal/drivers/button_gestures.py`: lần nhả ngắn đầu tiên gọi single-click ngay
+với `announce=False`; sau 0.4 s yên, 1/2/4+ click phát cue nghe, đúng 3 click
+thì reboot. Giữ chỉ thực hiện khi nhả: 2–<5 s sleepy, 5–<10 s shutdown,
+≥10 s factory reset. Chạm giữ lúc startup bị bỏ qua; MPR121 chưa có LED theo
+mức giữ. Mapping click/giữ mới chỉ kiểm tra bằng test mock local; lần test
+trên device trước đó chỉ kiểm tra single-click. Mặc định:
 địa chỉ `0x5A`, electrode 0–11, ngưỡng chạm/nhả 2/1, bật autoconfig,
 polling 10 ms và debounce 30 ms, chờ ổn định 100 ms lúc startup. Lỗi I²C hoặc
 cờ quá dòng chỉ dừng driver này. Logger `hal.drivers.mpr121` ghi cấu hình,

--- a/hal/drivers/button_actions.py
+++ b/hal/drivers/button_actions.py
@@ -31,13 +31,14 @@ from hal.i18n import (
     PHRASES_BY_LANG,
 )
 from hal.presets import DEFAULT_LANG
+from hal.drivers.button_gestures import (
+    DOUBLE_CLICK_WINDOW,
+    FACTORY_RESET_DURATION,
+    LONG_PRESS_DURATION,
+    SLEEP_HOLD_DURATION,
+)
 
 logger = logging.getLogger(__name__)
-
-DOUBLE_CLICK_WINDOW = 0.4  # seconds to wait for second click
-SLEEP_HOLD_DURATION = 2.0  # seconds held → sleepy emotion on release
-LONG_PRESS_DURATION = 5.0  # seconds held → shutdown on release
-FACTORY_RESET_DURATION = 10.0  # seconds held → factory-reset on release (supersedes shutdown)
 
 # OS server sensing endpoint. Head-pat notify is fire-and-forget — the
 # OS server appends a NO_REPLY hint so the agent records the event in
@@ -581,9 +582,8 @@ def shutdown_action(source: str = "button"):
 def hold_release_action(held_s: float, source: str = "button"):
     """Map a released hold duration to its explicit device action.
 
-    The GPIO driver owns edge handling and LED staging; this mapping owns the
-    semantic thresholds. A future input can provide the same duration signal
-    without duplicating the sleep/shutdown/factory-reset decision tree.
+    Input drivers supply released hold durations. This mapping shares the
+    sleep/shutdown/factory-reset decision tree across GPIO and MPR121 inputs.
     """
     if held_s >= FACTORY_RESET_DURATION:
         factory_reset_action(source)

--- a/hal/drivers/button_gestures.py
+++ b/hal/drivers/button_gestures.py
@@ -1,0 +1,6 @@
+"""Shared timing thresholds for mechanical and capacitive button gestures."""
+
+DOUBLE_CLICK_WINDOW = 0.4  # Seconds of quiet after the last short release.
+SLEEP_HOLD_DURATION = 2.0
+LONG_PRESS_DURATION = 5.0  # Shutdown threshold.
+FACTORY_RESET_DURATION = 10.0

--- a/hal/drivers/mpr121.py
+++ b/hal/drivers/mpr121.py
@@ -1,4 +1,4 @@
-"""Optional MPR121 capacitive input: a complete touch maps to single click.
+"""Optional MPR121 capacitive input using shared GPIO button gestures.
 
 I2C transport and register setup adapted from the user-supplied
 mpr121_opi_test.py. Only the device-declared bus/address is accessed.
@@ -10,8 +10,13 @@ import os
 import queue
 import threading
 import time
+from dataclasses import dataclass
 
 from hal.board.mpr121 import MPR121Config
+from hal.drivers.button_gestures import (
+    DOUBLE_CLICK_WINDOW, FACTORY_RESET_DURATION, LONG_PRESS_DURATION,
+    SLEEP_HOLD_DURATION,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +70,16 @@ class I2CBus:
         self._transfer([_I2CMsg(address, 0, 2, buffer)])
 
 
-class _TapDetector:
-    """Debounce the union of selected electrodes; ignore a boot-time hold."""
+@dataclass(frozen=True)
+class _GestureEvent:
+    kind: str
+    gesture_id: int
+    count: int = 0
+    held_s: float = 0.0
+
+
+class _GestureRecognizer:
+    """Poll-clock recognition independent of action execution and electrode count."""
 
     def __init__(self, debounce_ms):
         self._delay = debounce_ms / 1000
@@ -74,37 +87,102 @@ class _TapDetector:
         self._candidate = None
         self._since = 0.0
         self._armed = False
-        self._pressed = False
+        self._press_start = None
+        self._click_count = 0
+        self._deadline = None
+        self._gesture_id = 0
+        self._hold_tier = 0
+
+    def cancel(self):
+        self._press_start = None
+        self._click_count = 0
+        self._deadline = None
+        self._armed = False
 
     def update(self, touched, now):
+        events = []
         if self._stable is None:
             self._stable = self._candidate = touched
             self._since = now
             self._armed = not touched
             logger.info("MPR121 event=detector_seed touched=%s armed=%s startup_hold_suppressed=%s", touched, self._armed, touched)
-            return False
+            return events
         if touched != self._candidate:
             self._candidate = touched
             self._since = now
             logger.debug("MPR121 event=debounce_candidate touched=%s", touched)
-        if touched == self._stable or now - self._since < self._delay:
-            return False
-        self._stable = touched
-        if touched:
-            self._pressed = self._armed
-            logger.info("MPR121 event=stable_touch armed=%s", self._armed)
-            return False
-        clicked = self._pressed
-        self._pressed = False
-        self._armed = True
-        logger.info("MPR121 event=stable_release tap_accepted=%s startup_hold_suppressed=%s", clicked, not clicked)
-        return clicked
+            if touched:
+                # Cancel stale queued outcomes as soon as a new touch appears,
+                # but never use raw chatter to increment the gesture count.
+                events.append(_GestureEvent("invalidate", self._gesture_id))
+        if touched != self._stable and now - self._since >= self._delay:
+            self._stable = touched
+            if touched and self._armed:
+                if self._deadline is not None and self._since >= self._deadline:
+                    logger.info("MPR121 event=burst_cancelled gesture_id=%d count=%d reason=new_touch_after_deadline", self._gesture_id, self._click_count)
+                    self._click_count = 0
+                    self._deadline = None
+                if not self._click_count:
+                    self._gesture_id += 1
+                self._press_start = self._since
+                self._hold_tier = 0
+                events.append(_GestureEvent("press", self._gesture_id, self._click_count))
+            elif not touched:
+                if self._press_start is None:
+                    logger.info("MPR121 event=stable_release startup_hold_suppressed=true")
+                else:
+                    # Measure between the first samples of the accepted edges;
+                    # debounce must not push a just-short hold over a threshold.
+                    held = self._since - self._press_start
+                    events.append(_GestureEvent("release", self._gesture_id, self._click_count, held))
+                    if held >= SLEEP_HOLD_DURATION:
+                        self._click_count = 0
+                        self._deadline = None
+                        events.append(_GestureEvent("invalidate", self._gesture_id))
+                        events.append(_GestureEvent("hold", self._gesture_id, held_s=held))
+                    else:
+                        self._click_count += 1
+                        if self._click_count == 1:
+                            events.append(_GestureEvent("single", self._gesture_id, self._click_count, held))
+                        self._deadline = now + DOUBLE_CLICK_WINDOW
+                    self._press_start = None
+                self._armed = True
+        if self._press_start is not None:
+            held = (now if touched else self._since) - self._press_start
+            tier = sum(held >= threshold for threshold in (
+                SLEEP_HOLD_DURATION, LONG_PRESS_DURATION, FACTORY_RESET_DURATION,
+            ))
+            if tier > self._hold_tier:
+                self._hold_tier = tier
+                events.append(_GestureEvent("hold_tier", self._gesture_id, tier, held))
+        # A pending click window never commits a destructive outcome while
+        # another electrode is held; a completed hold clears the whole burst.
+        if not touched and not self._stable and self._deadline is not None and now >= self._deadline:
+            kind = "triple" if self._click_count == 3 else "cue"
+            events.append(_GestureEvent(kind, self._gesture_id, self._click_count))
+            self._click_count = 0
+            self._deadline = None
+        return events
 
 
-def single_click_action(*, source):
-    # Keep platform/audio dependencies out of transport initialization.
+def single_click_action(*, source, announce):
     from hal.drivers.button_actions import single_click_action as action
+    action(source=source, announce=announce)
+
+
+def announce_listening_cue(*, source):
+    from hal.drivers.button_actions import announce_listening_cue as action
     action(source=source)
+
+
+def triple_click_action(*, source):
+    from hal.drivers.button_actions import triple_click_action as action
+    action(source=source)
+
+
+def hold_release_action(held_s, *, source):
+    from hal.drivers.button_actions import hold_release_action as action
+    action(held_s, source=source)
 
 
 class MPR121Handler:
@@ -113,12 +191,14 @@ class MPR121Handler:
         self._mask = sum(1 << electrode for electrode in set(config.electrodes))
         self._bus = None
         self._stop = threading.Event()
-        self._pending = queue.Queue(maxsize=1)
+        self._pending = queue.Queue(maxsize=2)
         self._poll_thread = None
         self._action_thread = None
-        self._detector = _TapDetector(config.debounce_ms)
+        self._detector = _GestureRecognizer(config.debounce_ms)
         self._last_raw_mask = None
-        self._tap_id = 0
+        self._generation = 0
+        self._action_busy = False
+        self._gesture_lock = threading.Lock()
 
     def _initialize(self):
         config = self._config
@@ -171,15 +251,15 @@ class MPR121Handler:
         if any(thread and thread.is_alive() for thread in (self._poll_thread, self._action_thread)):
             raise RuntimeError("MPR121 handler already running or stopping")
         logger.info(
-            "MPR121 event=start bus=%d address=0x%02x electrodes=%s touch_threshold=%d release_threshold=%d autoconfig=%s poll_ms=%d debounce_ms=%d settle_ms=100 pending_capacity=1",
+            "MPR121 event=start bus=%d address=0x%02x electrodes=%s touch_threshold=%d release_threshold=%d autoconfig=%s poll_ms=%d debounce_ms=%d settle_ms=100 pending_capacity=2",
             self._config.bus, self._config.address, self._config.electrodes,
             self._config.touch_threshold, self._config.release_threshold,
             self._config.autoconfig, self._config.poll_ms, self._config.debounce_ms,
         )
         self._last_raw_mask = None
         self._stop.clear()
-        self._pending = queue.Queue(maxsize=1)
-        self._detector = _TapDetector(self._config.debounce_ms)
+        self._pending = queue.Queue(maxsize=2)
+        self._detector = _GestureRecognizer(self._config.debounce_ms)
         try:
             self._bus = I2CBus(self._config.bus)
             self._initialize()
@@ -207,54 +287,98 @@ class MPR121Handler:
             except OSError:
                 logger.exception("MPR121 bus close failed")
 
+    def _invalidate_pending(self, reason):
+        with self._gesture_lock:
+            self._generation += 1
+            while True:
+                try:
+                    _, event, _ = self._pending.get_nowait()
+                except queue.Empty:
+                    break
+                logger.info("MPR121 event=action_discarded gesture_id=%d action=%s reason=%s", event.gesture_id, event.kind, reason)
+
+    def _process_touch(self, touched, now):
+        for event in self._detector.update(touched, now):
+            if self._stop.is_set():
+                return
+            logger.info("MPR121 event=gesture kind=%s gesture_id=%d count=%d held_s=%.3f", event.kind, event.gesture_id, event.count, event.held_s)
+            if event.kind == "invalidate":
+                self._invalidate_pending("new_touch_or_hold")
+            elif event.kind in ("single", "cue", "triple", "hold"):
+                with self._gesture_lock:
+                    if self._stop.is_set():
+                        return
+                    if event.kind in ("hold", "triple") and (self._action_busy or not self._pending.empty()):
+                        logger.warning("MPR121 event=action_discarded gesture_id=%d action=%s reason=action_worker_busy", event.gesture_id, event.kind)
+                        continue
+                    try:
+                        self._pending.put_nowait((self._generation, event, time.monotonic()))
+                        logger.info("MPR121 event=action_queued gesture_id=%d action=%s", event.gesture_id, event.kind)
+                    except queue.Full:
+                        # Counts are resolved from every electrode edge above;
+                        # dropping a semantic outcome never invents a triple.
+                        logger.warning("MPR121 event=action_discarded gesture_id=%d action=%s reason=pending_queue_full", event.gesture_id, event.kind)
+
     def _poll(self):
         logger.info("MPR121 event=worker_started worker=poll")
         try:
             while not self._stop.wait(self._config.poll_ms / 1000):
-                if self._detector.update(self._read_touched(), time.monotonic()):
-                    self._tap_id += 1
-                    logger.info("MPR121 event=tap_accepted tap_id=%d", self._tap_id)
-                    try:
-                        self._pending.put_nowait(self._tap_id)
-                        logger.info("MPR121 event=action_queued tap_id=%d", self._tap_id)
-                    except queue.Full:
-                        logger.info("MPR121 event=action_coalesced tap_id=%d reason=pending_queue_full", self._tap_id)
+                self._process_touch(self._read_touched(), time.monotonic())
         except Exception:
             logger.exception("MPR121 polling stopped after hardware error")
             self._stop.set()
         finally:
+            self._detector.cancel()
+            self._invalidate_pending("poll_stopped")
             self._close_bus()
             logger.info("MPR121 event=worker_stopped worker=poll")
+
+    def _execute(self, event):
+        if event.kind == "single":
+            single_click_action(source="MPR121", announce=False)
+        elif event.kind == "cue":
+            announce_listening_cue(source="MPR121")
+        elif event.kind == "triple":
+            triple_click_action(source="MPR121")
+        elif event.kind == "hold":
+            hold_release_action(event.held_s, source="MPR121")
 
     def _dispatch(self):
         logger.info("MPR121 event=worker_started worker=action")
         try:
             while not self._stop.is_set():
                 try:
-                    tap_id = self._pending.get(timeout=0.1)
+                    generation, event, queued_at = self._pending.get(timeout=0.1)
                 except queue.Empty:
                     continue
-                if self._stop.is_set():
-                    logger.info("MPR121 event=action_discarded tap_id=%s reason=stopping", tap_id)
-                    return
+                with self._gesture_lock:
+                    valid = not self._stop.is_set() and generation == self._generation
+                    if event.kind in ("hold", "triple") and time.monotonic() - queued_at > DOUBLE_CLICK_WINDOW:
+                        valid = False
+                    if valid:
+                        self._action_busy = True
+                if not valid:
+                    logger.info("MPR121 event=action_discarded gesture_id=%d action=%s reason=stale_expired_or_stopping", event.gesture_id, event.kind)
+                    continue
                 try:
-                    logger.info("MPR121 event=action_begin tap_id=%s action=single_click", tap_id)
-                    single_click_action(source="MPR121")
-                    logger.info("MPR121 event=action_complete tap_id=%s action=single_click", tap_id)
+                    logger.info("MPR121 event=action_begin gesture_id=%d action=%s count=%d held_s=%.3f", event.gesture_id, event.kind, event.count, event.held_s)
+                    # Once a shared action starts its own I/O/OS sequence, it
+                    # cannot be interrupted here. Only pending work is canceled.
+                    self._execute(event)
+                    logger.info("MPR121 event=action_complete gesture_id=%d action=%s", event.gesture_id, event.kind)
                 except Exception:
-                    logger.exception("MPR121 event=action_failed tap_id=%s action=single_click", tap_id)
+                    logger.exception("MPR121 event=action_failed gesture_id=%d action=%s", event.gesture_id, event.kind)
+                finally:
+                    with self._gesture_lock:
+                        self._action_busy = False
         finally:
-            while True:
-                try:
-                    tap_id = self._pending.get_nowait()
-                except queue.Empty:
-                    break
-                logger.info("MPR121 event=action_discarded tap_id=%s reason=stopping", tap_id)
+            self._invalidate_pending("action_worker_stopped")
             logger.info("MPR121 event=worker_stopped worker=action")
 
     def stop(self):
         logger.info("MPR121 event=stop_requested")
         self._stop.set()
+        self._invalidate_pending("stop_requested")
         for thread in (self._poll_thread, self._action_thread):
             if thread is not None and thread.ident is not None:
                 thread.join(timeout=2)

--- a/hal/test/test_button_actions.py
+++ b/hal/test/test_button_actions.py
@@ -126,6 +126,24 @@ def test_triple_click_only_maps_the_gesture_to_reboot_action():
     reboot.assert_called_once_with("test button")
 
 
+def test_hold_release_boundaries_do_not_escalate_early():
+    for duration, expected in (
+        (0.1, None), (1.999, None), (2.0, "sleep"), (4.999, "sleep"),
+        (5.0, "shutdown"), (9.999, "shutdown"), (10.0, "reset"),
+    ):
+        with (
+            mock.patch.object(button_actions, "sleep_action") as sleep,
+            mock.patch.object(button_actions, "shutdown_action") as shutdown,
+            mock.patch.object(button_actions, "factory_reset_action") as reset,
+        ):
+            button_actions.hold_release_action(duration, "MPR121")
+            for name, action in (("sleep", sleep), ("shutdown", shutdown), ("reset", reset)):
+                if name == expected:
+                    action.assert_called_once_with("MPR121")
+                else:
+                    action.assert_not_called()
+
+
 def test_hold_release_maps_each_duration_to_one_explicit_action():
     with (
         mock.patch.object(button_actions, "sleep_action") as sleep,

--- a/hal/test/test_mpr121.py
+++ b/hal/test/test_mpr121.py
@@ -1,41 +1,95 @@
 """MPR121 register setup, touch grouping, and worker lifecycle without hardware."""
 
 import threading
+import time
 import unittest
 from unittest import mock
 
 from hal.board.mpr121 import MPR121Config
-from hal.drivers.mpr121 import I2CBus, MPR121Handler, _TapDetector
+from hal.drivers.mpr121 import I2CBus, MPR121Handler, _GestureRecognizer, _GestureEvent
 
 
-class TestTapDetector(unittest.TestCase):
-    def test_one_release_one_click_even_after_long_hold(self):
-        detector = _TapDetector(30)
-        samples = [(False, 0), (True, 1), (True, 1.04), (True, 20),
-                   (False, 21), (False, 21.04), (False, 22)]
-        self.assertEqual([detector.update(*sample) for sample in samples],
-                         [False, False, False, False, False, True, False])
+class TestGestures(unittest.TestCase):
+    def events(self, samples, debounce_ms=0):
+        detector = _GestureRecognizer(debounce_ms)
+        return [event for sample in samples for event in detector.update(*sample)]
 
-    def test_chatter_does_not_click_or_split_touch(self):
-        detector = _TapDetector(30)
+    def actions(self, events):
+        return [event for event in events if event.kind in ('single', 'cue', 'triple', 'hold')]
+
+    def test_one_two_three_four_taps(self):
+        for count in range(1, 5):
+            with self.subTest(count=count):
+                samples = [(False, 0)]
+                for index in range(count):
+                    samples += [(True, 1 + index * .2), (False, 1.1 + index * .2)]
+                samples += [(False, samples[-1][1] + .41)]
+                actions = self.actions(self.events(samples))
+                self.assertEqual([event.kind for event in actions], ['single', 'triple' if count == 3 else 'cue'])
+                self.assertEqual(actions[-1].count, count)
+
+    def test_exact_click_window_boundary(self):
+        detector = _GestureRecognizer(0)
+        for sample in [(False, 0), (True, .5), (False, 1)]:
+            detector.update(*sample)
+        self.assertEqual(detector.update(False, 1.399), [])
+        self.assertEqual([event.kind for event in detector.update(False, 1.4)], ['cue'])
+        events = detector.update(True, 1.5) + detector.update(False, 1.6) + detector.update(False, 2)
+        self.assertEqual([event.kind for event in self.actions(events)], ['single', 'cue'])
+
+    def test_hold_boundaries_and_no_action_while_held(self):
+        for duration in (1.999, 2, 4.999, 5, 9.999, 10, 15):
+            with self.subTest(duration=duration):
+                detector = _GestureRecognizer(0)
+                detector.update(False, 0)
+                detector.update(True, 1)
+                self.assertEqual(self.actions(detector.update(True, 1 + duration)), [])
+                actions = self.actions(detector.update(False, 1 + duration))
+                self.assertEqual([event.kind for event in actions], ['single' if duration < 2 else 'hold'])
+                self.assertAlmostEqual(actions[0].held_s, duration)
+
+    def test_hold_clears_pending_triple_and_cue(self):
+        samples = [(False, 0)]
+        for index in range(3):
+            samples += [(True, 1 + index * .2), (False, 1.1 + index * .2)]
+        samples += [(True, 1.7), (True, 4), (False, 4.7), (False, 6)]
+        self.assertEqual([event.kind for event in self.actions(self.events(samples))], ['single', 'hold'])
+
+    def test_chatter_does_not_count_or_change_duration(self):
         samples = [(False, 0), (True, 1), (False, 1.01), (False, 1.1),
                    (True, 2), (True, 2.04), (False, 3), (True, 3.01),
-                   (True, 3.1), (False, 4), (False, 4.04)]
-        self.assertEqual(sum(detector.update(*sample) for sample in samples), 1)
+                   (True, 3.1), (False, 4), (False, 4.04), (False, 5)]
+        actions = self.actions(self.events(samples, 30))
+        self.assertEqual([event.kind for event in actions], ['hold'])
+        self.assertEqual(actions[0].held_s, 2)
 
-    def test_boot_hold_is_suppressed_until_stable_release(self):
-        detector = _TapDetector(30)
+    def test_debounce_does_not_promote_short_hold(self):
+        samples = [(False, 0), (True, 1), (True, 1.04), (False, 2.999), (False, 3.04)]
+        actions = self.actions(self.events(samples, 30))
+        self.assertEqual([event.kind for event in actions], ['single'])
+        self.assertAlmostEqual(actions[0].held_s, 1.999)
+
+    def test_boot_hold_suppressed_until_stable_release(self):
         samples = [(True, 0), (True, 10), (False, 11), (True, 11.01),
                    (False, 12), (False, 12.04), (True, 13), (True, 13.04),
-                   (False, 14), (False, 14.04)]
-        results = [detector.update(*sample) for sample in samples]
-        self.assertEqual(results, [False] * 9 + [True])
+                   (False, 13.2), (False, 13.24), (False, 14)]
+        self.assertEqual([event.kind for event in self.actions(self.events(samples, 30))], ['single', 'cue'])
 
-    def test_rapid_separate_taps_remain_single_clicks(self):
-        detector = _TapDetector(30)
-        samples = [(False, 0), (True, .1), (True, .14), (False, .2),
-                   (False, .24), (True, .3), (True, .34), (False, .4), (False, .44)]
-        self.assertEqual(sum(detector.update(*sample) for sample in samples), 2)
+    def test_cancel_clears_pending_burst_and_hold(self):
+        detector = _GestureRecognizer(0)
+        for sample in [(False, 0), (True, 1), (False, 1.1)]:
+            detector.update(*sample)
+        detector.cancel()
+        self.assertEqual(self.actions(detector.update(False, 10)), [])
+        detector = _GestureRecognizer(0)
+        detector.update(False, 0)
+        detector.update(True, 1)
+        detector.cancel()
+        self.assertEqual(self.actions(detector.update(False, 20)), [])
+
+    def test_hold_tiers_are_logged_once_per_threshold(self):
+        events = self.events([(False, 0), (True, 1), (True, 3), (True, 4), (True, 6), (True, 11)])
+        self.assertEqual([event.count for event in events if event.kind == 'hold_tier'], [1, 2, 3])
 
 
 class TestMPR121(unittest.TestCase):
@@ -71,7 +125,10 @@ class TestMPR121(unittest.TestCase):
         masks = [4, 1, 1, 3, 2, 2, 4, 4]
         handler._bus.read_regs.side_effect = [mask.to_bytes(2, 'little') for mask in masks]
         times = [0, 1, 1.04, 2, 3, 3.04, 4, 4.04]
-        self.assertEqual(sum(handler._detector.update(handler._read_touched(), now) for now in times), 1)
+        events = [event for now in times for event in handler._detector.update(handler._read_touched(), now)]
+        holds = [event for event in events if event.kind == 'hold']
+        self.assertEqual(len(holds), 1)
+        self.assertEqual(holds[0].held_s, 3)
 
     def test_electrode_logs_include_changes_without_repeating_samples(self):
         handler = self.make_handler(electrodes=(0,))
@@ -112,30 +169,40 @@ class TestMPR121(unittest.TestCase):
                 handler.start()
         bus.close.assert_called_once()
 
-    def test_poll_delivers_tap_to_shared_single_click(self):
-        handler = self.make_handler(poll_ms=1)
-        bus = mock.Mock()
-        statuses = iter([0, 1, 1, 0, 0])
-        times = iter([0, 1, 1.04, 2, 2.04])
-        bus.read_regs.side_effect = lambda address, register, length: (
-            b'\x24' if register == 0x5D else next(statuses, 0).to_bytes(2, 'little')
-        )
+    def test_semantic_actions_call_shared_functions(self):
+        handler = self.make_handler()
+        with mock.patch('hal.drivers.mpr121.single_click_action') as single, \
+                mock.patch('hal.drivers.mpr121.announce_listening_cue') as cue, \
+                mock.patch('hal.drivers.mpr121.triple_click_action') as triple, \
+                mock.patch('hal.drivers.mpr121.hold_release_action') as hold:
+            for event in [_GestureEvent('single', 1), _GestureEvent('cue', 1),
+                          _GestureEvent('triple', 2, count=3), _GestureEvent('hold', 3, held_s=10)]:
+                handler._execute(event)
+        single.assert_called_once_with(source='MPR121', announce=False)
+        cue.assert_called_once_with(source='MPR121')
+        triple.assert_called_once_with(source='MPR121')
+        hold.assert_called_once_with(10, source='MPR121')
+
+    def test_worker_delivers_action_with_correlation_logs(self):
+        handler = self.make_handler()
         called = threading.Event()
-        with mock.patch('hal.drivers.mpr121.I2CBus', return_value=bus), \
-                mock.patch('hal.drivers.mpr121.time.sleep'), \
-                mock.patch('hal.drivers.mpr121.time.monotonic', side_effect=lambda: next(times, 3)), \
-                mock.patch('hal.drivers.mpr121.single_click_action', side_effect=lambda **kwargs: called.set()) as action, \
+        with mock.patch('hal.drivers.mpr121.single_click_action', side_effect=lambda **kwargs: called.set()) as action, \
                 self.assertLogs('hal.drivers.mpr121', level='INFO') as logs:
-            handler.start()
+            handler._action_thread = threading.Thread(target=handler._dispatch)
+            handler._action_thread.start()
             try:
+                handler._process_touch(False, 0)
+                handler._process_touch(True, 1)
+                handler._process_touch(True, 1.04)
+                handler._process_touch(False, 1.2)
+                handler._process_touch(False, 1.24)
                 self.assertTrue(called.wait(1))
             finally:
                 handler.stop()
-            action.assert_called_once_with(source='MPR121')
+            action.assert_called_once_with(source='MPR121', announce=False)
         output = '\n'.join(logs.output)
-        for event in ('tap_accepted', 'action_queued', 'action_begin', 'action_complete'):
-            self.assertIn(f'event={event} tap_id=1', output)
-        self.assertIn('event=worker_stopped worker=action', output)
+        for event in ('action_queued', 'action_begin', 'action_complete'):
+            self.assertIn(f'event={event} gesture_id=1 action=single', output)
 
     def test_poll_failure_closes_bus_and_stops_dispatch(self):
         handler = self.make_handler(poll_ms=1)
@@ -149,6 +216,21 @@ class TestMPR121(unittest.TestCase):
         self.assertFalse(handler._poll_thread.is_alive())
         self.assertFalse(handler._action_thread.is_alive())
 
+    def test_poll_fault_cancels_pending_gesture_and_actions(self):
+        handler = self.make_handler(poll_ms=1, debounce_ms=0)
+        handler._bus = bus = mock.Mock()
+        handler._process_touch(False, 0)
+        handler._process_touch(True, 1)
+        handler._process_touch(False, 1.1)
+        self.assertFalse(handler._pending.empty())
+        with mock.patch.object(handler, '_read_touched', side_effect=OSError('disconnected')), \
+                self.assertLogs('hal.drivers.mpr121', level='ERROR'):
+            handler._poll()
+        self.assertTrue(handler._stop.is_set())
+        self.assertTrue(handler._pending.empty())
+        self.assertEqual(handler._detector.update(False, 10), [])
+        bus.close.assert_called_once()
+
     def test_stop_closes_bus_once(self):
         handler = self.make_handler()
         bus = mock.Mock()
@@ -159,26 +241,57 @@ class TestMPR121(unittest.TestCase):
             handler.stop()
         bus.close.assert_called_once()
 
-    def test_action_dispatch_is_bounded_and_discards_pending_on_stop(self):
+    def test_busy_worker_rejects_destructive_outcomes(self):
+        for kind in ('hold', 'triple'):
+            with self.subTest(kind=kind):
+                handler = self.make_handler()
+                handler._action_busy = True
+                handler._detector = mock.Mock()
+                handler._detector.update.return_value = [_GestureEvent(kind, 1, held_s=10)]
+                with self.assertLogs('hal.drivers.mpr121', level='WARNING') as logs:
+                    handler._process_touch(False, 10)
+                self.assertTrue(handler._pending.empty())
+                self.assertIn('reason=action_worker_busy', logs.output[0])
+
+    def test_new_touch_invalidates_pending_destructive_outcome(self):
         handler = self.make_handler()
-        entered = threading.Event()
-        release = threading.Event()
+        handler._process_touch(False, 0)
+        handler._pending.put_nowait((handler._generation, _GestureEvent('hold', 1, held_s=10), time.monotonic()))
+        handler._process_touch(True, 1)
+        self.assertTrue(handler._pending.empty())
 
-        def action(**kwargs):
-            entered.set()
-            release.wait(1)
-
-        with mock.patch('hal.drivers.mpr121.single_click_action', side_effect=action) as callback:
+    def test_expired_destructive_outcome_never_executes(self):
+        handler = self.make_handler()
+        handler._pending.put_nowait((handler._generation, _GestureEvent('triple', 1, count=3), time.monotonic() - 1))
+        with mock.patch.object(handler, '_execute') as execute, \
+                self.assertLogs('hal.drivers.mpr121', level='INFO') as logs:
             handler._action_thread = threading.Thread(target=handler._dispatch)
             handler._action_thread.start()
-            handler._pending.put_nowait(True)
-            self.assertTrue(entered.wait(1))
-            handler._pending.put_nowait(True)
-            self.assertTrue(handler._pending.full())
-            handler._stop.set()
-            release.set()
+            # Observing an empty queue means the worker has consumed the request;
+            # stop then joins it before assertions about execution/logging.
+            deadline = time.monotonic() + 1
+            while not handler._pending.empty() and time.monotonic() < deadline:
+                threading.Event().wait(.001)
             handler.stop()
-        callback.assert_called_once_with(source='MPR121')
+        execute.assert_not_called()
+        self.assertTrue(any('reason=stale_expired_or_stopping' in item for item in logs.output))
+
+    def test_stop_discards_pending_actions(self):
+        handler = self.make_handler()
+        handler._pending.put_nowait((handler._generation, _GestureEvent('triple', 1, count=3), time.monotonic()))
+        with mock.patch.object(handler, '_execute') as execute:
+            handler.stop()
+            handler._dispatch()
+        self.assertTrue(handler._pending.empty())
+        execute.assert_not_called()
+
+    def test_queue_capacity_is_bounded_without_affecting_gesture_count(self):
+        handler = self.make_handler()
+        handler._detector = mock.Mock()
+        handler._detector.update.return_value = [_GestureEvent('cue', index) for index in range(10)]
+        with self.assertLogs('hal.drivers.mpr121', level='WARNING'):
+            handler._process_touch(False, 1)
+        self.assertEqual(handler._pending.qsize(), 2)
 
     def test_transport_close_is_idempotent(self):
         bus = I2CBus.__new__(I2CBus)

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -8,7 +8,7 @@ Lamp supports a mechanical button, TTP223 touchpads and an optional MPR121 capac
 |---|---|---|
 | **GPIO button** | One mechanical button. Used for decisive actions including destructive ones (reboot / shutdown / factory-reset). The mechanical feel and long-hold detection make accidental destructive actions unlikely. | Both Pi 4/5 and OrangePi sun60 |
 | **TTP223 capacitive touchpad** | Two touch pads arranged as a "dog head" surface for petting + soft stop/unmute. No destructive gestures because the IC's FastMode prevents reliable hold detection. | OrangePi sun60 only (4 Pro / A733) |
-| **MPR121 capacitive touch controller** | Up to 12 electrodes; one touch-and-release session calls the shared single-click action. No double-tap or destructive hold mapping. | Lamp with an explicit I²C configuration in `mpr121.json` |
+| **MPR121 capacitive touch controller** | Up to 12 electrodes with GPIO-like click and release-to-commit hold actions, including reboot, shutdown and reset. | Lamp with an explicit I²C configuration in `mpr121.json` |
 
 ## Wiring
 
@@ -65,7 +65,7 @@ Board detection reads `/proc/device-tree/model`:
 | **Hold 5–10 s, then release** | Shutdown OS (TTS announce → release servos → `sudo shutdown -h now`). LED blinks red while armed. | n/a — TTP223 hardware cannot reliably hold (see "FastMode" below) |
 | **Hold 10 s+, then release** | Factory-reset: wipe device state + reboot into AP setup (TTS announce → release servos → POST `/api/system/factory-reset` on the OS server). LED goes solid red while armed. | n/a |
 
-Hold gestures are intentionally only on the GPIO button because the mechanical button gives unambiguous evidence of intent. The sleep and destructive hold tiers **commit on release, not on a timer firing while held**. The destructive tiers escalate from shutdown to factory-reset after 10 s (see "GPIO button detection" below).
+The table above covers GPIO and TTP223. MPR121 also supports release-to-commit holds, as detailed in its detection section; the GPIO LED feedback in this table does not apply to MPR121. The sleep and destructive hold tiers **commit on release, not on a timer firing while held**. The destructive tiers escalate from shutdown to factory-reset after 10 s (see "GPIO button detection" below).
 
 ## Interrupting Lamp while it speaks (barge-in)
 
@@ -242,25 +242,46 @@ unavailable while GPIO/TTP223 continue. Change `bus` if verified wiring uses
 a different controller, then restart HAL.
 
 After initialization, the driver allows 100 ms for sensing to settle before
-reading the initial touch state. It then polls touch status every 10 ms by default. A stable touch followed
-by a stable release of **all selected electrodes** produces one
-`single_click_action(source="MPR121")`; both transitions use the 30 ms default
-debounce. Overlapping touches across electrodes form one session. An electrode
-held at startup is ignored until release. Holding longer does not trigger
-sleep, reboot, shutdown or reset, and there is no double-tap action. The shared
-single-click behavior described above applies after release, without a
-multi-click decision window. A bounded asynchronous action worker prevents
-polling from blocking; excess taps while busy may be coalesced or dropped
-instead of accumulating a backlog. An I²C failure or MPR121 overcurrent fault
-(`OVCF`) is logged and stops this driver while the existing input handlers
-continue.
+reading the initial touch state, then polls every 10 ms by default. Touch and
+release transitions use 30 ms debounce. Overlapping touches across selected
+electrodes form one contact; release means **all selected electrodes** are
+released. A contact held at startup is ignored until release.
+
+MPR121 shares gesture thresholds from `hal/drivers/button_gestures.py` with
+GPIO (also re-exported by `button_actions.py`) and calls the existing action
+functions:
+
+| Gesture | MPR121 action |
+|---|---|
+| First short release in a click burst | `single_click_action(source="MPR121", announce=False)` immediately stops tracking/audio, unmutes as permitted and plays the ack chime. |
+| 1, 2 or 4+ short taps, then 0.4 s quiet | Play the listening cue; repeated taps do not repeat the initial single-click action. |
+| Exactly 3 short taps, then 0.4 s quiet | `triple_click_action` reboots instead of playing the listening cue. |
+| Hold 2–<5 s, then release | `hold_release_action` enters sleepy. |
+| Hold 5–<10 s, then release | `hold_release_action` shuts down. |
+| Hold ≥10 s, then release | `hold_release_action` performs factory reset. |
+
+A short contact lasts less than 2 s. The click window does not resolve while
+any selected electrode remains touched. Releasing a hold clears the pending
+click burst. Destructive actions never commit while held. MPR121 does not
+provide the GPIO button's hold-tier LED feedback.
+
+The bounded asynchronous action worker keeps polling responsive. Excess
+actions may be dropped; a newer touch, stop or hardware error
+invalidates pending older destructive actions and listening cues. An I²C
+failure or MPR121 overcurrent fault (`OVCF`) is logged and stops this driver
+while the existing input handlers continue.
+
+The hardware verification above covered the earlier single-click behavior.
+These additional click/hold mappings are verified with mocked local tests;
+they have not been deployed or exercised destructively on the live device.
 
 Operation logs use logger `hal.drivers.mpr121` in the normal HAL log/journal;
 there is no separate raw trace file. INFO entries cover initialization and
 configuration (bus, address, electrodes, thresholds and timing), per-electrode
 raw touch/release changes, debounced transitions, suppressed startup touches,
-tap queueing/coalescing, action begin/end and lifecycle. `tap_id` correlates
-accepted taps with queued, coalesced or executed actions. Failures include
+click counts, hold duration/tier, action queueing/discarding, action begin/end
+and lifecycle. `gesture_id` correlates a click burst or hold with queued,
+discarded or executed actions. Failures include
 error logs. Unchanged 10 ms polls produce no INFO entry, so idle operation does not
 flood the log. Follow the service log with `journalctl -u hal.service -f` and
 filter for `hal.drivers.mpr121` when investigating a missed or duplicate tap.
@@ -291,7 +312,7 @@ After a session ends:
 
 **On by default** since 2026-08-27, after hands-on validation on orange-lamp across tap, fast and slow double tap, pet and swipe. Setting `HAL_TOUCH_SWIPE=false` restores the two-gesture behaviour in one step and without a redeploy — that is the rollback if a field unit misbehaves.
 
-Turning it on means a double tap toggles the **microphone** and a swipe **sleeps** the device. Both are reversible (double tap again; one tap wakes), and nothing destructive is reachable here — FastMode cannot measure a hold, so reboot / shutdown / factory-reset stay on the mechanical button.
+Turning it on means a double tap toggles the **microphone** and a swipe **sleeps** the device. Both are reversible (double tap again; one tap wakes), and nothing destructive is reachable here — FastMode cannot measure a hold, so TTP223 cannot trigger reboot / shutdown / factory-reset; those gestures are provided by the mechanical button and MPR121.
 
 **The signal is *when* pads fire, not which.** Device-measured on orange-lamp, 2026-08-27 — inter-pad gaps inside a single contact:
 
@@ -442,7 +463,8 @@ Phrases are intentionally short — they fire mid-stroke and need to feel respon
 | `hal/board/ttp223.py` | Device-owned TTP223 configuration loader with legacy fallback |
 | `hal/drivers/ttp223.py` | TTP223 capacitive touchpad handler (OrangePi sun60 only) |
 | `hal/board/mpr121.py` | Device-owned MPR121 configuration loader and validation |
-| `hal/drivers/mpr121.py` | Optional I²C MPR121 touch-and-release handler |
+| `hal/drivers/mpr121.py` | Optional I²C MPR121 click/hold handler |
+| `hal/drivers/button_gestures.py` | Shared GPIO/MPR121 gesture thresholds |
 | `hal/drivers/button_actions.py` | Shared action functions + localized phrase pools |
 | `hal/presets.py` | Language code constants (`LANG_EN`, etc.) |
 | `hal/test_ttp223_probe_orangepi.py` | Standalone pad probe (stdlib ioctl, no gpiod). `info` reads line state with HAL running; `watch` maps pad→line and needs `hal.service` stopped. Lines come from the selected device’s `ttp223.json`, with the same legacy board-profile fallback as HAL. Select the device with `--device-type`. |

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -8,7 +8,7 @@ Lamp hỗ trợ nút cơ học, touchpad TTP223 và bộ điều khiển cảm �
 |---|---|---|
 | **Nút GPIO** | Một nút bấm cơ. Dùng cho các hành động dứt khoát kể cả destructive (reboot / shutdown / factory-reset). Cảm giác cơ + detect giữ lâu khiến destructive action khó xảy ra do vô tình. | Pi 4/5 và OrangePi sun60 |
 | **Touchpad cảm ứng TTP223** | Hai pad chạm xếp như "đầu cún" để vuốt ve + stop/unmute nhẹ. Không có destructive gesture vì FastMode của IC không cho detect giữ lâu tin cậy. | Chỉ OrangePi sun60 (4 Pro / A733) |
-| **Bộ điều khiển cảm ứng MPR121** | Tối đa 12 electrode; một phiên chạm rồi nhả gọi action single-click dùng chung. Không map double-tap hay giữ để thực hiện hành động destructive. | Lamp khai báo cấu hình I²C cụ thể trong `mpr121.json` |
+| **Bộ điều khiển cảm ứng MPR121** | Tối đa 12 electrode, hỗ trợ click và giữ rồi nhả như GPIO, gồm reboot, shutdown và reset. | Lamp khai báo cấu hình I²C cụ thể trong `mpr121.json` |
 
 ## Wiring
 
@@ -62,7 +62,7 @@ Board được detect qua `/proc/device-tree/model`:
 | **Giữ 5–10 s rồi nhả** | Shutdown OS (TTS báo → release servo → `sudo shutdown -h now`). LED nháy đỏ khi đã arm. | n/a — phần cứng TTP223 không hold đáng tin được (xem "FastMode" dưới) |
 | **Giữ 10 s+ rồi nhả** | Factory-reset: wipe state thiết bị + reboot vào AP setup (TTS báo → release servo → POST `/api/system/factory-reset` trên OS server). LED đỏ đứng khi đã arm. | n/a |
 
-Gesture giữ chỉ có trên nút GPIO vì nút cơ học cho bằng chứng intent rõ ràng. Mức sleep và các mức destructive **commit khi nhả, không phải khi timer fire lúc đang giữ**. Các mức destructive escalate từ shutdown sang factory-reset sau 10 s (xem "Detect nút GPIO" dưới).
+Bảng trên mô tả GPIO và TTP223. MPR121 cũng hỗ trợ giữ rồi nhả để thực hiện action, xem phần detect riêng; phản hồi LED GPIO trong bảng không áp dụng cho MPR121. Mức sleep và các mức destructive **commit khi nhả, không phải khi timer fire lúc đang giữ**. Các mức destructive escalate từ shutdown sang factory-reset sau 10 s (xem "Detect nút GPIO" dưới).
 
 ## Cắt Lamp giữa câu (barge-in)
 
@@ -236,25 +236,46 @@ Nếu thiếu `/dev/i2c-0`, khởi tạo log lỗi và MPR121 không hoạt đ�
 GPIO/TTP223 tiếp tục chạy. Sửa `bus` nếu wiring đã xác minh dùng controller
 khác, rồi restart HAL.
 
-Sau khởi tạo, driver chờ 100 ms cho cảm biến ổn định trước khi đọc trạng thái
-chạm ban đầu. Sau đó driver đọc touch status mỗi 10 ms theo mặc định. Chạm ổn định rồi nhả ổn định
-**toàn bộ electrode được chọn** tạo một lần
-`single_click_action(source="MPR121")`; cả hai chuyển trạng thái dùng debounce
-mặc định 30 ms. Các lần chạm chồng nhau trên nhiều electrode tính là một
-phiên. Electrode đang bị giữ khi startup bị bỏ qua đến khi nhả. Giữ lâu không
-kích hoạt sleep, reboot, shutdown hay reset, và không có action double-tap.
-Hành vi single-click dùng chung mô tả ở trên chạy sau khi nhả, không chờ cửa
-sổ phân loại nhiều lần click. Worker action bất đồng bộ có giới hạn giúp
-polling không bị chặn; tap dư khi worker bận có thể được gộp hoặc bỏ để tránh
-tích tụ hàng đợi. Lỗi I²C hoặc cờ quá dòng MPR121 (`OVCF`) được log và dừng
-driver này, các handler đầu vào hiện có tiếp tục chạy.
+Sau khởi tạo, driver chờ cảm biến ổn định 100 ms trước khi đọc trạng thái
+chạm ban đầu, rồi poll mỗi 10 ms theo mặc định. Chuyển trạng thái chạm và
+nhả dùng debounce 30 ms. Chạm chồng nhau trên các electrode được chọn tính
+là một contact; nhả nghĩa là **toàn bộ electrode được chọn** đã nhả.
+Contact đang bị giữ khi startup bị bỏ qua đến khi nhả.
+
+MPR121 dùng chung ngưỡng cử chỉ từ `hal/drivers/button_gestures.py` với GPIO
+(được `button_actions.py` re-export) và gọi các action hiện có:
+
+| Cử chỉ | Action MPR121 |
+|---|---|
+| Lần nhả ngắn đầu tiên trong chuỗi click | `single_click_action(source="MPR121", announce=False)` lập tức dừng tracking/audio, unmute khi được phép và phát ack chime. |
+| 1, 2 hoặc 4+ tap ngắn, rồi yên 0.4 s | Phát cue nghe; các tap lặp không gọi lại action single-click ban đầu. |
+| Đúng 3 tap ngắn, rồi yên 0.4 s | `triple_click_action` reboot thay vì phát cue nghe. |
+| Giữ 2–<5 s rồi nhả | `hold_release_action` vào sleepy. |
+| Giữ 5–<10 s rồi nhả | `hold_release_action` shutdown. |
+| Giữ ≥10 s rồi nhả | `hold_release_action` factory reset. |
+
+Contact ngắn kéo dài dưới 2 s. Cửa sổ click không phân giải khi còn bất kỳ
+electrode được chọn nào đang chạm. Nhả sau giữ xóa chuỗi click đang chờ.
+Action destructive không chạy khi còn giữ. MPR121 chưa có phản hồi LED theo
+mức giữ như nút GPIO.
+
+Worker action bất đồng bộ có hàng đợi giới hạn giữ polling phản hồi kịp thời.
+Action dư có thể bị bỏ; chạm mới, stop hoặc lỗi phần cứng làm mất
+hiệu lực các action destructive và cue nghe cũ đang chờ. Lỗi I²C hoặc cờ quá
+dòng MPR121 (`OVCF`) được log và dừng driver này, các handler đầu vào hiện có
+tiếp tục chạy.
+
+Lần xác minh phần cứng ở trên chỉ kiểm tra hành vi single-click trước đây.
+Các mapping click/giữ bổ sung được kiểm tra bằng test mock local; chưa deploy
+hoặc chạy hành động destructive trên device thật.
 
 Log hoạt động dùng logger `hal.drivers.mpr121` trong log/journal HAL thông
 thường; không tạo file raw trace riêng. Log INFO gồm khởi tạo và cấu hình
 (bus, địa chỉ, electrode, ngưỡng và thời gian), thay đổi chạm/nhả thô trên từng
 electrode, chuyển trạng thái đã debounce, chạm lúc startup bị bỏ qua, xếp hàng
-hoặc gộp tap, bắt đầu/kết thúc action và vòng đời driver. `tap_id` liên kết
-tap được nhận với action đã xếp hàng, gộp hoặc thực thi. Khi lỗi có log lỗi.
+hoặc bỏ action, số click, thời lượng/mức giữ, bắt đầu/kết thúc action và
+vòng đời driver. `gesture_id` liên kết chuỗi click hoặc giữ với action đã
+xếp hàng, bỏ hoặc thực thi. Khi lỗi có log lỗi.
 Các lần poll 10 ms không đổi trạng thái không tạo log INFO, tránh tràn log
 khi không chạm. Theo dõi bằng `journalctl -u hal.service -f` và lọc
 `hal.drivers.mpr121` khi cần tìm nguyên nhân mất hoặc lặp tap.
@@ -285,7 +306,7 @@ Sau khi session kết thúc:
 
 **Mặc định bật** từ 2026-08-27, sau khi kiểm chứng trực tiếp trên orange-lamp với tap, double tap nhanh và chậm, pet và swipe. Đặt `HAL_TOUCH_SWIPE=false` sẽ khôi phục hành vi hai-cử-chỉ trong một bước và không cần deploy lại — đó là đường lùi nếu một máy ngoài thực địa hành xử sai.
 
-Bật nó lên nghĩa là một cú double tap sẽ toggle **microphone** và một cú swipe sẽ đưa thiết bị vào **giấc ngủ**. Cả hai đều đảo ngược được (double tap lần nữa; một cú tap là thức dậy), và không có hành động phá hủy nào với tới được từ đây — FastMode không đo được thao tác giữ, nên reboot / shutdown / factory-reset vẫn ở lại trên nút bấm cơ.
+Bật nó lên nghĩa là một cú double tap sẽ toggle **microphone** và một cú swipe sẽ đưa thiết bị vào **giấc ngủ**. Cả hai đều đảo ngược được (double tap lần nữa; một cú tap là thức dậy), và không có hành động phá hủy nào với tới được từ đây — FastMode không đo được thao tác giữ, nên TTP223 không kích hoạt reboot / shutdown / factory-reset; các cử chỉ đó có trên nút cơ và MPR121.
 
 **Tín hiệu nằm ở *thời điểm* các pad bắn, không phải pad nào.** Đo trên orange-lamp ngày 2026-08-27 — khoảng cách giữa các pad bên trong một lần tiếp xúc:
 
@@ -435,7 +456,8 @@ Phrase cố tình ngắn — chúng fire giữa lúc vuốt nên cần cảm gi�
 | `hal/board/ttp223.py` | Đọc cấu hình TTP223 theo device, có fallback cũ |
 | `hal/drivers/ttp223.py` | Handler touchpad cảm ứng TTP223 (chỉ OrangePi sun60) |
 | `hal/board/mpr121.py` | Đọc và kiểm tra cấu hình MPR121 do device quản lý |
-| `hal/drivers/mpr121.py` | Handler I²C MPR121 tùy chọn, detect chạm rồi nhả |
+| `hal/drivers/mpr121.py` | Handler I²C MPR121 tùy chọn, detect click/giữ |
+| `hal/drivers/button_gestures.py` | Ngưỡng cử chỉ dùng chung GPIO/MPR121 |
 | `hal/drivers/button_actions.py` | Hàm action chung + pool phrase local |
 | `hal/presets.py` | Hằng số mã ngôn ngữ (`LANG_EN`, v.v.) |
 | `hal/test_ttp223_probe_orangepi.py` | Probe pad độc lập (ioctl thuần stdlib, không cần gpiod). `info` đọc trạng thái line khi HAL vẫn chạy; `watch` map pad→line và cần dừng `hal.service`. Line lấy từ `ttp223.json` của device được chọn, fallback về board profile cũ giống HAL. Chọn device bằng `--device-type`. |


### PR DESCRIPTION
MPR121 previously supported only single-click input. Add exactly three taps within the shared 0.4-second tap window to reboot, and release-based holds for sleep (2–<5 seconds), shutdown (5–<10 seconds), and factory reset (≥10 seconds), using the existing GPIO action functions and shared timing constants.

Keep the immediate single-click action on the first short release of a burst. Two or four-plus taps do not reboot. Recognize gestures from debounced electrode state, log gesture IDs and hold durations, and reject pending stale, expired, or busy destructive actions. Update English and Vietnamese documentation.

Validation:
- Focused pytest suite: 128 passed, 55 subtests passed (MPR121, button actions/config, TTP223, and board tests).
- `uv run --no-project --with pyflakes python hal/scripts/lint.py`: clean.
- `git diff --check`: clean.
- New power gestures are covered with mocked actions; not yet deployed or tested destructively on hardware.

Based on current main after #362; this PR contains only the additional MPR121 gesture changes.
