### PR TITLE
hal: share hold LED feedback across GPIO and MPR121

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -96,9 +96,13 @@ contact. It shares GPIO gesture thresholds in `hal/drivers/button_gestures.py`:
 the first short release immediately calls single-click with `announce=False`;
 a 0.4 s quiet window produces the listening cue for 1/2/4+ clicks or reboot
 for exactly 3. Holds commit only on release: 2–<5 s sleepy, 5–<10 s shutdown,
-≥10 s factory reset. Boot-held contacts are suppressed; MPR121 has no hold-tier
-LED feedback. New click/hold mappings have mocked local verification only;
-the earlier live test covered single-click. Defaults are address
+≥10 s factory reset. While held, debounced hold-tier events use the same
+`HoldLEDFeedback` in `hal/drivers/button_actions.py` and `BUTTON_LED_PRESETS`
+as GPIO: purple blinking at 2 Hz for 2–<5 s, red blinking
+at 2 Hz for 5–<10 s, and solid red from 10 s. Release stops blinking; accepted
+shutdown/reset actions reaffirm solid red before execution. Boot-held contacts
+show no feedback; stop or hardware failure cancels it. LED feedback is verified
+with mocked local tests; it has not been checked on the live device. Defaults are address
 `0x5A`, electrodes 0–11, touch/release thresholds 2/1, autoconfiguration enabled,
 10 ms polling and 30 ms debounce, with 100 ms startup settling. An I²C failure
 or overcurrent fault stops only this driver. Logger `hal.drivers.mpr121` records

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -93,9 +93,12 @@ nhả đã debounce. Ngưỡng cử chỉ dùng chung GPIO trong
 `hal/drivers/button_gestures.py`: lần nhả ngắn đầu tiên gọi single-click ngay
 với `announce=False`; sau 0.4 s yên, 1/2/4+ click phát cue nghe, đúng 3 click
 thì reboot. Giữ chỉ thực hiện khi nhả: 2–<5 s sleepy, 5–<10 s shutdown,
-≥10 s factory reset. Chạm giữ lúc startup bị bỏ qua; MPR121 chưa có LED theo
-mức giữ. Mapping click/giữ mới chỉ kiểm tra bằng test mock local; lần test
-trên device trước đó chỉ kiểm tra single-click. Mặc định:
+≥10 s factory reset. Khi giữ, event mức giữ đã debounce dùng cùng `HoldLEDFeedback`
+trong `hal/drivers/button_actions.py` và `BUTTON_LED_PRESETS` với GPIO: tím nháy 2 Hz ở 2–<5 s, đỏ nháy 2 Hz ở
+5–<10 s và đỏ đứng từ 10 s. Nhả thì dừng nháy; action shutdown/reset được
+chấp nhận đặt lại đỏ đứng trước khi chạy. Chạm giữ lúc startup không hiện
+phản hồi; stop hoặc lỗi phần cứng hủy phản hồi. LED được kiểm tra bằng test
+mock local, chưa kiểm tra trên device thật. Mặc định:
 địa chỉ `0x5A`, electrode 0–11, ngưỡng chạm/nhả 2/1, bật autoconfig,
 polling 10 ms và debounce 30 ms, chờ ổn định 100 ms lúc startup. Lỗi I²C hoặc
 cờ quá dòng chỉ dừng driver này. Logger `hal.drivers.mpr121` ghi cấu hình,

--- a/hal/drivers/button_actions.py
+++ b/hal/drivers/button_actions.py
@@ -648,3 +648,131 @@ def factory_reset_action(source: str = "button"):
         )
     except Exception as e:
         logger.error("factory-reset HTTP call failed: %s", e)
+
+
+# Hold LED feedback shared by GPIO and capacitive button inputs.
+LED_OFF = (0, 0, 0)
+LED_BLINK_HALF_PERIOD_S = 0.25
+
+
+def warn_color(tier):
+    """Read the live device-overridden preset on every dispatch."""
+    from hal.presets import BUTTON_LED_PRESETS
+
+    return tuple(BUTTON_LED_PRESETS[tier]["color"])
+
+
+def dispatch_led(color, *, still_current=None):
+    """Preempt emotion effects exactly as the GPIO button does."""
+    import hal.app_state as state
+    from hal.drivers.base import Priority
+    from hal.presets import RGB_CMD_SOLID
+
+    rgb = state.rgb_service
+    if rgb is None:
+        return
+    try:
+        state._stop_current_effect()
+        if still_current is None or still_current():
+            rgb.dispatch(RGB_CMD_SOLID, color, priority=Priority.HIGH)
+    except Exception:
+        logger.warning("Button LED dispatch failed", exc_info=True)
+
+
+class HoldLEDFeedback:
+    """Consume accepted hold tiers without blocking the hardware poll loop.
+
+    A single worker owns RGB calls, including commit colors. Release cancels
+    future blinking immediately; commit waits for any in-flight RGB call so an
+    old blink cannot overwrite the ensuing sleep/shutdown/reset action.
+    """
+
+    def __init__(self):
+        self._condition = threading.Condition()
+        self._thread = None
+        self._closed = False
+        self._generation = 0
+        self._completed = 0
+        self._tier = 0
+        self._committing = False
+
+    def _request(self, tier, committing=False):
+        with self._condition:
+            if self._closed:
+                return None
+            self._generation += 1
+            self._tier = tier
+            self._committing = committing
+            if self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run, daemon=True, name="button-hold-led",
+                )
+                self._thread.start()
+            self._condition.notify_all()
+            return self._generation
+
+    def set_tier(self, tier):
+        self._request(tier)
+
+    def release(self):
+        with self._condition:
+            if self._thread is None:
+                return
+            self._request(0)
+
+    def commit(self, held_s):
+        tier = 3 if held_s >= FACTORY_RESET_DURATION else 2 if held_s >= LONG_PRESS_DURATION else 0
+        generation = self._request(tier, committing=True)
+        if generation is None:
+            return False
+        with self._condition:
+            self._condition.wait_for(
+                lambda: self._closed or self._completed >= generation,
+            )
+
+            return not self._closed and self._generation == generation
+
+    def _is_current(self, generation):
+        with self._condition:
+            return not self._closed and self._generation == generation
+
+    def stop(self):
+        # Do not join here: poll cleanup must never wait for an RGB effect.
+        with self._condition:
+            self._closed = True
+            self._condition.notify_all()
+
+    def _run(self):
+        generation = -1
+        blink_on = False
+        while True:
+            with self._condition:
+                if self._closed:
+                    return
+                changed = generation != self._generation
+                if changed:
+                    generation = self._generation
+                    blink_on = False
+                tier, committing = self._tier, self._committing
+            try:
+                if tier:
+                    name = {1: "sleep_warn", 2: "shutdown_warn", 3: "factory_reset"}[tier]
+                    blink_on = not blink_on
+                    color = warn_color(name)
+                    dispatch_led(
+                        color if committing or tier == 3 or blink_on else LED_OFF,
+                        still_current=lambda: self._is_current(generation),
+                    )
+            except Exception:
+                # Missing RGB/presets must never prevent the semantic action.
+                logger.warning("Button hold LED feedback failed", exc_info=True)
+            with self._condition:
+                self._completed = max(self._completed, generation)
+                self._condition.notify_all()
+                if self._closed:
+                    return
+                timeout = LED_BLINK_HALF_PERIOD_S if tier in (1, 2) and not committing else None
+                self._condition.wait_for(
+                    lambda: self._closed or self._generation != generation,
+                    timeout=timeout,
+                )

