### PR TITLE
hal: add configurable Lamp factory reset button on pin 35

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -56,15 +56,25 @@ integrations/                     — Off-device: companions/, chat-bridges/, pe
 
 Mechanical GPIO button wiring is owned by each device in
 `robots/lamp/gpio_button.json` and `robots/intern-v2/gpio_button.json`.
-HAL resolves the device directory through `DEVICES_DIR` and `DEVICE_TYPE`,
-selects the detected board's `chip`, `line`, and `debounce_ns` from the `boards`
-map, and passes that configuration to the shared `hal/drivers/gpio_button.py`
-driver. Device configuration takes priority; a missing file or board entry
-falls back to the existing `button` defaults in `hal/board/boards.json`.
-Changing a device's button pins requires updating its JSON file and restarting
-HAL; moving physical wires is not detected automatically. Malformed
-configuration is rejected before GPIO is claimed. Simulation skips the
-hardware button.
+HAL resolves the device directory through `DEVICES_DIR` and `DEVICE_TYPE`.
+Each detected-board entry accepts the original flat `chip`, `line`,
+`debounce_ns` configuration or a `buttons` list with named inputs.
+`load_button_configs` supplies one shared `hal/drivers/gpio_button.py` instance
+per input; HAL stops every instance on cleanup. `load_button_config` remains
+available for callers that need only the first input (the primary button in Lamp). Lamp on OrangePi uses
+`primary` at pin 37 / PD4 / gpiochip0 line 100 (`behavior: "standard"`) and
+`factory_reset` at pin 35 / PD3 / gpiochip0 line 99
+(`behavior: "factory_reset"`, `hold_s: 5`). The reset input ignores taps and
+holds below 5 s; holding at least 5 s arms the shared solid-red LED feedback,
+then releasing calls the shared factory-reset action. It does not reset while
+held or invoke sleep, shutdown, or single/triple-click actions.
+Device configuration takes priority; a missing file or board entry falls back
+to exactly one existing `button` default in `hal/board/boards.json`.
+Intern v2's JSON remains unchanged. Changing wiring requires updating the
+selected device's JSON and restarting HAL; moving physical wires is not
+detected automatically. Malformed configuration, duplicate input names, and
+duplicate chip/line pairs are rejected before GPIO is claimed. Simulation
+skips hardware buttons.
 
 TTP223 touch wiring is device-owned in `robots/lamp/ttp223.json`. Intern v2
 has no TTP223 hardware and does not ship this file. `hal/board/ttp223.py` resolves the detected

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -56,13 +56,23 @@ integrations/                     — Off-device: companions/, chat-bridges/, pe
 
 Wiring nút GPIO cơ học thuộc về từng device trong
 `robots/lamp/gpio_button.json` và `robots/intern-v2/gpio_button.json`.
-HAL xác định thư mục device qua `DEVICES_DIR` và `DEVICE_TYPE`, chọn `chip`,
-`line`, `debounce_ns` của board đã detect từ map `boards`, rồi truyền cấu hình
-vào driver dùng chung `hal/drivers/gpio_button.py`. Cấu hình device được ưu tiên;
-thiếu file hoặc entry của board thì dùng lại mặc định `button` trong
-`hal/board/boards.json`. Khi đổi chân nút của device, cần sửa file JSON tương
-ứng và khởi động lại HAL; hệ thống không tự phát hiện việc đổi dây cắm.
-Config sai bị từ chối trước khi claim GPIO. Chế độ mô phỏng bỏ qua nút phần cứng.
+HAL xác định thư mục device qua `DEVICES_DIR` và `DEVICE_TYPE`.
+Entry của board hỗ trợ cấu hình phẳng cũ `chip`, `line`, `debounce_ns` hoặc
+list `buttons` có tên cho từng input. `load_button_configs` cấp cấu hình cho
+mỗi instance của driver dùng chung `hal/drivers/gpio_button.py`; HAL dừng tất
+cả instance khi cleanup. `load_button_config` vẫn dùng được cho caller chỉ
+cần nút đầu tiên (nút chính trong cấu hình Lamp). Lamp trên OrangePi có `primary` ở pin 37 / PD4 / gpiochip0
+line 100 (`behavior: "standard"`) và `factory_reset` ở pin 35 / PD3 /
+gpiochip0 line 99 (`behavior: "factory_reset"`, `hold_s: 5`). Nút reset bỏ
+qua tap và giữ dưới 5 s; giữ đủ 5 s bật LED đỏ đứng dùng chung để báo đã arm,
+rồi nhả mới gọi factory-reset dùng chung. Không reset khi còn giữ và không
+gọi sleep, shutdown hay action single/triple-click.
+Cấu hình device được ưu tiên; thiếu file hoặc entry board thì fallback về
+đúng một nút mặc định `button` cũ trong `hal/board/boards.json`.
+JSON của Intern v2 giữ nguyên. Khi đổi wiring, cần sửa JSON của device được
+chọn rồi restart HAL; hệ thống không tự phát hiện đổi dây cắm. Config sai,
+tên input trùng hoặc cặp chip/line trùng bị từ chối trước khi claim GPIO.
+Chế độ mô phỏng bỏ qua nút phần cứng.
 
 Wiring TTP223 do device quản lý trong `robots/lamp/ttp223.json`. Intern v2
 không có phần cứng TTP223 nên không kèm file này. `hal/board/ttp223.py` chọn `chip`, `lines` và

--- a/hal/board/gpio_button.py
+++ b/hal/board/gpio_button.py
@@ -1,18 +1,71 @@
 """Load mechanical button wiring owned by a device, keyed by board ID."""
 
+from dataclasses import dataclass
 import json
+import math
 from pathlib import Path
+import re
 
 from hal.board.board import ButtonConfig, PROFILES
 
 
-def load_button_config(device_dir: str, board_id: str) -> ButtonConfig:
-    """Absent file/board uses legacy board wiring; invalid declarations are boot errors.
+@dataclass(frozen=True)
+class ButtonInputConfig:
+    wiring: ButtonConfig
+    name: str = "primary"
+    behavior: str = "standard"
+    hold_s: float = 5.0
+
+
+def _wiring(values):
+    fields = {key: values[key] for key in ("chip", "line", "debounce_ns")}
+    if any(type(value) is not int or value < 0 for value in fields.values()):
+        raise ValueError("wiring values must be non-negative integers")
+    return ButtonConfig(**fields)
+
+
+def _board_buttons(values):
+    if not isinstance(values, dict):
+        raise ValueError("expected a board object")
+    if "buttons" not in values:
+        if set(values) != {"chip", "line", "debounce_ns"}:
+            raise ValueError("expected chip, line and debounce_ns")
+        return [ButtonInputConfig(_wiring(values))]
+    if set(values) != {"buttons"} or not isinstance(values["buttons"], list) or not values["buttons"]:
+        raise ValueError("expected a non-empty buttons list")
+    result, names, pins = [], set(), set()
+    required = {"name", "chip", "line", "debounce_ns"}
+    for entry in values["buttons"]:
+        if not isinstance(entry, dict) or not required <= set(entry) or set(entry) - required - {"behavior", "hold_s"}:
+            raise ValueError("button requires name, chip, line, debounce_ns and optional behavior/hold_s")
+        name = entry["name"]
+        if not isinstance(name, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", name):
+            raise ValueError("button name must contain only letters, digits, '_' or '-'")
+        behavior = entry.get("behavior", "standard")
+        if behavior not in ("standard", "factory_reset"):
+            raise ValueError("behavior must be standard or factory_reset")
+        if behavior == "standard" and "hold_s" in entry:
+            raise ValueError("hold_s is only valid for factory_reset buttons")
+        hold_s = entry.get("hold_s", 5.0)
+        if type(hold_s) not in (int, float) or not math.isfinite(hold_s) or hold_s <= 0:
+            raise ValueError("hold_s must be finite and positive")
+        wiring = _wiring(entry)
+        pin = (wiring.chip, wiring.line)
+        if name in names or pin in pins:
+            raise ValueError("duplicate button name or chip/line")
+        names.add(name)
+        pins.add(pin)
+        result.append(ButtonInputConfig(wiring, name, behavior, float(hold_s)))
+    return result
+
+
+def load_button_configs(device_dir: str, board_id: str) -> list[ButtonInputConfig]:
+    """Load one or more inputs; absent file/board keeps exactly one legacy button.
 
     GPIO lines are chip-relative offsets, not physical header pin numbers.
     The shared driver uses pull-up and active-low wiring.
     """
-    fallback = PROFILES[board_id].button
+    fallback = [ButtonInputConfig(PROFILES[board_id].button)]
     path = Path(device_dir) / "gpio_button.json"
     try:
         text = path.read_text()
@@ -20,18 +73,14 @@ def load_button_config(device_dir: str, board_id: str) -> ButtonConfig:
         return fallback
     try:
         data = json.loads(text)
-        if not isinstance(data, dict) or set(data) != {"boards"}:
-            raise ValueError("expected an object containing only 'boards'")
-        boards = data["boards"]
-        if not isinstance(boards, dict):
-            raise ValueError("'boards' must be an object")
-        configs = {}
-        for name, values in boards.items():
-            if not isinstance(values, dict) or set(values) != {"chip", "line", "debounce_ns"}:
-                raise ValueError(f"{name}: expected chip, line and debounce_ns")
-            if any(type(value) is not int or value < 0 for value in values.values()):
-                raise ValueError(f"{name}: wiring values must be non-negative integers")
-            configs[name] = ButtonConfig(**values)
+        if not isinstance(data, dict) or set(data) != {"boards"} or not isinstance(data["boards"], dict):
+            raise ValueError("expected an object containing a boards map")
+        configs = {name: _board_buttons(values) for name, values in data["boards"].items()}
         return configs.get(board_id, fallback)
-    except (ValueError, TypeError) as exc:
+    except (ValueError, TypeError, KeyError) as exc:
         raise ValueError(f"Invalid GPIO button wiring at {path}: {exc}") from exc
+
+
+def load_button_config(device_dir: str, board_id: str) -> ButtonConfig:
+    """Compatibility accessor for callers that only need the first button."""
+    return load_button_configs(device_dir, board_id)[0].wiring

--- a/hal/drivers/button_actions.py
+++ b/hal/drivers/button_actions.py
@@ -593,6 +593,27 @@ def hold_release_action(held_s: float, source: str = "button"):
         sleep_action(source)
 
 
+def button_hold_tier(held_s, *, behavior="standard", hold_s=5.0):
+    """Select shared feedback for normal and dedicated reset buttons."""
+    if behavior == "factory_reset":
+        return 3 if held_s >= hold_s else 0
+    return (3 if held_s >= FACTORY_RESET_DURATION else
+            2 if held_s >= LONG_PRESS_DURATION else
+            1 if held_s >= SLEEP_HOLD_DURATION else 0)
+
+
+def button_hold_release_action(held_s, feedback, *, behavior="standard", hold_s=5.0,
+                               source="button"):
+    """Commit the actual policy's LED and action using a released duration."""
+    if not button_hold_tier(held_s, behavior=behavior, hold_s=hold_s):
+        return
+    if behavior == "factory_reset":
+        if feedback.commit_tier(3) is not False:
+            factory_reset_action(source)
+    elif feedback.commit(held_s) is not False:
+        hold_release_action(held_s, source=source)
+
+
 def _factory_reset_phrase() -> str:
     """Inline i18n until PHRASE_FACTORY_RESET lands in i18n.py."""
     lang = _current_lang()
@@ -609,10 +630,10 @@ def factory_reset_action(source: str = "button"):
     into AP setup mode. HAL does NOT touch state itself — single source of
     truth for what gets wiped lives in the OS server's deviceWipePaths.
 
-    Authoritative because of physical presence: 10s deliberate hold + the
+    Authoritative because of physical presence: a deliberate configured hold + the
     /api/system/factory-reset endpoint allows loopback origin without Bearer
     (see os-server server.go adminOrLoopbackAuth)."""
-    logger.info("%s factory-reset hold (10s+) -- triggering soft reset", source)
+    logger.info("%s factory-reset hold -- triggering soft reset", source)
     logger.info("%s LED: red solid (factory-reset armed)", source)
 
     # Suppress the lifespan-shutdown re-announce — same reason as
@@ -722,6 +743,10 @@ class HoldLEDFeedback:
 
     def commit(self, held_s):
         tier = 3 if held_s >= FACTORY_RESET_DURATION else 2 if held_s >= LONG_PRESS_DURATION else 0
+        return self.commit_tier(tier)
+
+    def commit_tier(self, tier):
+        """Commit a semantic tier without inventing a hold duration."""
         generation = self._request(tier, committing=True)
         if generation is None:
             return False

--- a/hal/drivers/gpio_button.py
+++ b/hal/drivers/gpio_button.py
@@ -1,6 +1,6 @@
 """GPIO button handler with device-declared wiring.
 
-Supports five actions on a single button:
+Each handler owns one configured line. Standard buttons support five actions:
 - Single click: stop speaker / unmute mic (fires immediately on release)
 - Triple click: reboot OS (resolved after the click window)
 - Hold + release (2–5s):   sleepy emotion
@@ -20,6 +20,10 @@ nothing on top of the floor-grab — destructive actions (reboot/shutdown/
 factory-reset) need a deliberate gesture so a user panic-clicking the
 button to interrupt TTS doesn't accidentally reboot.
 