--- a/hal/drivers/gpio_button.py
+++ b/hal/drivers/gpio_button.py
@@ -28,14 +28,9 @@ import logging
 import threading
 import time
 
-import hal.app_state as state
-from hal.presets import (
-    BUTTON_LED_PRESETS,
-    RGB_CMD_SOLID,
-)
 from hal.board.gpio_button import ButtonConfig
-from hal.drivers.base import Priority
 from hal.drivers.button_actions import (
+    HoldLEDFeedback,
     DOUBLE_CLICK_WINDOW,
     FACTORY_RESET_DURATION,
     LONG_PRESS_DURATION,
@@ -47,26 +42,6 @@ from hal.drivers.button_actions import (
 )
 
 logger = logging.getLogger(__name__)
-
-# LED feedback during hold (Tier B design from the factory-reset discussion).
-# Purple blink at 2–5s tells the user sleepy is armed. Red blink at 5–10s
-# tells them shutdown is armed. Red solid at 10s+ means factory-reset.
-# Both dispatch at HIGH priority so they preempt the current emotion LED.
-# The purple comes from sleepy's previous display preset.
-# The three warn colors live in hal/presets.py (BUTTON_LED_PRESETS) alongside
-# the other LED presets, so a device can restyle them via presets.json — this
-# file owns the staging (when to blink, when to go solid), not the look. Read
-# them through _warn_color() at call time: the overlay merges the table in
-# place at boot, so a name imported once would keep the pre-override value.
-LED_OFF = (0, 0, 0)
-
-
-def _warn_color(tier: str):
-    """Current color for a button hold tier, read from the (possibly
-    device-overridden) preset table at call time."""
-    return tuple(BUTTON_LED_PRESETS[tier]["color"])
-# Blink: 0.25 s on + 0.25 s off = 2 Hz full cycle.
-LED_BLINK_HALF_PERIOD_S = 0.25
 
 class GPIOButtonHandler:
     def __init__(self, config: ButtonConfig):
@@ -83,59 +58,37 @@ class GPIOButtonHandler:
         # (per-watcher stop) so the previous watcher exits cleanly without
         # racing the new one. None when no hold is active.
         self._hold_watcher_stop = None
+        self._hold_lock = threading.Lock()
+        self._hold_led = HoldLEDFeedback()
         self._chip = config.chip
         self._pin = config.line
         self._debounce_ns = config.debounce_ns
         self._last_press_tick = 0
         self._last_release_tick = 0
 
-    def _dispatch_led(self, color):
-        """Push a solid color to RGB service at HIGH priority so it preempts
-        the current emotion LED. Silent no-op when RGB service unavailable
-        (dev machines, hardware issues — button still works)."""
-        rgb = state.rgb_service
-        if rgb is None:
-            return
-        try:
-            state._stop_current_effect()
-            rgb.dispatch(RGB_CMD_SOLID, color, priority=Priority.HIGH)
-        except Exception as e:
-            logger.warning("LED dispatch failed: %s", e)
-
     def _hold_watcher(self, stop_event):
-        """Poll hold duration and update LED at threshold crossings. One
-        watcher thread per press — release sets stop_event and a new press
-        starts a fresh watcher with a new Event so the two never race."""
-        last_stage = -1
-        blink_on = False
+        """Report hold tiers; shared feedback owns all LED animation."""
+        last_stage = 0
         while not stop_event.is_set():
-            held = time.monotonic() - self._press_start
-            if held >= FACTORY_RESET_DURATION:
-                stage = 3  # red solid — armed for factory-reset
-            elif held >= LONG_PRESS_DURATION:
-                stage = 2  # red blink 2 Hz — armed for shutdown
-            elif held >= SLEEP_HOLD_DURATION:
-                stage = 1  # purple blink 2 Hz — armed for sleepy
-            else:
-                stage = 0  # quiet — short tap
-
-            # Stage 3 entry: set red solid once (no blink). Subsequent loops
-            # leave it alone so the LED doesn't flicker.
-            if stage != last_stage and stage == 3:
-                self._dispatch_led(_warn_color("factory_reset"))
-            last_stage = stage
-
-            if stage in (1, 2):
-                # Half-period toggle gives a 2 Hz blink (0.25 s on, 0.25 s off).
-                blink_on = not blink_on
-                color = _warn_color("sleep_warn" if stage == 1 else "shutdown_warn")
-                self._dispatch_led(color if blink_on else LED_OFF)
-                wait = LED_BLINK_HALF_PERIOD_S
-            else:
-                wait = 0.1
-
-            if stop_event.wait(timeout=wait):
+            with self._hold_lock:
+                if stop_event.is_set() or self._hold_watcher_stop is not stop_event:
+                    return
+                held = time.monotonic() - self._press_start
+                stage = (3 if held >= FACTORY_RESET_DURATION else
+                         2 if held >= LONG_PRESS_DURATION else
+                         1 if held >= SLEEP_HOLD_DURATION else 0)
+                if stage != last_stage:
+                    self._hold_led.set_tier(stage)
+                    last_stage = stage
+            if stop_event.wait(timeout=0.1):
                 return
+
+    def _run_hold_action(self, held):
+        if self._hold_led.commit(held) is False:
+            return
+        action = "factory-reset" if held >= FACTORY_RESET_DURATION else "shutdown" if held >= LONG_PRESS_DURATION else "sleepy"
+        logger.info("GPIO button hold %.1fs -- %s", held, action)
+        hold_release_action(held, source="GPIO button")
 
     def start(self):
         import lgpio
@@ -175,14 +128,14 @@ class GPIOButtonHandler:
             # so the user can always cancel by releasing before the next
             # threshold (or escalate from shutdown → factory-reset by
             # holding past 10s). LED feedback runs in a watcher thread.
-            self._press_start = time.monotonic()
-            self._pressed = True
-            # Signal any leftover watcher (shouldn't exist due to release
-            # cleanup, defensive) then start a fresh one with a new Event.
-            if self._hold_watcher_stop is not None:
-                self._hold_watcher_stop.set()
-            new_stop = threading.Event()
-            self._hold_watcher_stop = new_stop
+            with self._hold_lock:
+                self._press_start = time.monotonic()
+                self._pressed = True
+                if self._hold_watcher_stop is not None:
+                    self._hold_watcher_stop.set()
+                self._hold_led.release()
+                new_stop = threading.Event()
+                self._hold_watcher_stop = new_stop
             threading.Thread(
                 target=self._hold_watcher,
                 args=(new_stop,),
@@ -199,13 +152,12 @@ class GPIOButtonHandler:
             logger.warning("GPIO button release without matching press -- ignoring")
             return
         self._pressed = False
-        # Stop LED watcher. Watcher exits within its current sleep (< 0.5 s).
-        # LED stays at whatever colour it last dispatched — destructive
-        # branches below reaffirm with a solid colour so it doesn't freeze
-        # mid-blink.
-        if self._hold_watcher_stop is not None:
-            self._hold_watcher_stop.set()
-            self._hold_watcher_stop = None
+        # Cancel blinking without blocking the GPIO callback on RGB I/O.
+        with self._hold_lock:
+            if self._hold_watcher_stop is not None:
+                self._hold_watcher_stop.set()
+                self._hold_watcher_stop = None
+            self._hold_led.release()
 
         held = time.monotonic() - self._press_start
         if held >= SLEEP_HOLD_DURATION:
@@ -213,27 +165,14 @@ class GPIOButtonHandler:
             if self._click_timer:
                 self._click_timer.cancel()
                 self._click_timer = None
-            if held >= FACTORY_RESET_DURATION:
-                logger.info("GPIO button hold %.1fs -- factory-reset", held)
-                # Lock the LED at red solid until reboot kills us. Watcher already
-                # set it but reaffirm (idempotent at HIGH priority).
-                self._dispatch_led(_warn_color("factory_reset"))
-            elif held >= LONG_PRESS_DURATION:
-                logger.info("GPIO button hold %.1fs -- shutdown", held)
-                # Freeze LED at red solid (was blinking). Confirms the gesture
-                # committed to shutdown, stays on through the 5 s TTS announce.
-                self._dispatch_led(_warn_color("shutdown_warn"))
-            else:
-                logger.info("GPIO button hold %.1fs -- sleepy", held)
 
             # Edge handling only supplies the released-duration signal. The
             # action library owns which semantic action that duration selects.
             # It may wait for a cue or release servos, so keep the GPIO callback
             # short and never block subsequent hardware edges.
             threading.Thread(
-                target=hold_release_action,
+                target=self._run_hold_action,
                 args=(held,),
-                kwargs={"source": "GPIO button"},
                 daemon=True,
                 name="gpio-button-hold-action",
             ).start()

--- a/hal/drivers/mpr121.py
+++ b/hal/drivers/mpr121.py
@@ -199,6 +199,17 @@ class MPR121Handler:
         self._generation = 0
         self._action_busy = False
         self._gesture_lock = threading.Lock()
+        self._hold_led = None
+
+    def _feedback(self):
+        with self._gesture_lock:
+            if self._hold_led is None:
+                from hal.drivers.button_actions import HoldLEDFeedback
+
+                self._hold_led = HoldLEDFeedback()
+            if self._stop.is_set():
+                self._hold_led.stop()
+            return self._hold_led
 
     def _initialize(self):
         config = self._config
@@ -257,6 +268,9 @@ class MPR121Handler:
             self._config.autoconfig, self._config.poll_ms, self._config.debounce_ms,
         )
         self._last_raw_mask = None
+        if self._hold_led is not None:
+            self._hold_led.stop()
+        self._hold_led = None
         self._stop.clear()
         self._pending = queue.Queue(maxsize=2)
         self._detector = _GestureRecognizer(self._config.debounce_ms)
@@ -274,6 +288,8 @@ class MPR121Handler:
         except Exception:
             logger.exception("MPR121 event=start_failed")
             self._stop.set()
+            if self._hold_led is not None:
+                self._hold_led.stop()
             self._close_bus()
             raise
         logger.info("MPR121 ready on i2c-%d address 0x%02x electrodes %s", self._config.bus, self._config.address, self._config.electrodes)
@@ -304,6 +320,11 @@ class MPR121Handler:
             logger.info("MPR121 event=gesture kind=%s gesture_id=%d count=%d held_s=%.3f", event.kind, event.gesture_id, event.count, event.held_s)
             if event.kind == "invalidate":
                 self._invalidate_pending("new_touch_or_hold")
+            elif event.kind == "hold_tier":
+                self._feedback().set_tier(event.count)
+            elif event.kind == "release":
+                if self._hold_led is not None:
+                    self._hold_led.release()
             elif event.kind in ("single", "cue", "triple", "hold"):
                 with self._gesture_lock:
                     if self._stop.is_set():
@@ -329,6 +350,8 @@ class MPR121Handler:
             self._stop.set()
         finally:
             self._detector.cancel()
+            if self._hold_led is not None:
+                self._hold_led.stop()
             self._invalidate_pending("poll_stopped")
             self._close_bus()
             logger.info("MPR121 event=worker_stopped worker=poll")
@@ -341,6 +364,9 @@ class MPR121Handler:
         elif event.kind == "triple":
             triple_click_action(source="MPR121")
         elif event.kind == "hold":
+            if self._feedback().commit(event.held_s) is False:
+                logger.info("MPR121 event=action_discarded gesture_id=%d action=hold reason=feedback_cancelled", event.gesture_id)
+                return
             hold_release_action(event.held_s, source="MPR121")
 
     def _dispatch(self):
@@ -378,6 +404,8 @@ class MPR121Handler:
     def stop(self):
         logger.info("MPR121 event=stop_requested")
         self._stop.set()
+        if self._hold_led is not None:
+            self._hold_led.stop()
         self._invalidate_pending("stop_requested")
         for thread in (self._poll_thread, self._action_thread):
             if thread is not None and thread.ident is not None:

--- a/hal/test/test_button_feedback.py
+++ b/hal/test/test_button_feedback.py
@@ -1,0 +1,194 @@
+"""Shared GPIO/MPR hold feedback, including slow RGB dispatch ordering."""
+
+import threading
+import unittest
+from unittest.mock import Mock, patch
+
+from hal.board.gpio_button import ButtonConfig
+from hal.drivers import button_actions as feedback
+from hal.drivers.gpio_button import GPIOButtonHandler
+
+
+class HoldLEDFeedbackTests(unittest.TestCase):
+    def test_blink_tiers_and_solid_reset(self):
+        colors = []
+        condition = threading.Condition()
+
+        def dispatch(color, **kwargs):
+            with condition:
+                colors.append(color)
+                condition.notify_all()
+
+        def await_count(count):
+            with condition:
+                self.assertTrue(condition.wait_for(lambda: len(colors) >= count, timeout=2))
+
+        led = feedback.HoldLEDFeedback()
+        with patch.object(feedback, "dispatch_led", side_effect=dispatch), patch.object(
+            feedback, "warn_color", side_effect=lambda tier: tier,
+        ), patch.object(feedback, "LED_BLINK_HALF_PERIOD_S", 0.01):
+            try:
+                led.set_tier(1)
+                await_count(2)
+                self.assertEqual(colors[:2], ["sleep_warn", feedback.LED_OFF])
+                led.set_tier(2)
+                with condition:
+                    self.assertTrue(condition.wait_for(lambda: "shutdown_warn" in colors, timeout=2))
+                led.set_tier(3)
+                with condition:
+                    self.assertTrue(condition.wait_for(lambda: "factory_reset" in colors, timeout=2))
+                led.release()
+                led.commit(2)
+                self.assertEqual(colors[-1], "factory_reset")
+            finally:
+                led.stop()
+                led._thread.join(timeout=2)
+
+    def test_release_is_nonblocking_and_commit_serializes_old_blink(self):
+        entered, unblock, committed = threading.Event(), threading.Event(), threading.Event()
+        colors = []
+
+        def dispatch(color, **kwargs):
+            colors.append(color)
+            if len(colors) == 1:
+                entered.set()
+                self.assertTrue(unblock.wait(2))
+
+        led = feedback.HoldLEDFeedback()
+        with patch.object(feedback, "dispatch_led", side_effect=dispatch), patch.object(
+            feedback, "warn_color", side_effect=lambda tier: tier,
+        ):
+            try:
+                led.set_tier(1)
+                self.assertTrue(entered.wait(2))
+                led.release()
+                action = threading.Thread(target=lambda: (led.commit(5), committed.set()))
+                action.start()
+                self.assertFalse(committed.is_set())
+                unblock.set()
+                self.assertTrue(committed.wait(2))
+                action.join(2)
+                self.assertEqual(colors, ["sleep_warn", "shutdown_warn"])
+                led.commit(10)
+                self.assertEqual(colors[-1], "factory_reset")
+            finally:
+                unblock.set()
+                led.stop()
+                led._thread.join(2)
+
+    def test_stop_cancels_future_blinks_without_waiting_for_rgb(self):
+        entered, unblock = threading.Event(), threading.Event()
+        led = feedback.HoldLEDFeedback()
+        with patch.object(feedback, "dispatch_led", side_effect=lambda _, **kwargs: (entered.set(), unblock.wait(2))) as dispatch, patch.object(feedback, "warn_color", return_value=(1, 2, 3)):
+            led.set_tier(1)
+            self.assertTrue(entered.wait(2))
+            led.stop()
+            unblock.set()
+            led._thread.join(2)
+            self.assertFalse(led._thread.is_alive())
+            self.assertEqual(dispatch.call_count, 1)
+            led.commit(10)
+            self.assertEqual(dispatch.call_count, 1)
+
+    def test_stop_during_effect_cleanup_prevents_stale_rgb_write(self):
+        import hal.app_state as state
+
+        entered, unblock = threading.Event(), threading.Event()
+        led = feedback.HoldLEDFeedback()
+        rgb = Mock()
+        result = []
+        with patch.object(state, "rgb_service", rgb), patch.object(
+            state, "_stop_current_effect", side_effect=lambda: (entered.set(), unblock.wait(2)),
+        ):
+            action = threading.Thread(target=lambda: result.append(led.commit(5)))
+            action.start()
+            self.assertTrue(entered.wait(2))
+            led.stop()
+            action.join(2)
+            self.assertEqual(result, [False])
+            unblock.set()
+            led._thread.join(2)
+            rgb.dispatch.assert_not_called()
+
+    def test_superseded_commit_waits_for_inflight_rgb_then_cancels(self):
+        entered, unblock, committing = threading.Event(), threading.Event(), threading.Event()
+        led = feedback.HoldLEDFeedback()
+        result = []
+        with patch.object(feedback, "dispatch_led", side_effect=lambda *args, **kwargs: (entered.set(), unblock.wait(2))):
+            led.set_tier(1)
+            self.assertTrue(entered.wait(2))
+
+            def commit():
+                committing.set()
+                result.append(led.commit(5))
+
+            action = threading.Thread(target=commit)
+            action.start()
+            self.assertTrue(committing.wait(2))
+            with led._condition:
+                self.assertTrue(led._condition.wait_for(lambda: led._committing, timeout=2))
+            led.release()
+            self.assertEqual(result, [])
+            unblock.set()
+            action.join(2)
+            self.assertEqual(result, [False])
+            led.stop()
+            led._thread.join(2)
+
+    def test_rgb_error_does_not_block_action(self):
+        led = feedback.HoldLEDFeedback()
+        with patch.object(feedback, "warn_color", side_effect=RuntimeError("no LED")):
+            led.commit(5)
+            led.stop()
+            led._thread.join(2)
+            self.assertFalse(led._thread.is_alive())
+
+    def test_presets_are_read_at_dispatch_time(self):
+        from hal.presets import BUTTON_LED_PRESETS
+
+        with patch.dict(BUTTON_LED_PRESETS, sleep_warn={"color": [1, 2, 3]}):
+            self.assertEqual(feedback.warn_color("sleep_warn"), (1, 2, 3))
+            BUTTON_LED_PRESETS["sleep_warn"] = {"color": [4, 5, 6]}
+            self.assertEqual(feedback.warn_color("sleep_warn"), (4, 5, 6))
+
+    def test_dispatch_uses_high_priority_and_stops_effect(self):
+        import hal.app_state as state
+        from hal.drivers.base import Priority
+        from hal.presets import RGB_CMD_SOLID
+
+        rgb = Mock()
+        with patch.object(state, "rgb_service", rgb), patch.object(state, "_stop_current_effect") as stop:
+            feedback.dispatch_led((1, 2, 3))
+        stop.assert_called_once_with()
+        rgb.dispatch.assert_called_once_with(RGB_CMD_SOLID, (1, 2, 3), priority=Priority.HIGH)
+
+    def test_gpio_reports_tiers_and_shared_commit_precedes_action(self):
+        handler = GPIOButtonHandler(ButtonConfig(chip=0, line=100, debounce_ns=0))
+        handler._hold_led = Mock()
+        stop = Mock()
+        stop.is_set.return_value = False
+        stop.wait.side_effect = [False, False, True]
+        handler._hold_watcher_stop = stop
+        handler._press_start = 0
+        with patch("hal.drivers.gpio_button.time.monotonic", side_effect=[2, 5, 10]):
+            handler._hold_watcher(stop)
+        self.assertEqual([c.args[0] for c in handler._hold_led.set_tier.call_args_list], [1, 2, 3])
+        order = Mock()
+        order.attach_mock(handler._hold_led.commit, "commit")
+        with patch("hal.drivers.gpio_button.hold_release_action") as action:
+            order.attach_mock(action, "action")
+            handler._run_hold_action(5)
+        self.assertEqual([c[0] for c in order.mock_calls], ["commit", "action"])
+        handler._hold_led.commit.assert_called_once_with(5)
+        action.assert_called_once_with(5, source="GPIO button")
+
+    def test_gpio_old_watcher_cannot_override_new_hold(self):
+        handler = GPIOButtonHandler(ButtonConfig(chip=0, line=100, debounce_ns=0))
+        handler._hold_led = Mock()
+        handler._hold_watcher_stop = threading.Event()
+        handler._hold_watcher(threading.Event())
+        handler._hold_led.set_tier.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hal/test/test_mpr121.py
+++ b/hal/test/test_mpr121.py
@@ -96,6 +96,63 @@ class TestMPR121(unittest.TestCase):
     def make_handler(self, **kwargs):
         return MPR121Handler(MPR121Config(bus=5, **kwargs))
 
+    def test_hold_feedback_follows_debounced_tiers_until_release(self):
+        handler = self.make_handler()
+        handler._hold_led = feedback = mock.Mock()
+        for sample in [(False, 0), (True, 1), (True, 1.04),
+                       (True, 2.999), (True, 3), (True, 6), (True, 11)]:
+            handler._process_touch(*sample)
+        self.assertEqual(feedback.set_tier.call_args_list,
+                         [mock.call(1), mock.call(2), mock.call(3)])
+        feedback.commit.assert_not_called()
+        feedback.release.reset_mock()
+        handler._process_touch(False, 11.1)
+        feedback.release.assert_not_called()
+        handler._process_touch(False, 11.14)
+        feedback.release.assert_called_once_with()
+        feedback.commit.assert_not_called()
+
+    def test_boot_held_and_chatter_do_not_arm_feedback(self):
+        handler = self.make_handler()
+        handler._hold_led = feedback = mock.Mock()
+        for sample in [(True, 0), (True, 12), (False, 13), (False, 13.04),
+                       (True, 14), (False, 14.01), (False, 20)]:
+            handler._process_touch(*sample)
+        feedback.set_tier.assert_not_called()
+        feedback.commit.assert_not_called()
+
+    def test_feedback_commits_before_shared_hold_action(self):
+        handler = self.make_handler()
+        handler._hold_led = feedback = mock.Mock()
+        calls = mock.Mock()
+        calls.attach_mock(feedback.commit, 'led')
+        with mock.patch('hal.drivers.mpr121.hold_release_action') as hold:
+            calls.attach_mock(hold, 'action')
+            handler._execute(_GestureEvent('hold', 1, held_s=5))
+        self.assertEqual(calls.mock_calls,
+                         [mock.call.led(5), mock.call.action(5, source='MPR121')])
+
+    def test_cancelled_feedback_commit_does_not_start_hold_action(self):
+        handler = self.make_handler()
+        handler._hold_led = mock.Mock()
+        handler._hold_led.commit.return_value = False
+        with mock.patch('hal.drivers.mpr121.hold_release_action') as hold:
+            handler._execute(_GestureEvent('hold', 1, held_s=10))
+        hold.assert_not_called()
+
+    def test_stop_and_poll_fault_stop_feedback(self):
+        for fault in (False, True):
+            with self.subTest(fault=fault):
+                handler = self.make_handler(poll_ms=1)
+                handler._hold_led = feedback = mock.Mock()
+                if fault:
+                    with mock.patch.object(handler, '_read_touched', side_effect=OSError('disconnected')), \
+                            self.assertLogs('hal.drivers.mpr121', level='ERROR'):
+                        handler._poll()
+                else:
+                    handler.stop()
+                feedback.stop.assert_called()
+
     def test_register_initialization(self):
         handler = self.make_handler()
         handler._bus = bus = mock.Mock()
@@ -171,6 +228,7 @@ class TestMPR121(unittest.TestCase):
 
     def test_semantic_actions_call_shared_functions(self):
         handler = self.make_handler()
+        handler._hold_led = mock.Mock()
         with mock.patch('hal.drivers.mpr121.single_click_action') as single, \
                 mock.patch('hal.drivers.mpr121.announce_listening_cue') as cue, \
                 mock.patch('hal.drivers.mpr121.triple_click_action') as triple, \
@@ -245,6 +303,7 @@ class TestMPR121(unittest.TestCase):
         for kind in ('hold', 'triple'):
             with self.subTest(kind=kind):
                 handler = self.make_handler()
+                handler._hold_led = feedback = mock.Mock()
                 handler._action_busy = True
                 handler._detector = mock.Mock()
                 handler._detector.update.return_value = [_GestureEvent(kind, 1, held_s=10)]
@@ -252,6 +311,7 @@ class TestMPR121(unittest.TestCase):
                     handler._process_touch(False, 10)
                 self.assertTrue(handler._pending.empty())
                 self.assertIn('reason=action_worker_busy', logs.output[0])
+                feedback.commit.assert_not_called()
 
     def test_new_touch_invalidates_pending_destructive_outcome(self):
         handler = self.make_handler()

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -66,7 +66,7 @@ Board detection reads `/proc/device-tree/model`:
 | **Hold 5–10 s, then release** | Shutdown OS (TTS announce → release servos → `sudo shutdown -h now`). LED blinks red while armed. | n/a — TTP223 hardware cannot reliably hold (see "FastMode" below) |
 | **Hold 10 s+, then release** | Factory-reset: wipe device state + reboot into AP setup (TTS announce → release servos → POST `/api/system/factory-reset` on the OS server). LED goes solid red while armed. | n/a |
 
-The table above covers GPIO and TTP223. MPR121 also supports release-to-commit holds, as detailed in its detection section; the GPIO LED feedback in this table does not apply to MPR121. The sleep and destructive hold tiers **commit on release, not on a timer firing while held**. The destructive tiers escalate from shutdown to factory-reset after 10 s (see "GPIO button detection" below).
+The table above covers GPIO and TTP223. MPR121 also supports release-to-commit holds and the same hold-tier LED feedback, as detailed in its detection section. The sleep and destructive hold tiers **commit on release, not on a timer firing while held**. The destructive tiers escalate from shutdown to factory-reset after 10 s (see "GPIO button detection" below).
 
 ## Interrupting Lamp while it speaks (barge-in)
 
@@ -179,7 +179,7 @@ A release edge with no matching press (the press was debounce-dropped) is ignore
 
 ### Hold LED feedback
 
-The watcher thread polls the hold duration and drives the RGB LED at HIGH priority (preempts the current emotion) so the user sees how far they've armed before they release:
+The GPIO watcher thread polls the hold duration and selects a tier. Shared `HoldLEDFeedback` in `hal/drivers/button_actions.py`, also used by MPR121, drives the RGB LED at HIGH priority (preempts the current emotion) so the user sees how far they've armed before they release:
 
 | Hold elapsed | LED | Meaning |
 |---|---|---|
@@ -190,7 +190,7 @@ The watcher thread polls the hold duration and drives the RGB LED at HIGH priori
 
 Purple identifies the sleep tier; red blink vs red solid differentiates shutdown from factory-reset. The LED is a silent no-op when the RGB service is unavailable (dev machines) — the button still works.
 
-The three colors are presets, not constants baked into the driver: `BUTTON_LED_PRESETS` in `hal/presets.py` (`sleep_warn` / `shutdown_warn` / `factory_reset`), overridable per device through the `button_led` section of `robots/<id>/presets.json` like every other LED table. The driver owns the staging — when to blink, when to go solid — and reads the color at the moment it paints, because the overlay merges the table in place at boot.
+The three colors are presets, not constants baked into the driver: `BUTTON_LED_PRESETS` in `hal/presets.py` (`sleep_warn` / `shutdown_warn` / `factory_reset`), overridable per device through the `button_led` section of `robots/<id>/presets.json` like every other LED table. Shared `HoldLEDFeedback` owns blinking, release cleanup and final action feedback; each input supplies its detected tier. It reads the color at the moment it paints, because the overlay merges the table in place at boot.
 
 Per-edge debounce is 200 ms (press and release ticks tracked independently so a quick tap isn't dropped while bouncy repeats of the same edge are filtered).
 
@@ -263,8 +263,23 @@ functions:
 
 A short contact lasts less than 2 s. The click window does not resolve while
 any selected electrode remains touched. Releasing a hold clears the pending
-click burst. Destructive actions never commit while held. MPR121 does not
-provide the GPIO button's hold-tier LED feedback.
+click burst. Destructive actions never commit while held.
+
+Debounced `hold_tier` events feed the same `HoldLEDFeedback` component as
+GPIO, sharing `BUTTON_LED_PRESETS`, blinking, release cleanup and final action
+feedback. Per-device `button_led` overrides apply to both inputs:
+
+| Hold elapsed | MPR121 LED |
+|---|---|
+| <2 s | No hold feedback |
+| 2–<5 s | Sleepy purple, blinking at 2 Hz |
+| 5–<10 s | Red, blinking at 2 Hz |
+| ≥10 s | Solid red |
+
+Release stops blinking. An accepted shutdown or factory-reset action reaffirms
+solid red before execution; sleepy turns the LED off through the shared action.
+A contact held at startup produces no hold feedback. Stop or hardware failure
+cancels feedback, and an unavailable RGB service does not prevent input actions.
 
 The bounded asynchronous action worker keeps polling responsive. Excess
 actions may be dropped; a newer touch, stop or hardware error
@@ -273,8 +288,8 @@ failure or MPR121 overcurrent fault (`OVCF`) is logged and stops this driver
 while the existing input handlers continue.
 
 The hardware verification above covered the earlier single-click behavior.
-These additional click/hold mappings are verified with mocked local tests;
-they have not been deployed or exercised destructively on the live device.
+Hold LED feedback is verified with mocked local tests; it has not been checked
+on the live device. These tests do not execute real reboot, shutdown or reset.
 
 Operation logs use logger `hal.drivers.mpr121` in the normal HAL log/journal;
 there is no separate raw trace file. INFO entries cover initialization and
@@ -466,7 +481,7 @@ Phrases are intentionally short — they fire mid-stroke and need to feel respon
 | `hal/board/mpr121.py` | Device-owned MPR121 configuration loader and validation |
 | `hal/drivers/mpr121.py` | Optional I²C MPR121 click/hold handler |
 | `hal/drivers/button_gestures.py` | Shared GPIO/MPR121 gesture thresholds |
-| `hal/drivers/button_actions.py` | Shared action functions + localized phrase pools |
+| `hal/drivers/button_actions.py` | Shared action functions, GPIO/MPR121 `HoldLEDFeedback` and localized phrase pools |
 | `hal/presets.py` | Language code constants (`LANG_EN`, etc.) |
 | `hal/test_ttp223_probe_orangepi.py` | Standalone pad probe (stdlib ioctl, no gpiod). `info` reads line state with HAL running; `watch` maps pad→line and needs `hal.service` stopped. Lines come from the selected device’s `ttp223.json`, with the same legacy board-profile fallback as HAL. Select the device with `--device-type`. |
 | `hal/test_gpio.py` | Standalone probe for verifying GPIO button line |

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -63,7 +63,7 @@ Board được detect qua `/proc/device-tree/model`:
 | **Giữ 5–10 s rồi nhả** | Shutdown OS (TTS báo → release servo → `sudo shutdown -h now`). LED nháy đỏ khi đã arm. | n/a — phần cứng TTP223 không hold đáng tin được (xem "FastMode" dưới) |
 | **Giữ 10 s+ rồi nhả** | Factory-reset: wipe state thiết bị + reboot vào AP setup (TTS báo → release servo → POST `/api/system/factory-reset` trên OS server). LED đỏ đứng khi đã arm. | n/a |
 
-Bảng trên mô tả GPIO và TTP223. MPR121 cũng hỗ trợ giữ rồi nhả để thực hiện action, xem phần detect riêng; phản hồi LED GPIO trong bảng không áp dụng cho MPR121. Mức sleep và các mức destructive **commit khi nhả, không phải khi timer fire lúc đang giữ**. Các mức destructive escalate từ shutdown sang factory-reset sau 10 s (xem "Detect nút GPIO" dưới).
+Bảng trên mô tả GPIO và TTP223. MPR121 cũng hỗ trợ giữ rồi nhả để thực hiện action và cùng phản hồi LED theo mức giữ, xem phần detect riêng. Mức sleep và các mức destructive **commit khi nhả, không phải khi timer fire lúc đang giữ**. Các mức destructive escalate từ shutdown sang factory-reset sau 10 s (xem "Detect nút GPIO" dưới).
 
 ## Cắt Lamp giữa câu (barge-in)
 
@@ -176,7 +176,7 @@ Release edge không có press khớp (press bị debounce nuốt) thì bỏ qua 
 
 ### LED feedback khi giữ
 
-Thread watcher poll thời lượng giữ và đẩy LED RGB ở priority HIGH (preempt emotion hiện tại) để user thấy đã arm tới đâu trước khi nhả:
+Thread watcher GPIO poll thời lượng giữ và chọn mức giữ. `HoldLEDFeedback` dùng chung trong `hal/drivers/button_actions.py`, cũng được MPR121 sử dụng, đẩy LED RGB ở priority HIGH (preempt emotion hiện tại) để user thấy đã arm tới đâu trước khi nhả:
 
 | Thời gian giữ | LED | Ý nghĩa |
 |---|---|---|
@@ -187,7 +187,7 @@ Thread watcher poll thời lượng giữ và đẩy LED RGB ở priority HIGH (
 
 Màu tím nhận diện mức sleep; đỏ nháy vs đỏ đứng phân biệt shutdown với factory-reset. LED là no-op im lặng khi RGB service không có (máy dev) — nút vẫn hoạt động.
 
-Ba màu này là preset chứ không phải hằng nhúng cứng trong driver: `BUTTON_LED_PRESETS` trong `hal/presets.py` (`sleep_warn` / `shutdown_warn` / `factory_reset`), device override được qua section `button_led` của `robots/<id>/presets.json` giống mọi bảng LED khác. Driver giữ phần staging — lúc nào nháy, lúc nào để đứng — và đọc màu ngay lúc paint, vì overlay merge bảng tại chỗ lúc boot.
+Ba màu này là preset chứ không phải hằng nhúng cứng trong driver: `BUTTON_LED_PRESETS` trong `hal/presets.py` (`sleep_warn` / `shutdown_warn` / `factory_reset`), device override được qua section `button_led` của `robots/<id>/presets.json` giống mọi bảng LED khác. `HoldLEDFeedback` dùng chung xử lý nháy, dọn phản hồi khi nhả và phản hồi chốt action; mỗi input cung cấp mức giữ đã detect. Nó đọc màu ngay lúc paint, vì overlay merge bảng tại chỗ lúc boot.
 
 Debounce mỗi edge là 200 ms (tick nhấn và nhả track độc lập để tap nhanh không bị drop trong khi bounce lặp của cùng một edge bị lọc).
 
@@ -257,8 +257,23 @@ MPR121 dùng chung ngưỡng cử chỉ từ `hal/drivers/button_gestures.py` v�
 
 Contact ngắn kéo dài dưới 2 s. Cửa sổ click không phân giải khi còn bất kỳ
 electrode được chọn nào đang chạm. Nhả sau giữ xóa chuỗi click đang chờ.
-Action destructive không chạy khi còn giữ. MPR121 chưa có phản hồi LED theo
-mức giữ như nút GPIO.
+Action destructive không chạy khi còn giữ.
+
+Event `hold_tier` đã debounce truyền vào cùng `HoldLEDFeedback` với GPIO,
+dùng chung `BUTTON_LED_PRESETS`, xử lý nháy, dọn phản hồi khi nhả và phản hồi
+chốt action. Override `button_led` theo device áp dụng cho cả hai input:
+
+| Thời gian giữ | LED MPR121 |
+|---|---|
+| <2 s | Không có phản hồi giữ |
+| 2–<5 s | Tím sleepy, nháy 2 Hz |
+| 5–<10 s | Đỏ, nháy 2 Hz |
+| ≥10 s | Đỏ đứng |
+
+Nhả thì dừng nháy. Action shutdown hoặc factory-reset được chấp nhận đặt lại
+đỏ đứng trước khi chạy; sleepy tắt LED qua action dùng chung. Chạm giữ lúc
+startup không hiện phản hồi giữ. Stop hoặc lỗi phần cứng hủy phản hồi; thiếu
+RGB service không ngăn các action đầu vào hoạt động.
 
 Worker action bất đồng bộ có hàng đợi giới hạn giữ polling phản hồi kịp thời.
 Action dư có thể bị bỏ; chạm mới, stop hoặc lỗi phần cứng làm mất
@@ -267,8 +282,8 @@ dòng MPR121 (`OVCF`) được log và dừng driver này, các handler đầu v
 tiếp tục chạy.
 
 Lần xác minh phần cứng ở trên chỉ kiểm tra hành vi single-click trước đây.
-Các mapping click/giữ bổ sung được kiểm tra bằng test mock local; chưa deploy
-hoặc chạy hành động destructive trên device thật.
+Phản hồi LED khi giữ được kiểm tra bằng test mock local, chưa kiểm tra trên
+device thật. Các test này không thực thi reboot, shutdown hay reset thật.
 
 Log hoạt động dùng logger `hal.drivers.mpr121` trong log/journal HAL thông
 thường; không tạo file raw trace riêng. Log INFO gồm khởi tạo và cấu hình
@@ -459,7 +474,7 @@ Phrase cố tình ngắn — chúng fire giữa lúc vuốt nên cần cảm gi�
 | `hal/board/mpr121.py` | Đọc và kiểm tra cấu hình MPR121 do device quản lý |
 | `hal/drivers/mpr121.py` | Handler I²C MPR121 tùy chọn, detect click/giữ |
 | `hal/drivers/button_gestures.py` | Ngưỡng cử chỉ dùng chung GPIO/MPR121 |
-| `hal/drivers/button_actions.py` | Hàm action chung + pool phrase local |
+| `hal/drivers/button_actions.py` | Hàm action chung, `HoldLEDFeedback` cho GPIO/MPR121 và pool phrase local |
 | `hal/presets.py` | Hằng số mã ngôn ngữ (`LANG_EN`, v.v.) |
 | `hal/test_ttp223_probe_orangepi.py` | Probe pad độc lập (ioctl thuần stdlib, không cần gpiod). `info` đọc trạng thái line khi HAL vẫn chạy; `watch` map pad→line và cần dừng `hal.service`. Line lấy từ `ttp223.json` của device được chọn, fallback về board profile cũ giống HAL. Chọn device bằng `--device-type`. |
 | `hal/test_gpio.py` | Probe độc lập để verify line nút GPIO |


### PR DESCRIPTION
MPR121 hold gestures executed the GPIO actions but provided no LED indication while held. Move hold LED behavior into HoldLEDFeedback in hal/drivers/button_actions.py and use it from both GPIO and MPR121: purple blink at 2–<5 seconds, red blink at 5–<10 seconds, and solid red from 10 seconds. Both inputs share live device presets and 2 Hz blinking.

Drivers report detected tiers and release; shared feedback owns animation and final action colors. RGB work stays off hardware polling. Release, stop, and superseded commits cancel pending feedback; serialized dispatch prevents an old blink from overwriting an accepted action. Update English and Vietnamese docs.

Validation:
- Focused input suite: 143 tests and 57 subtests passed.
- Final feedback/MPR121 checks after lifecycle refinements: 42 tests and 15 subtests passed.
- HAL lint clean across 353 files; git diff --check clean.
- LED and destructive actions tested with mocks; this change has not been deployed to hardware.