+A dedicated factory_reset button ignores clicks and commits reset only on
+release after its configured hold threshold; feedback and action selection
+stay in the shared action module.
+
 The actual action logic lives in `button_actions.py` so other input
 devices (touchpad, remote) can reuse the same gestures.
 """
@@ -32,11 +36,9 @@ from hal.board.gpio_button import ButtonConfig
 from hal.drivers.button_actions import (
     HoldLEDFeedback,
     DOUBLE_CLICK_WINDOW,
-    FACTORY_RESET_DURATION,
-    LONG_PRESS_DURATION,
-    SLEEP_HOLD_DURATION,
+    button_hold_tier,
+    button_hold_release_action,
     announce_listening_cue,
-    hold_release_action,
     single_click_action,
     triple_click_action,
 )
@@ -44,7 +46,16 @@ from hal.drivers.button_actions import (
 logger = logging.getLogger(__name__)
 
 class GPIOButtonHandler:
-    def __init__(self, config: ButtonConfig):
+    def __init__(self, config: ButtonConfig, *, name="primary",
+                 behavior="standard", hold_s=5.0):
+        if behavior not in ("standard", "factory_reset"):
+            raise ValueError(f"Unknown GPIO button behavior: {behavior}")
+        self._behavior = behavior
+        self._hold_s = hold_s
+        self._source = ("GPIO button" if name == "primary" and behavior == "standard" else
+                        f"GPIO button {name} (gpiochip{config.chip}/line{config.line})")
+        self._stopped = False
+        self._action_lock = threading.RLock()
         self._lgpio = None
         self._handle = None
         self._callback = None
@@ -74,9 +85,7 @@ class GPIOButtonHandler:
                 if stop_event.is_set() or self._hold_watcher_stop is not stop_event:
                     return
                 held = time.monotonic() - self._press_start
-                stage = (3 if held >= FACTORY_RESET_DURATION else
-                         2 if held >= LONG_PRESS_DURATION else
-                         1 if held >= SLEEP_HOLD_DURATION else 0)
+                stage = button_hold_tier(held, behavior=self._behavior, hold_s=self._hold_s)
                 if stage != last_stage:
                     self._hold_led.set_tier(stage)
                     last_stage = stage
@@ -84,31 +93,72 @@ class GPIOButtonHandler:
                 return
 
     def _run_hold_action(self, held):
-        if self._hold_led.commit(held) is False:
-            return
-        action = "factory-reset" if held >= FACTORY_RESET_DURATION else "shutdown" if held >= LONG_PRESS_DURATION else "sleepy"
-        logger.info("GPIO button hold %.1fs -- %s", held, action)
-        hold_release_action(held, source="GPIO button")
+        with self._action_lock:
+            if self._stopped:
+                return
+            logger.info("%s released hold %.3fs -- %s", self._source, held, self._behavior)
+            button_hold_release_action(
+                held, self._hold_led, behavior=self._behavior,
+                hold_s=self._hold_s, source=self._source,
+            )
+
+    def _run_single_click(self):
+        with self._action_lock:
+            if not self._stopped:
+                single_click_action(source=self._source, announce=False)
 
     def start(self):
         import lgpio
 
         self._lgpio = lgpio
-        self._handle = lgpio.gpiochip_open(self._chip)
-        lgpio.gpio_claim_alert(
-            self._handle, self._pin, lgpio.BOTH_EDGES, lgpio.SET_PULL_UP
-        )
-        self._callback = lgpio.callback(
-            self._handle, self._pin, lgpio.BOTH_EDGES, self._on_edge
-        )
+        try:
+            self._handle = lgpio.gpiochip_open(self._chip)
+            lgpio.gpio_claim_alert(
+                self._handle, self._pin, lgpio.BOTH_EDGES, lgpio.SET_PULL_UP
+            )
+            self._callback = lgpio.callback(
+                self._handle, self._pin, lgpio.BOTH_EDGES, self._on_edge
+            )
+        except Exception:
+            self.stop()
+            raise
         logger.info(
-            "GPIO button ready on gpiochip%d line %d (manual debounce %d ms)",
-            self._chip,
-            self._pin,
-            self._debounce_ns // 1_000_000,
+            "%s ready on gpiochip%d line %d (manual debounce %d ms, behavior=%s, hold=%.1fs)",
+            self._source, self._chip, self._pin, self._debounce_ns // 1_000_000,
+            self._behavior, self._hold_s,
         )
 
+    def stop(self):
+        """Cancel pending work; actions already executing cannot be recalled."""
+        self._stopped = True
+        with self._hold_lock:
+            self._pressed = False
+            if self._hold_watcher_stop is not None:
+                self._hold_watcher_stop.set()
+                self._hold_watcher_stop = None
+            self._hold_led.stop()
+            if self._click_timer is not None:
+                self._click_timer.cancel()
+                self._click_timer = None
+            self._click_count = 0
+        if self._callback is not None:
+            try:
+                self._callback.cancel()
+            except Exception:
+                logger.warning("%s callback cleanup failed", self._source, exc_info=True)
+            finally:
+                self._callback = None
+        if self._handle is not None:
+            try:
+                self._lgpio.gpiochip_close(self._handle)
+            except Exception:
+                logger.warning("%s chip cleanup failed", self._source, exc_info=True)
+            finally:
+                self._handle = None
+
     def _on_edge(self, chip, gpio, level, tick):
+        if self._stopped or level not in (0, 1):
+            return
         # Per-edge debounce. Track press/release ticks independently so a
         # quick click (rising edge soon after the falling edge) isn't
         # dropped, while bouncy repeats of the same edge are filtered out.
@@ -129,6 +179,8 @@ class GPIOButtonHandler:
             # threshold (or escalate from shutdown → factory-reset by
             # holding past 10s). LED feedback runs in a watcher thread.
             with self._hold_lock:
+                if self._stopped or self._pressed:
+                    return
                 self._press_start = time.monotonic()
                 self._pressed = True
                 if self._hold_watcher_stop is not None:
@@ -160,7 +212,7 @@ class GPIOButtonHandler:
             self._hold_led.release()
 
         held = time.monotonic() - self._press_start
-        if held >= SLEEP_HOLD_DURATION:
+        if button_hold_tier(held, behavior=self._behavior, hold_s=self._hold_s):
             self._click_count = 0  # destructive, terminal: scrub any pending clicks
             if self._click_timer:
                 self._click_timer.cancel()
@@ -178,6 +230,11 @@ class GPIOButtonHandler:
             ).start()
             return
 
+        if self._behavior == "factory_reset":
+            logger.info("%s released hold %.3fs -- ignored (requires %.1fs)",
+                        self._source, held, self._hold_s)
+            return
+
         # Short tap → count toward triple-click resolution. The SILENT part
         # of the single-click action (stop speaker / unmute mic) fires
         # IMMEDIATELY on the first tap of a burst — it's a non-destructive
@@ -193,8 +250,7 @@ class GPIOButtonHandler:
             # lgpio callback must return promptly (same reasoning as the
             # long-press branches above).
             threading.Thread(
-                target=single_click_action,
-                kwargs={"source": "GPIO button", "announce": False},
+                target=self._run_single_click,
                 daemon=True,
                 name="gpio-button-single-click",
             ).start()
@@ -207,10 +263,16 @@ class GPIOButtonHandler:
         self._click_timer.start()
 
     def _on_click_timeout(self):
+        with self._action_lock:
+            if self._stopped or self._behavior != "standard":
+                return
+            self._resolve_clicks()
+
+    def _resolve_clicks(self):
         count = self._click_count
         self._click_count = 0
         if count == 3:
-            triple_click_action(source="GPIO button")
+            triple_click_action(source=self._source)
             return
         if count != 1:
             # count == 2 → likely a slipped/panic double-tap of single
@@ -219,4 +281,4 @@ class GPIOButtonHandler:
         # Any non-triple burst already grabbed the floor silently on its
         # first tap — now that it's resolved, speak the deferred cue so the
         # user hears confirmation exactly once per burst.
-        announce_listening_cue(source="GPIO button")
+        announce_listening_cue(source=self._source)

--- a/hal/server.py
+++ b/hal/server.py
@@ -295,7 +295,7 @@ if "display" in _declared:
     except ImportError as e:
         logger.warning(f"Display service not available: {e}")
 
-_gpio_button_handler = None
+_gpio_button_handlers = []
 _ttp223_handler = None
 _mpr121_handler = None
 
@@ -364,7 +364,7 @@ def _sim_audio_probe(sd_module) -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global _gpio_button_handler, _ttp223_handler, _mpr121_handler
+    global _gpio_button_handlers, _ttp223_handler, _mpr121_handler
 
     # --- Phase 0: Borrow the hardware from whoever owns it ---
     # Empty unless ROBOT.md declares an `owner:`. Where one exists it holds
@@ -899,16 +899,21 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("TrackerService skipped — needs servo+camera routes mounted")
 
-    # Device wiring overrides the legacy board defaults. Simulation skips GPIO.
-    if _gpio_button_config is not None:
+    # Each declared button owns its GPIO handle and gesture state.
+    _gpio_button_handlers = []
+    for button in _gpio_button_configs:
         try:
             from hal.drivers.gpio_button import GPIOButtonHandler
 
-            _gpio_button_handler = GPIOButtonHandler(_gpio_button_config)
-            _gpio_button_handler.start()
+            handler = GPIOButtonHandler(
+                button.wiring, name=button.name, behavior=button.behavior,
+                hold_s=button.hold_s,
+            )
+            handler.start()
+            _gpio_button_handlers.append(handler)
         except Exception as e:
-            logger.warning(f"GPIO button init failed: {e}")
-    else:
+            logger.warning("GPIO button %s init failed: %s", button.name, e)
+    if not _gpio_button_configs:
         logger.info("GPIO button skipped — mock board has no hardware")
 
     # MPR121 is opt-in per device/board; absent hardware leaves other inputs running.
@@ -1018,6 +1023,9 @@ async def lifespan(app: FastAPI):
 
     _lifespan_stopping.set()
     _thermal_stop.set()
+    for handler in _gpio_button_handlers:
+        handler.stop()
+    _gpio_button_handlers = []
     if _mpr121_handler is not None:
         _mpr121_handler.stop()
 
@@ -1301,10 +1309,10 @@ from hal.board.board import assert_board_supported
 _board_id = assert_board_supported([] if _simulation else _profile.boards)
 logger.info("Board gate: device=%s board=%s declared=%s", _resolve_device_type(), _board_id, _profile.boards)
 
-from hal.board.gpio_button import load_button_config
+from hal.board.gpio_button import load_button_configs
 
-_gpio_button_config = (
-    None if _board_id == "sim" else load_button_config(_device_dir, _board_id)
+_gpio_button_configs = (
+    [] if _board_id == "sim" else load_button_configs(_device_dir, _board_id)
 )
 
 from hal.board.mpr121 import load_mpr121_config

--- a/hal/test/test_button_feedback.py
+++ b/hal/test/test_button_feedback.py
@@ -175,7 +175,7 @@ class HoldLEDFeedbackTests(unittest.TestCase):
         self.assertEqual([c.args[0] for c in handler._hold_led.set_tier.call_args_list], [1, 2, 3])
         order = Mock()
         order.attach_mock(handler._hold_led.commit, "commit")
-        with patch("hal.drivers.gpio_button.hold_release_action") as action:
+        with patch("hal.drivers.button_actions.hold_release_action") as action:
             order.attach_mock(action, "action")
             handler._run_hold_action(5)
         self.assertEqual([c[0] for c in order.mock_calls], ["commit", "action"])

--- a/hal/test/test_gpio_button.py
+++ b/hal/test/test_gpio_button.py
@@ -1,0 +1,153 @@
+"""GPIO gesture and lifecycle tests without hardware or destructive actions."""
+from unittest import mock
+
+import pytest
+
+from hal.board.gpio_button import ButtonConfig
+from hal.drivers import button_actions, gpio_button
+
+
+class ImmediateThread:
+    def __init__(self, target, args=(), kwargs=None, **unused):
+        self.target, self.args, self.kwargs = target, args, kwargs or {}
+
+    def start(self):
+        if self.target.__name__ != "_hold_watcher":
+            self.target(*self.args, **self.kwargs)
+
+
+@pytest.fixture
+def actions():
+    with (
+        mock.patch.object(gpio_button, "HoldLEDFeedback") as led,
+        mock.patch.object(gpio_button.threading, "Thread", ImmediateThread),
+        mock.patch.object(button_actions, "factory_reset_action") as reset,
+        mock.patch.object(button_actions, "hold_release_action") as normal,
+        mock.patch.object(gpio_button, "single_click_action") as single,
+        mock.patch.object(gpio_button, "triple_click_action") as triple,
+        mock.patch.object(gpio_button, "announce_listening_cue") as cue,
+    ):
+        yield led, reset, normal, single, triple, cue
+
+
+def handler(**kwargs):
+    return gpio_button.GPIOButtonHandler(ButtonConfig(chip=0, line=99, debounce_ns=0),
+                                         name="reset", behavior="factory_reset", **kwargs)
+
+
+def edge(button, level, seconds):
+    with mock.patch.object(gpio_button.time, "monotonic", return_value=seconds):
+        button._on_edge(0, 99, level, int((seconds + 1) * 1e9))
+
+
+@pytest.mark.parametrize("duration,expected", [(0.1, 0), (4.999, 0), (5.0, 1), (20.0, 1)])
+def test_reset_release_boundary(actions, duration, expected):
+    led, reset, normal, single, triple, cue = actions
+    button = handler()
+    edge(button, 0, 0)
+    reset.assert_not_called()
+    edge(button, 1, duration)
+    assert reset.call_count == expected
+    if expected:
+        reset.assert_called_once_with("GPIO button reset (gpiochip0/line99)")
+        led.return_value.commit_tier.assert_called_once_with(3)
+        led.return_value.commit.assert_not_called()
+    edge(button, 1, duration + 1)
+    assert reset.call_count == expected
+    for action in (normal, single, triple, cue):
+        action.assert_not_called()
+
+
+def test_reset_ignores_triple_tap_and_watchdog(actions):
+    button = handler()
+    for start in (1, 2, 3):
+        edge(button, 0, start)
+        edge(button, 2, start + 0.01)
+        assert button._pressed
+        edge(button, 1, start + 0.1)
+    button._on_click_timeout()
+    for action in actions[1:]:
+        action.assert_not_called()
+    assert button._click_timer is None
+
+
+def test_reset_hold_feedback_at_threshold_without_action(actions):
+    button = handler()
+    edge(button, 0, 0)
+    stop = button._hold_watcher_stop
+    with mock.patch.object(gpio_button.time, "monotonic", return_value=5):
+        with mock.patch.object(stop, "wait", return_value=True):
+            button._hold_watcher(stop)
+    actions[0].return_value.set_tier.assert_called_once_with(3)
+    actions[1].assert_not_called()
+
+
+def test_independent_buttons_use_independent_release_duration(actions):
+    first, second = handler(), handler(hold_s=8)
+    edge(first, 0, 0)
+    edge(second, 0, 4)
+    edge(first, 1, 5)
+    edge(second, 1, 9)
+    assert actions[1].call_count == 1
+
+
+def test_stop_cancels_all_resources_and_pending_actions(actions):
+    button = handler()
+    edge(button, 0, 0)
+    watcher = button._hold_watcher_stop
+    callback, timer, lgpio = mock.Mock(), mock.Mock(), mock.Mock()
+    button._callback, button._click_timer = callback, timer
+    button._handle, button._lgpio = 12, lgpio
+    button.stop()
+    button.stop()
+    assert watcher.is_set()
+    callback.cancel.assert_called_once_with()
+    timer.cancel.assert_called_once_with()
+    lgpio.gpiochip_close.assert_called_once_with(12)
+    edge(button, 1, 10)
+    button._run_hold_action(10)
+    button._run_single_click()
+    button._on_click_timeout()
+    for action in actions[1:]:
+        action.assert_not_called()
+
+
+def test_start_failure_closes_open_chip(actions):
+    lgpio = mock.Mock()
+    lgpio.gpiochip_open.return_value = 7
+    lgpio.gpio_claim_alert.side_effect = RuntimeError("line busy")
+    button = handler()
+    with mock.patch.dict("sys.modules", lgpio=lgpio):
+        with pytest.raises(RuntimeError, match="line busy"):
+            button.start()
+    lgpio.gpiochip_close.assert_called_once_with(7)
+    assert button._stopped
+
+
+def test_standard_policy_preserves_existing_hold_action(actions):
+    button = gpio_button.GPIOButtonHandler(ButtonConfig(chip=0, line=100, debounce_ns=0))
+    edge(button, 0, 0)
+    edge(button, 1, 5)
+    actions[0].return_value.commit.assert_called_once_with(5)
+    actions[2].assert_called_once_with(5, source="GPIO button")
+    actions[1].assert_not_called()
+
+
+def test_cancelled_led_commit_does_not_reset(actions):
+    actions[0].return_value.commit_tier.return_value = False
+    button = handler()
+    edge(button, 0, 0)
+    edge(button, 1, 5)
+    actions[1].assert_not_called()
+
+
+def test_cleanup_errors_do_not_prevent_remaining_cleanup(actions):
+    button = handler()
+    button._callback = mock.Mock()
+    button._callback.cancel.side_effect = RuntimeError("callback failure")
+    button._lgpio = mock.Mock()
+    button._lgpio.gpiochip_close.side_effect = RuntimeError("close failure")
+    button._handle = 7
+    button.stop()
+    button._lgpio.gpiochip_close.assert_called_once_with(7)
+    assert button._callback is None and button._handle is None

--- a/hal/test/test_gpio_button_config.py
+++ b/hal/test/test_gpio_button_config.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from unittest import mock
 
-from hal.board.gpio_button import ButtonConfig, load_button_config
+from hal.board.gpio_button import ButtonConfig, load_button_config, load_button_configs
 
 
 class TestButtonConfig(unittest.TestCase):
@@ -53,6 +53,39 @@ class TestButtonConfig(unittest.TestCase):
                              ButtonConfig(2, 31, 10_000_000))
             self.assertEqual(load_button_config(directory, "raspberry_pi_4"),
                              ButtonConfig(0, 17, 200_000_000))
+
+    def test_lamp_has_independent_primary_and_reset_inputs(self):
+        root = Path(__file__).resolve().parents[2] / "robots"
+        buttons = load_button_configs(root / "lamp", "orangepi_sun60")
+        self.assertEqual([(b.name, b.wiring.chip, b.wiring.line, b.behavior, b.hold_s)
+                          for b in buttons],
+                         [("primary", 0, 100, "standard", 5.0),
+                          ("factory_reset", 0, 99, "factory_reset", 5.0)])
+        self.assertEqual(len(load_button_configs(root / "intern-v2", "orangepi_sun60")), 1)
+        with tempfile.TemporaryDirectory() as directory:
+            fallback = load_button_configs(directory, "orangepi_sun60")
+            self.assertEqual(len(fallback), 1)
+            self.assertEqual(fallback[0].wiring, ButtonConfig(1, 9, 200_000_000))
+            self.assertEqual(fallback[0].behavior, "standard")
+
+    def test_multiple_inputs_reject_ambiguous_or_invalid_actions(self):
+        primary = dict(name="primary", chip=0, line=100, debounce_ns=200)
+        reset = dict(name="reset", chip=0, line=99, debounce_ns=200,
+                     behavior="factory_reset", hold_s=5)
+        cases = [[], [primary, dict(reset, line=100)],
+                 [primary, dict(reset, name="primary")],
+                 [dict(reset, hold_s=0)], [dict(reset, hold_s=-1)],
+                 [dict(reset, hold_s=True)], [dict(reset, hold_s=float("inf"))],
+                 [dict(reset, hold_s=float("nan"))], [dict(reset, behavior="reboot")],
+                 [dict(primary, hold_s=5)], [dict(reset, name="reset\\ninvalid")],
+                 [dict(reset, extra=True)]]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "gpio_button.json"
+            for buttons in cases:
+                with self.subTest(buttons=buttons):
+                    path.write_text(json.dumps({"boards": {"orangepi_sun60": {"buttons": buttons}}}))
+                    with self.assertRaisesRegex(ValueError, "gpio_button.json"):
+                        load_button_configs(directory, "orangepi_sun60")
 
     def test_invalid_config_rejected_with_path(self):
         cases = ["{", "null", '{"boards": []}']

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -1,12 +1,12 @@
 # Physical Controls — GPIO Button, TTP223 and MPR121
 
-Lamp supports a mechanical button, TTP223 touchpads and an optional MPR121 capacitive touch controller. They share the same action library (`hal/drivers/button_actions.py`) so any gesture mapped to "single click" behaves identically whether it came from the mechanical button or the capacitive touchpad.
+Lamp supports mechanical buttons, TTP223 touchpads and an optional MPR121 capacitive touch controller. They share the same action library (`hal/drivers/button_actions.py`) so any gesture mapped to "single click" behaves identically whether it came from the mechanical button or the capacitive touchpad.
 
 ## Input devices
 
 | Device | Role | Where |
 |---|---|---|
-| **GPIO button** | One mechanical button. Used for decisive actions including destructive ones (reboot / shutdown / factory-reset). The mechanical feel and long-hold detection make accidental destructive actions unlikely. | Both Pi 4/5 and OrangePi sun60 |
+| **GPIO button** | A primary mechanical button for click and hold actions, plus a dedicated reset button on OrangePi. Destructive hold actions require release. | Both Pi 4/5 and OrangePi sun60 |
 | **TTP223 capacitive touchpad** | Two touch pads arranged as a "dog head" surface for petting + soft stop/unmute. No destructive gestures because the IC's FastMode prevents reliable hold detection. | OrangePi sun60 only (4 Pro / A733) |
 | **MPR121 capacitive touch controller** | Up to 12 electrodes with GPIO-like click and release-to-commit hold actions, including reboot, shutdown and reset. | Lamp with an explicit I²C configuration in `mpr121.json` |
 
@@ -14,23 +14,38 @@ Lamp supports a mechanical button, TTP223 touchpads and an optional MPR121 capac
 
 | Device | Pi 4/5 | OrangePi sun60 |
 |---|---|---|
-| GPIO button | gpiochip0 BCM 17 (pull-up, active-LOW) | Physical pin 37 / PD4 / gpiochip0 line 100 (pull-up, active-LOW) |
+| Primary GPIO button | gpiochip0 BCM 17 (pull-up, active-LOW) | Physical pin 37 / PD4 / gpiochip0 line 100 (pull-up, active-LOW) |
+| Reset GPIO button | not wired | Physical pin 35 / PD3 / gpiochip0 line 99 (pull-up, active-LOW); hold ≥5 s then release to factory-reset |
 | TTP223 | not wired | Two pads: S1 at physical pin 29 / PD0 / gpiochip0 line 96; S3 at physical pin 33 / PD2 / gpiochip0 line 98. **Pull-up, active-LOW** (pads rest HIGH; a touch is the falling edge). |
 
 Mechanical button wiring belongs to the device: `robots/lamp/gpio_button.json`
 and `robots/intern-v2/gpio_button.json` each declare a `boards` map keyed by
-`raspberry_pi_4`, `raspberry_pi_5`, and `orangepi_sun60`. Each entry has `chip`,
-`line`, and `debounce_ns` (currently `200000000`, or 200 ms). Lamp uses the
-button pins shown above; Intern v2 retains gpiochip1 line 9 on OrangePi.
-Change the selected device's file when its wiring changes, then restart HAL; moving physical wires is not detected automatically.
-HAL resolves the directory using `DEVICES_DIR` and `DEVICE_TYPE`, then passes
-the detected board's `ButtonConfig` to the shared driver. Device configuration
-takes priority. A missing file or board entry falls back to the existing
-`button` defaults in `hal/board/boards.json`: chip 0 / line 17 for Pi 4, Pi 5,
-CM4 and sim; chip 1 / line 9 for OrangePi sun60; all with 200 ms debounce.
-Malformed configuration is rejected before claiming GPIO. Simulation skips
-the hardware button. Pull-up, active-LOW input and gesture behavior remain in
-the shared driver.
+`raspberry_pi_4`, `raspberry_pi_5`, and `orangepi_sun60`. Entries accept the
+original flat `chip`, `line`, `debounce_ns` shape or a `buttons` list. Lamp's
+OrangePi entry is:
+
+```json
+{
+  "buttons": [
+    {"name": "primary", "chip": 0, "line": 100, "debounce_ns": 200000000, "behavior": "standard"},
+    {"name": "factory_reset", "chip": 0, "line": 99, "debounce_ns": 200000000, "behavior": "factory_reset", "hold_s": 5}
+  ]
+}
+```
+
+Intern v2's JSON stays unchanged, with gpiochip1 line 9 on OrangePi.
+Change the selected device's file when its wiring changes, then restart HAL;
+moving physical wires is not detected automatically. HAL resolves the directory
+using `DEVICES_DIR` and `DEVICE_TYPE`. `load_button_configs` supplies one shared
+driver instance per input; HAL stops all instances during cleanup.
+`load_button_config` remains compatible for callers needing the first input (the primary button in Lamp).
+Device configuration takes priority. A missing file or board entry falls back
+to exactly one existing `button` default in `hal/board/boards.json`: chip 0 /
+line 17 for Pi 4, Pi 5, CM4 and sim; chip 1 / line 9 for OrangePi sun60; all
+with 200 ms debounce. Malformed configuration, duplicate names, and duplicate
+chip/line pairs are rejected before claiming GPIO. Simulation skips hardware
+buttons. Pull-up, active-LOW input and gesture detection remain in the shared
+driver.
 
 TTP223 wiring is also device-owned: `robots/lamp/ttp223.json` declares a
 `boards` map. Intern v2 has no TTP223 hardware and does not ship this file. Each enabled entry has
@@ -56,7 +71,7 @@ Board detection reads `/proc/device-tree/model`:
 
 ## Gesture map
 
-| Gesture | GPIO button | TTP223 touchpad |
+| Gesture | Primary GPIO button | TTP223 touchpad |
 |---|---|---|
 | **1 tap** | Stop active object tracking, then stop speaker / unmute mic + speaker + ack chime (~120 ms ping) — all fire immediately on release (no click-window wait); the "Listening" cue plays once the 0.4 s click window resolves | Same after the 1.2 s tap-vs-pet decision resolves — active tracking stops, then the mic/speaker action and cue run. The initial touch still stops in-flight TTS and plays its ack chime immediately. |
 | **2 taps** (≤ 0.4 s apart, button) / (≤ 1.2 s apart, TTP223) | Nothing beyond the single-click already fired on tap 1 (panic-click guard) | Pet response. With `HAL_TOUCH_SWIPE` on (the default), repeated taps in one place — fast or slow, one finger or several — are a **double tap** → mic mute toggle; pet then means the finger revisited a pad |
@@ -66,7 +81,9 @@ Board detection reads `/proc/device-tree/model`:
 | **Hold 5–10 s, then release** | Shutdown OS (TTS announce → release servos → `sudo shutdown -h now`). LED blinks red while armed. | n/a — TTP223 hardware cannot reliably hold (see "FastMode" below) |
 | **Hold 10 s+, then release** | Factory-reset: wipe device state + reboot into AP setup (TTS announce → release servos → POST `/api/system/factory-reset` on the OS server). LED goes solid red while armed. | n/a |
 
-The table above covers GPIO and TTP223. MPR121 also supports release-to-commit holds and the same hold-tier LED feedback, as detailed in its detection section. The sleep and destructive hold tiers **commit on release, not on a timer firing while held**. The destructive tiers escalate from shutdown to factory-reset after 10 s (see "GPIO button detection" below).
+The table above covers the primary GPIO button and TTP223. The dedicated reset button on pin 35 only factory-resets when released after a hold of at least 5 s. Shorter holds and single/triple taps do nothing; it never invokes sleep or shutdown. LED stays unchanged below 5 s and uses the shared solid-red factory-reset preset from 5 s onward.
+
+MPR121 also supports release-to-commit holds and the same hold-tier LED feedback, as detailed in its detection section. The sleep and destructive hold tiers **commit on release, not on a timer firing while held**. The destructive tiers escalate from shutdown to factory-reset after 10 s (see "GPIO button detection" below).
 
 ## Interrupting Lamp while it speaks (barge-in)
 
@@ -163,6 +180,8 @@ To characterise a new deployment: park `HAL_BARGE_IN_RMS_THRESHOLD` at 30000, sa
 
 ## GPIO button detection (`hal/drivers/gpio_button.py`)
 
+The same driver serves each configured button independently. The sequence below describes `behavior: "standard"` (the primary button). For `behavior: "factory_reset"`, a release after `hold_s` (5 s on Lamp pin 35) calls the shared `factory_reset_action`; shorter holds and all tap sequences are ignored. Its hold watcher selects only the shared factory-reset LED tier at that threshold.
+
 Edge-counting driver where **all destructive actions commit on the release edge based on hold duration** — no timer fires while the button is held. This is what lets the user cancel mid-hold (release before a threshold) or escalate (keep holding past 10 s).
 
 1. **Falling edge (press):** record `press_start` (monotonic clock) and spawn a hold-LED watcher thread (one per press, with its own stop `Event`). No action timer is armed.
@@ -179,7 +198,7 @@ A release edge with no matching press (the press was debounce-dropped) is ignore
 
 ### Hold LED feedback
 
-The GPIO watcher thread polls the hold duration and selects a tier. Shared `HoldLEDFeedback` in `hal/drivers/button_actions.py`, also used by MPR121, drives the RGB LED at HIGH priority (preempts the current emotion) so the user sees how far they've armed before they release:
+For the primary button, the GPIO watcher thread polls the hold duration and selects a tier. Shared `HoldLEDFeedback` in `hal/drivers/button_actions.py`, also used by MPR121, drives the RGB LED at HIGH priority (preempts the current emotion) so the user sees how far they've armed before they release:
 
 | Hold elapsed | LED | Meaning |
 |---|---|---|
@@ -187,6 +206,8 @@ The GPIO watcher thread polls the hold duration and selects a tier. Shared `Hold
 | 2–5 s | sleepy purple, blinking 2 Hz | sleepy is armed; releasing enters sleep (LED then turns off) |
 | 5–10 s | red, blinking 2 Hz | shutdown armed — releasing now shuts down |
 | 10 s+ | red, solid | factory-reset armed — releasing now wipes + reboots |
+
+The dedicated reset button uses only the solid-red `factory_reset` preset at ≥5 s; releasing before 5 s does nothing. No factory-reset runs while it remains held. Both GPIO inputs reuse this feedback implementation and the existing action library.
 
 Purple identifies the sleep tier; red blink vs red solid differentiates shutdown from factory-reset. The LED is a silent no-op when the RGB service is unavailable (dev machines) — the button still works.
 
@@ -403,7 +424,7 @@ The actions live in one place so the GPIO button, TTP223, MPR121, and any future
 
 ### Factory-reset: what gets wiped
 
-`factory_reset_action` only **announces + delegates** — the actual reset lives in the OS server (`system/server/system/factoryreset.go`), reachable from the device over loopback without a Bearer token (authoritative because of physical presence: a deliberate 10 s hold). `POST /api/system/factory-reset` is a **soft** reset (state wipe, not a reflash — kernel / OS packages / binaries / HAL `.venv` are untouched):
+`factory_reset_action` only **announces + delegates** — the actual reset lives in the OS server (`system/server/system/factoryreset.go`), reachable from the device over loopback without a Bearer token (authoritative because of physical presence: a deliberate 10 s hold on the primary button/MPR121 or 5 s on the dedicated reset button, followed by release). `POST /api/system/factory-reset` is a **soft** reset (state wipe, not a reflash — kernel / OS packages / binaries / HAL `.venv` are untouched):
 
 1. Wipe the active agent backend's state (OpenClaw or Hermes, auto-detected from `config.json` `agent_runtime`).
 2. Wipe the device state paths: `/root/config` (config.json — API keys, channel tokens, MQTT creds), `/root/local/users` + `/root/local/strangers` (face/voice enrollments), `/var/lib/hal/snapshots` (camera snapshots), and `/etc/wpa_supplicant/wpa_supplicant-wlan0.conf` (home WiFi creds → forces AP mode on next boot).

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -1,12 +1,12 @@
 # Điều khiển vật lý — Nút GPIO, TTP223 và MPR121
 
-Lamp hỗ trợ nút cơ học, touchpad TTP223 và bộ điều khiển cảm ứng điện dung MPR121 tùy chọn. Chúng dùng chung thư viện action (`hal/drivers/button_actions.py`) nên cùng một cử chỉ "single click" sẽ hành xử giống nhau dù đến từ nút bấm cơ học hay touchpad cảm ứng.
+Lamp hỗ trợ các nút cơ học, touchpad TTP223 và bộ điều khiển cảm ứng điện dung MPR121 tùy chọn. Chúng dùng chung thư viện action (`hal/drivers/button_actions.py`) nên cùng một cử chỉ "single click" sẽ hành xử giống nhau dù đến từ nút bấm cơ học hay touchpad cảm ứng.
 
 ## Thiết bị đầu vào
 
 | Thiết bị | Vai trò | Có ở |
 |---|---|---|
-| **Nút GPIO** | Một nút bấm cơ. Dùng cho các hành động dứt khoát kể cả destructive (reboot / shutdown / factory-reset). Cảm giác cơ + detect giữ lâu khiến destructive action khó xảy ra do vô tình. | Pi 4/5 và OrangePi sun60 |
+| **Nút GPIO** | Nút cơ chính cho click và giữ, thêm nút reset riêng trên OrangePi. Action giữ destructive chỉ thực hiện khi nhả. | Pi 4/5 và OrangePi sun60 |
 | **Touchpad cảm ứng TTP223** | Hai pad chạm xếp như "đầu cún" để vuốt ve + stop/unmute nhẹ. Không có destructive gesture vì FastMode của IC không cho detect giữ lâu tin cậy. | Chỉ OrangePi sun60 (4 Pro / A733) |
 | **Bộ điều khiển cảm ứng MPR121** | Tối đa 12 electrode, hỗ trợ click và giữ rồi nhả như GPIO, gồm reboot, shutdown và reset. | Lamp khai báo cấu hình I²C cụ thể trong `mpr121.json` |
 
@@ -14,22 +14,36 @@ Lamp hỗ trợ nút cơ học, touchpad TTP223 và bộ điều khiển cảm �
 
 | Thiết bị | Pi 4/5 | OrangePi sun60 |
 |---|---|---|
-| Nút GPIO | gpiochip0 BCM 17 (pull-up, active-LOW) | Pin vật lý 37 / PD4 / gpiochip0 line 100 (pull-up, active-LOW) |
+| Nút GPIO chính | gpiochip0 BCM 17 (pull-up, active-LOW) | Pin vật lý 37 / PD4 / gpiochip0 line 100 (pull-up, active-LOW) |
+| Nút GPIO reset | không wire | Pin vật lý 35 / PD3 / gpiochip0 line 99 (pull-up, active-LOW); giữ ≥5 s rồi nhả để factory-reset |
 | TTP223 | không wire | Hai pad: S1 tại pin vật lý 29 / PD0 / gpiochip0 line 96; S3 tại pin vật lý 33 / PD2 / gpiochip0 line 98. **Pull-up, active-LOW** (pad nghỉ ở mức HIGH; chạm là edge xuống). |
 
 Wiring nút cơ thuộc về từng device: `robots/lamp/gpio_button.json` và
 `robots/intern-v2/gpio_button.json` đều khai báo map `boards` với các key
-`raspberry_pi_4`, `raspberry_pi_5`, `orangepi_sun60`. Mỗi entry có `chip`, `line`
-và `debounce_ns` (hiện là `200000000`, tức 200 ms). Lamp dùng chân nút trong
-bảng trên; Intern v2 vẫn dùng gpiochip1 line 9 trên OrangePi. Khi đổi wiring,
-sửa file của device tương ứng rồi khởi động lại HAL; hệ thống không tự phát hiện việc đổi dây cắm. HAL xác định thư mục
-qua `DEVICES_DIR` và `DEVICE_TYPE`, rồi truyền `ButtonConfig` của board đã
-detect vào driver dùng chung. Cấu hình device được ưu tiên. Thiếu file hoặc
-entry của board thì dùng lại mặc định `button` trong `hal/board/boards.json`:
-chip 0 / line 17 cho Pi 4, Pi 5, CM4 và sim; chip 1 / line 9 cho OrangePi
-sun60; tất cả có debounce 200 ms. Config sai bị từ chối trước khi claim GPIO.
-Chế độ mô phỏng bỏ qua nút phần cứng. Pull-up, active-LOW và hành vi cử chỉ
-vẫn nằm trong driver dùng chung.
+`raspberry_pi_4`, `raspberry_pi_5`, `orangepi_sun60`. Entry hỗ trợ dạng phẳng
+cũ `chip`, `line`, `debounce_ns` hoặc list `buttons`. Entry OrangePi của Lamp:
+
+```json
+{
+  "buttons": [
+    {"name": "primary", "chip": 0, "line": 100, "debounce_ns": 200000000, "behavior": "standard"},
+    {"name": "factory_reset", "chip": 0, "line": 99, "debounce_ns": 200000000, "behavior": "factory_reset", "hold_s": 5}
+  ]
+}
+```
+
+JSON của Intern v2 giữ nguyên, với gpiochip1 line 9 trên OrangePi.
+Khi đổi wiring, sửa file của device tương ứng rồi restart HAL; hệ thống không
+tự phát hiện đổi dây cắm. HAL xác định thư mục qua `DEVICES_DIR` và
+`DEVICE_TYPE`. `load_button_configs` cấp cấu hình cho mỗi instance driver
+dùng chung; HAL dừng tất cả instance khi cleanup. `load_button_config` vẫn
+tương thích với caller chỉ cần nút đầu tiên (nút chính trong cấu hình Lamp). Cấu hình device được ưu tiên.
+Thiếu file hoặc entry board thì fallback về đúng một nút mặc định `button`
+cũ trong `hal/board/boards.json`: chip 0 / line 17 cho Pi 4, Pi 5, CM4 và
+sim; chip 1 / line 9 cho OrangePi sun60; tất cả debounce 200 ms. Config sai,
+tên trùng hoặc cặp chip/line trùng bị từ chối trước khi claim GPIO. Mô phỏng
+bỏ qua các nút phần cứng. Pull-up, active-LOW và nhận diện cử chỉ vẫn ở driver
+dùng chung.
 
 Wiring TTP223 cũng do device quản lý: `robots/lamp/ttp223.json` khai báo
 map `boards`. Intern v2 không có phần cứng TTP223 nên không kèm file này. Mỗi entry bật có `chip`,
@@ -53,7 +67,7 @@ Board được detect qua `/proc/device-tree/model`:
 
 ## Bảng cử chỉ
 
-| Cử chỉ | Nút GPIO | Touchpad TTP223 |
+| Cử chỉ | Nút GPIO chính | Touchpad TTP223 |
 |---|---|---|
 | **1 chạm** | Dừng object tracking đang chạy, rồi stop loa / unmute mic + speaker + chime ack (~120 ms ping) — tất cả fire ngay khi nhả nút (không đợi click window); cue "Nghe đây" phát sau khi click window 0.4 s phân giải xong | Tương tự sau khi quyết định tap-vs-pet 1.2 s xong — tracking đang chạy dừng, rồi action mic/loa và cue chạy. Chạm đầu tiên vẫn cắt TTS đang phát và kêu chime ack ngay. |
 | **2 chạm** (≤ 0.4 s, nút) / (≤ 1.2 s, TTP223) | Không thêm gì ngoài single-click đã fire ở chạm 1 (panic-click guard) | Pet response. Khi bật `HAL_TOUCH_SWIPE` (mặc định), các cú tap lặp lại tại cùng một chỗ — nhanh hay chậm, một ngón hay nhiều ngón — là **double tap** → toggle mute mic; khi đó pet nghĩa là ngón tay đã quay lại một pad |
@@ -63,7 +77,9 @@ Board được detect qua `/proc/device-tree/model`:
 | **Giữ 5–10 s rồi nhả** | Shutdown OS (TTS báo → release servo → `sudo shutdown -h now`). LED nháy đỏ khi đã arm. | n/a — phần cứng TTP223 không hold đáng tin được (xem "FastMode" dưới) |
 | **Giữ 10 s+ rồi nhả** | Factory-reset: wipe state thiết bị + reboot vào AP setup (TTS báo → release servo → POST `/api/system/factory-reset` trên OS server). LED đỏ đứng khi đã arm. | n/a |
 
-Bảng trên mô tả GPIO và TTP223. MPR121 cũng hỗ trợ giữ rồi nhả để thực hiện action và cùng phản hồi LED theo mức giữ, xem phần detect riêng. Mức sleep và các mức destructive **commit khi nhả, không phải khi timer fire lúc đang giữ**. Các mức destructive escalate từ shutdown sang factory-reset sau 10 s (xem "Detect nút GPIO" dưới).
+Bảng trên mô tả nút GPIO chính và TTP223. Nút reset riêng ở pin 35 chỉ factory-reset khi nhả sau khi giữ ít nhất 5 s. Giữ ngắn hơn và single/triple tap đều không làm gì; nút này không gọi sleep hoặc shutdown. LED giữ nguyên dưới 5 s và dùng preset factory-reset đỏ đứng chung từ 5 s trở lên.
+
+MPR121 cũng hỗ trợ giữ rồi nhả để thực hiện action và cùng phản hồi LED theo mức giữ, xem phần detect riêng. Mức sleep và các mức destructive **commit khi nhả, không phải khi timer fire lúc đang giữ**. Các mức destructive escalate từ shutdown sang factory-reset sau 10 s (xem "Detect nút GPIO" dưới).
 
 ## Cắt Lamp giữa câu (barge-in)
 
@@ -160,6 +176,8 @@ Khi barge-in được bật, đường đang chạy là vòng **warm mic**, khô
 
 ## Detect nút GPIO (`hal/drivers/gpio_button.py`)
 
+Cùng driver phục vụ từng nút được cấu hình một cách độc lập. Flow dưới đây mô tả `behavior: "standard"` (nút chính). Với `behavior: "factory_reset"`, nhả sau `hold_s` (5 s ở pin 35 của Lamp) gọi `factory_reset_action` dùng chung; giữ ngắn hơn và mọi chuỗi tap đều bị bỏ qua. Hold watcher chỉ chọn mức LED factory-reset dùng chung khi đạt ngưỡng đó.
+
 Driver đếm edge nơi **mọi destructive action commit ở rising edge (nhả) dựa trên thời lượng giữ** — không timer nào fire lúc đang giữ. Đây chính là cái cho phép user huỷ giữa chừng (nhả trước ngưỡng) hoặc escalate (giữ tiếp quá 10 s).
 
 1. **Falling edge (nhấn):** ghi `press_start` (đồng hồ monotonic) và spawn thread hold-LED watcher (mỗi lần nhấn 1 thread, có stop `Event` riêng). Không arm timer action nào.
@@ -176,7 +194,7 @@ Release edge không có press khớp (press bị debounce nuốt) thì bỏ qua 
 
 ### LED feedback khi giữ
 
-Thread watcher GPIO poll thời lượng giữ và chọn mức giữ. `HoldLEDFeedback` dùng chung trong `hal/drivers/button_actions.py`, cũng được MPR121 sử dụng, đẩy LED RGB ở priority HIGH (preempt emotion hiện tại) để user thấy đã arm tới đâu trước khi nhả:
+Với nút chính, thread watcher GPIO poll thời lượng giữ và chọn mức giữ. `HoldLEDFeedback` dùng chung trong `hal/drivers/button_actions.py`, cũng được MPR121 sử dụng, đẩy LED RGB ở priority HIGH (preempt emotion hiện tại) để user thấy đã arm tới đâu trước khi nhả:
 
 | Thời gian giữ | LED | Ý nghĩa |
 |---|---|---|
@@ -184,6 +202,8 @@ Thread watcher GPIO poll thời lượng giữ và chọn mức giữ. `HoldLEDF
 | 2–5 s | tím sleepy, nháy 2 Hz | đã arm sleepy; nhả ra sẽ vào sleep (LED sau đó tắt) |
 | 5–10 s | đỏ, nháy 2 Hz | đã arm shutdown — nhả bây giờ là tắt máy |
 | 10 s+ | đỏ, đứng | đã arm factory-reset — nhả bây giờ là wipe + reboot |
+
+Nút reset riêng chỉ dùng preset `factory_reset` đỏ đứng khi giữ ≥5 s; nhả trước 5 s không làm gì. Không factory-reset khi còn giữ. Cả hai nút GPIO dùng lại phần xử lý feedback này và thư viện action hiện có.
 
 Màu tím nhận diện mức sleep; đỏ nháy vs đỏ đứng phân biệt shutdown với factory-reset. LED là no-op im lặng khi RGB service không có (máy dev) — nút vẫn hoạt động.
 
@@ -397,7 +417,7 @@ Các action sống ở một chỗ để nút GPIO, TTP223, MPR121, và mọi in
 
 ### Factory-reset: wipe những gì
 
-`factory_reset_action` chỉ **báo + uỷ quyền** — phần reset thật nằm ở OS server (`system/server/system/factoryreset.go`), gọi được từ thiết bị qua loopback không cần Bearer token (authoritative nhờ hiện diện vật lý: giữ 10 s có chủ ý). `POST /api/system/factory-reset` là reset **mềm** (wipe state, không reflash — kernel / package OS / binary / `.venv` HAL không bị đụng):
+`factory_reset_action` chỉ **báo + uỷ quyền** — phần reset thật nằm ở OS server (`system/server/system/factoryreset.go`), gọi được từ thiết bị qua loopback không cần Bearer token (authoritative nhờ hiện diện vật lý: giữ có chủ ý 10 s trên nút chính/MPR121 hoặc 5 s trên nút reset riêng, rồi nhả). `POST /api/system/factory-reset` là reset **mềm** (wipe state, không reflash — kernel / package OS / binary / `.venv` HAL không bị đụng):
 
 1. Wipe state của agent backend đang chạy (OpenClaw hoặc Hermes, auto-detect từ `config.json` `agent_runtime`).
 2. Wipe các path state của thiết bị: `/root/config` (config.json — API key, channel token, MQTT creds), `/root/local/users` + `/root/local/strangers` (enrollment khuôn mặt/giọng), `/var/lib/hal/snapshots` (snapshot camera), và `/etc/wpa_supplicant/wpa_supplicant-wlan0.conf` (WiFi nhà → ép vào AP mode lần boot kế).

--- a/robots/lamp/gpio_button.json
+++ b/robots/lamp/gpio_button.json
@@ -11,9 +11,23 @@
       "debounce_ns": 200000000
     },
     "orangepi_sun60": {
-      "chip": 0,
-      "line": 100,
-      "debounce_ns": 200000000
+      "buttons": [
+        {
+          "name": "primary",
+          "chip": 0,
+          "line": 100,
+          "debounce_ns": 200000000,
+          "behavior": "standard"
+        },
+        {
+          "name": "factory_reset",
+          "chip": 0,
+          "line": 99,
+          "debounce_ns": 200000000,
+          "behavior": "factory_reset",
+          "hold_s": 5
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Lamp now has a dedicated reset button at physical pin 35 (PD3, gpiochip0/line99), alongside the existing primary button at pin 37. Configure both in the device JSON and instantiate the existing GPIO driver independently for each input.

The reset button ignores taps and holds below 5 seconds. At 5 seconds it shows the shared solid-red reset indication; releasing calls the existing factory-reset action once. The primary button retains its standard gestures. LED and action selection remain shared in button_actions.py.

Support named buttons lists while retaining the original flat JSON format and one-button legacy fallback for missing files/boards. Reject duplicate names/pins and invalid behavior/threshold declarations. Stop each GPIO handler on HAL shutdown and clean up failed starts. Update English and Vietnamese documentation.

Validation: 157 tests and 69 subtests passed across GPIO, button actions/feedback, MPR121, TTP223, and board tests. HAL lint clean across 354 files; startup/config syntax and git diff --check passed. Actual Lamp config has no pin overlap with TTP223. Destructive actions were mocked; not deployed to hardware.
