### PR TITLE
hal: configure Lamp mic switch and add MPR121 swipe to sleep

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -76,6 +76,23 @@ detected automatically. Malformed configuration, duplicate input names, and
 duplicate chip/line pairs are rejected before GPIO is claimed. Simulation
 skips hardware buttons.
 
+The microphone slide switch uses device-owned `mic_button.json`, initially
+shipped only at `robots/intern-v2/mic_button.json`. The detected board's entry
+under `boards` supplies `chip`, `line`, `settle_s`, `muted_level`, and
+`watchdog_s` to `hal/board/mic_button.py`, then the shared
+`hal/drivers/mic_button.py` driver. Intern v2's `orangepi_sun60` entry preserves
+gpiochip0 line 97 (PD1), a 0.06 s settling delay, LOW (`0`) for muted, and a
+30 s watchdog. Pull-up remains enabled; `muted_level` accepts `0` or `1`.
+A missing file or board entry preserves the old defaults for `intern-v2`
+only, including its existing device-type gate regardless of board ID. Other
+devices without configuration skip the switch; `enabled: false` explicitly
+disables it. Malformed configuration is rejected before GPIO is claimed.
+HAL synchronizes mute to the switch position at startup and after settled
+edges. The watchdog reconciles only when the pin changed, preserving software
+mute changes while the switch stays still. Restart HAL to apply JSON changes;
+simulation skips this hardware input. Lamp has no mic-switch JSON yet and
+remains disabled; no Lamp pin mapping is introduced by this refactor.
+
 TTP223 touch wiring is device-owned in `robots/lamp/ttp223.json`. Intern v2
 has no TTP223 hardware and does not ship this file. `hal/board/ttp223.py` resolves the detected
 board's `chip`, `lines` and optional `axis` from `boards` and passes a
@@ -103,7 +120,7 @@ inputs; simulation also skips it. Malformed enabled configuration rejects
 startup. Restart HAL after changing wiring configuration. The shared
 `hal/drivers/mpr121.py` driver groups selected electrodes into one debounced
 contact. It shares GPIO gesture thresholds in `hal/drivers/button_gestures.py`:
-the first short release immediately calls single-click with `announce=False`;
+the first resolved short release calls single-click with `announce=False`;
 a 0.4 s quiet window produces the listening cue for 1/2/4+ clicks or reboot
 for exactly 3. Holds commit only on release: 2–<5 s sleepy, 5–<10 s shutdown,
 ≥10 s factory reset. While held, debounced hold-tier events use the same
@@ -118,6 +135,17 @@ with mocked local tests; it has not been checked on the live device. Defaults ar
 or overcurrent fault stops only this driver. Logger `hal.drivers.mpr121` records
 configuration, electrode changes, debounced taps, action dispatch and lifecycle
 in the normal HAL log/journal; unchanged polls do not emit INFO logs.
+Lamp enables swipe detection with `swipe_axis: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]`.
+This ordered electrode axis follows observed travel in device logs; either
+orientation works because both directions call shared `swipe_action` to sleep.
+Partial traversals are supported. Stationary contacts keep click/hold actions;
+a moving contact suppresses those actions so dragging cannot become reset.
+Swipe classification adds up to 120 ms of release grace for electrode handoff.
+Missing/null `swipe_axis` preserves the original click/hold-only behavior.
+Install the updated HAL before the new device JSON: older strict loaders reject
+unknown configuration fields. Swipe tests replay recorded electrode transitions;
+the new runtime and swipe configuration were deployed to Lamp `lamp-0c4e` on
+2026-09-11 and startup was verified. Live gesture testing is pending.
 See [physical controls](../robots/lamp/docs/physical-controls.md) for configuration
 and gesture details.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -77,12 +77,12 @@ duplicate chip/line pairs are rejected before GPIO is claimed. Simulation
 skips hardware buttons.
 
 The microphone slide switch uses device-owned `mic_button.json`, initially
-shipped only at `robots/intern-v2/mic_button.json`. The detected board's entry
+shipped at `robots/lamp/mic_button.json` for physical pin 11 / PL9 / gpiochip1 line 9. The detected board's entry
 under `boards` supplies `chip`, `line`, `settle_s`, `muted_level`, and
 `watchdog_s` to `hal/board/mic_button.py`, then the shared
-`hal/drivers/mic_button.py` driver. Intern v2's `orangepi_sun60` entry preserves
-gpiochip0 line 97 (PD1), a 0.06 s settling delay, LOW (`0`) for muted, and a
-30 s watchdog. Pull-up remains enabled; `muted_level` accepts `0` or `1`.
+`hal/drivers/mic_button.py` driver. Intern v2 ships no mic JSON and continues
+using the code fallback: gpiochip0 line 97 (PD1), a 0.06 s settling delay,
+LOW (`0`) for muted, and a 30 s watchdog. Lamp uses the same timing/polarity. Pull-up remains enabled; `muted_level` accepts `0` or `1`.
 A missing file or board entry preserves the old defaults for `intern-v2`
 only, including its existing device-type gate regardless of board ID. Other
 devices without configuration skip the switch; `enabled: false` explicitly
@@ -90,8 +90,9 @@ disables it. Malformed configuration is rejected before GPIO is claimed.
 HAL synchronizes mute to the switch position at startup and after settled
 edges. The watchdog reconciles only when the pin changed, preserving software
 mute changes while the switch stays still. Restart HAL to apply JSON changes;
-simulation skips this hardware input. Lamp has no mic-switch JSON yet and
-remains disabled; no Lamp pin mapping is introduced by this refactor.
+simulation skips this hardware input. Keep Lamp's GPIO button JSON installed:
+its legacy primary-button fallback also uses pin 11, while the device JSON
+moves the primary button to pin 37. The Lamp mic JSON has not yet been deployed.
 
 TTP223 touch wiring is device-owned in `robots/lamp/ttp223.json`. Intern v2
 has no TTP223 hardware and does not ship this file. `hal/board/ttp223.py` resolves the detected

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -92,7 +92,8 @@ edges. The watchdog reconciles only when the pin changed, preserving software
 mute changes while the switch stays still. Restart HAL to apply JSON changes;
 simulation skips this hardware input. Keep Lamp's GPIO button JSON installed:
 its legacy primary-button fallback also uses pin 11, while the device JSON
-moves the primary button to pin 37. The Lamp mic JSON has not yet been deployed.
+moves the primary button to pin 37. Lamp startup with this mic JSON was verified on 2026-09-11: chip1/line9
+was ready and the initial LOW position applied mute. Live toggle testing is pending.
 
 TTP223 touch wiring is device-owned in `robots/lamp/ttp223.json`. Intern v2
 has no TTP223 hardware and does not ship this file. `hal/board/ttp223.py` resolves the detected

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -74,6 +74,22 @@ chọn rồi restart HAL; hệ thống không tự phát hiện đổi dây cắ
 tên input trùng hoặc cặp chip/line trùng bị từ chối trước khi claim GPIO.
 Chế độ mô phỏng bỏ qua nút phần cứng.
 
+Công tắc gạt microphone dùng `mic_button.json` do device quản lý, hiện chỉ
+kèm file `robots/intern-v2/mic_button.json`. Entry của board được phát hiện
+trong `boards` cung cấp `chip`, `line`, `settle_s`, `muted_level` và
+`watchdog_s` cho `hal/board/mic_button.py`, rồi truyền vào driver dùng chung
+`hal/drivers/mic_button.py`. Entry `orangepi_sun60` của Intern v2 giữ nguyên
+gpiochip0 line 97 (PD1), thời gian chờ ổn định 0,06 s, LOW (`0`) là mute và
+watchdog 30 s. Pull-up vẫn bật; `muted_level` nhận `0` hoặc `1`.
+Thiếu file hoặc entry board thì giữ default cũ chỉ cho `intern-v2`, bao gồm
+điều kiện device-type hiện có bất kể board ID. Device khác không có cấu hình
+thì bỏ qua công tắc; `enabled: false` tắt rõ ràng. Cấu hình sai bị từ chối
+trước khi claim GPIO. HAL đồng bộ mute theo vị trí công tắc lúc khởi động
+và sau khi cạnh tín hiệu ổn định. Watchdog chỉ đồng bộ lại khi chân đổi mức,
+giữ các thay đổi mute bằng phần mềm khi công tắc đứng yên. Restart HAL để
+áp dụng JSON mới; simulation bỏ qua input phần cứng này. Lamp chưa có JSON
+công tắc mic nên vẫn tắt; bước refactor này chưa thêm mapping chân cho Lamp.
+
 Wiring TTP223 do device quản lý trong `robots/lamp/ttp223.json`. Intern v2
 không có phần cứng TTP223 nên không kèm file này. `hal/board/ttp223.py` chọn `chip`, `lines` và
 `axis` tùy chọn của board đã detect từ `boards`, truyền `TouchConfig` cho driver
@@ -100,7 +116,7 @@ hiện có; chế độ mô phỏng cũng bỏ qua. Cấu hình bật nhưng sai
 startup. Restart HAL sau khi đổi cấu hình wiring. Driver dùng chung
 `hal/drivers/mpr121.py` gom các electrode được chọn thành một phiên chạm rồi
 nhả đã debounce. Ngưỡng cử chỉ dùng chung GPIO trong
-`hal/drivers/button_gestures.py`: lần nhả ngắn đầu tiên gọi single-click ngay
+`hal/drivers/button_gestures.py`: lần nhả ngắn đầu tiên được phân giải gọi single-click
 với `announce=False`; sau 0.4 s yên, 1/2/4+ click phát cue nghe, đúng 3 click
 thì reboot. Giữ chỉ thực hiện khi nhả: 2–<5 s sleepy, 5–<10 s shutdown,
 ≥10 s factory reset. Khi giữ, event mức giữ đã debounce dùng cùng `HoldLEDFeedback`
@@ -114,6 +130,16 @@ polling 10 ms và debounce 30 ms, chờ ổn định 100 ms lúc startup. Lỗi 
 cờ quá dòng chỉ dừng driver này. Logger `hal.drivers.mpr121` ghi cấu hình,
 thay đổi electrode, tap đã debounce, thực thi action và vòng đời driver trong
 log/journal HAL thường dùng; poll không đổi trạng thái không tạo log INFO.
+Lamp bật nhận diện vuốt với `swipe_axis: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]`.
+Trục electrode này theo chuỗi di chuyển quan sát được trong log device; đảo
+chiều trục không đổi action vì cả hai hướng gọi `swipe_action` dùng chung để sleep.
+Hỗ trợ vuốt một phần dải. Chạm đứng yên giữ action click/hold; contact di chuyển
+loại bỏ các action đó để vuốt không biến thành reset. Nhận diện swipe thêm tối đa
+120 ms chờ nhả để nối chuyển tiếp giữa electrode. Thiếu/null `swipe_axis` giữ
+hành vi chỉ click/hold cũ. Cài HAL mới trước JSON device mới vì loader cũ kiểm tra
+nghiêm ngặt và từ chối trường chưa biết. Test swipe phát lại chuyển trạng thái
+electrode đã ghi; runtime và cấu hình swipe mới đã deploy lên Lamp `lamp-0c4e`
+ngày 2026-09-11, xác minh startup thành công. Chờ live test cử chỉ.
 Xem [điều khiển vật lý](../../robots/lamp/docs/vi/physical-controls_vi.md) để
 biết cấu hình và chi tiết cử chỉ.
 

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -89,7 +89,8 @@ và sau khi cạnh tín hiệu ổn định. Watchdog chỉ đồng bộ lại k
 giữ các thay đổi mute bằng phần mềm khi công tắc đứng yên. Restart HAL để
 áp dụng JSON mới; simulation bỏ qua input phần cứng này. Cần giữ JSON nút GPIO
 của Lamp vì fallback nút chính cũ cũng dùng pin 11, còn JSON device chuyển nút
-chính sang pin 37. JSON mic mới của Lamp chưa được deploy.
+chính sang pin 37. Đã xác minh startup với JSON mic Lamp ngày 2026-09-11: chip1/line9 ready,
+vị trí LOW ban đầu áp dụng mute. Chờ live test thao tác gạt.
 
 Wiring TTP223 do device quản lý trong `robots/lamp/ttp223.json`. Intern v2
 không có phần cứng TTP223 nên không kèm file này. `hal/board/ttp223.py` chọn `chip`, `lines` và

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -75,20 +75,21 @@ tên input trùng hoặc cặp chip/line trùng bị từ chối trước khi cl
 Chế độ mô phỏng bỏ qua nút phần cứng.
 
 Công tắc gạt microphone dùng `mic_button.json` do device quản lý, hiện chỉ
-kèm file `robots/intern-v2/mic_button.json`. Entry của board được phát hiện
+kèm file `robots/lamp/mic_button.json` cho pin vật lý 11 / PL9 / gpiochip1 line 9. Entry của board được phát hiện
 trong `boards` cung cấp `chip`, `line`, `settle_s`, `muted_level` và
 `watchdog_s` cho `hal/board/mic_button.py`, rồi truyền vào driver dùng chung
-`hal/drivers/mic_button.py`. Entry `orangepi_sun60` của Intern v2 giữ nguyên
-gpiochip0 line 97 (PD1), thời gian chờ ổn định 0,06 s, LOW (`0`) là mute và
-watchdog 30 s. Pull-up vẫn bật; `muted_level` nhận `0` hoặc `1`.
+`hal/drivers/mic_button.py`. Intern v2 không kèm JSON mic, tiếp tục dùng
+fallback trong code: gpiochip0 line 97 (PD1), chờ ổn định 0,06 s, LOW (`0`)
+là mute và watchdog 30 s. Lamp dùng cùng timing/polarity. Pull-up vẫn bật; `muted_level` nhận `0` hoặc `1`.
 Thiếu file hoặc entry board thì giữ default cũ chỉ cho `intern-v2`, bao gồm
 điều kiện device-type hiện có bất kể board ID. Device khác không có cấu hình
 thì bỏ qua công tắc; `enabled: false` tắt rõ ràng. Cấu hình sai bị từ chối
 trước khi claim GPIO. HAL đồng bộ mute theo vị trí công tắc lúc khởi động
 và sau khi cạnh tín hiệu ổn định. Watchdog chỉ đồng bộ lại khi chân đổi mức,
 giữ các thay đổi mute bằng phần mềm khi công tắc đứng yên. Restart HAL để
-áp dụng JSON mới; simulation bỏ qua input phần cứng này. Lamp chưa có JSON
-công tắc mic nên vẫn tắt; bước refactor này chưa thêm mapping chân cho Lamp.
+áp dụng JSON mới; simulation bỏ qua input phần cứng này. Cần giữ JSON nút GPIO
+của Lamp vì fallback nút chính cũ cũng dùng pin 11, còn JSON device chuyển nút
+chính sang pin 37. JSON mic mới của Lamp chưa được deploy.
 
 Wiring TTP223 do device quản lý trong `robots/lamp/ttp223.json`. Intern v2
 không có phần cứng TTP223 nên không kèm file này. `hal/board/ttp223.py` chọn `chip`, `lines` và

--- a/hal/board/mic_button.py
+++ b/hal/board/mic_button.py
@@ -1,0 +1,65 @@
+"""Device-owned microphone slide-switch wiring with the legacy Intern fallback."""
+
+from dataclasses import dataclass, fields
+import json
+import math
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class MicButtonConfig:
+    chip: int = 0
+    line: int = 97
+    settle_s: float = 0.06
+    muted_level: int = 0
+    watchdog_s: float = 30.0
+
+
+def load_mic_button_config(device_dir: str, board_id: str,
+                           device_type: str) -> MicButtonConfig | None:
+    """Missing declarations preserve the old device-only Intern gate and wiring.
+
+    Other devices remain disabled until explicitly configured. The caller skips
+    simulation before invoking the loader, as for the other hardware inputs.
+    """
+    fallback = MicButtonConfig() if device_type == "intern-v2" else None
+    path = Path(device_dir) / "mic_button.json"
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        return fallback
+    try:
+        data = json.loads(text)
+        if not isinstance(data, dict) or set(data) != {"boards"} or not isinstance(data["boards"], dict):
+            raise ValueError("expected an object containing a boards map")
+        configs = {}
+        allowed = {field.name for field in fields(MicButtonConfig)} | {"enabled"}
+        for board, entry in data["boards"].items():
+            if not isinstance(entry, dict) or set(entry) - allowed:
+                raise ValueError(f"{board}: invalid mic switch fields")
+            values = dict(entry)
+            enabled = values.pop("enabled", True)
+            if type(enabled) is not bool:
+                raise ValueError(f"{board}: enabled must be boolean")
+            if not enabled:
+                configs[board] = None
+                continue
+            if not {"chip", "line"} <= set(values):
+                raise ValueError(f"{board}: chip and line are required")
+            config = MicButtonConfig(**values)
+            for name in ("chip", "line"):
+                value = getattr(config, name)
+                if type(value) is not int or value < 0:
+                    raise ValueError(f"{board}: {name} must be a non-negative integer")
+            if type(config.muted_level) is not int or config.muted_level not in (0, 1):
+                raise ValueError(f"{board}: muted_level must be 0 or 1")
+            for name in ("settle_s", "watchdog_s"):
+                value = getattr(config, name)
+                if type(value) not in (int, float) or not math.isfinite(value) or value < 0:
+                    raise ValueError(f"{board}: {name} must be finite and non-negative")
+            if config.watchdog_s == 0:
+                raise ValueError(f"{board}: watchdog_s must be positive")
+            configs[board] = config
+        return configs.get(board_id, fallback)
+    except (ValueError, TypeError, OverflowError) as exc:
+        raise ValueError(f"Invalid mic switch wiring at {path}: {exc}") from exc

--- a/hal/board/mpr121.py
+++ b/hal/board/mpr121.py
@@ -16,6 +16,7 @@ class MPR121Config:
     autoconfig: bool = True
     poll_ms: int = 10
     debounce_ms: int = 30
+    swipe_axis: tuple[int, ...] | None = None
 
     def __post_init__(self):
         for name in ("bus", "address", "touch_threshold", "release_threshold", "poll_ms", "debounce_ms"):
@@ -38,6 +39,13 @@ class MPR121Config:
         if len(set(self.electrodes)) != len(self.electrodes):
             raise ValueError("electrodes must not contain duplicates")
         object.__setattr__(self, "electrodes", tuple(self.electrodes))
+        if self.swipe_axis is not None:
+            axis = self.swipe_axis
+            if (not isinstance(axis, (list, tuple)) or not 2 <= len(axis) <= 12
+                    or any(type(i) is not int or i not in self.electrodes for i in axis)
+                    or len(set(axis)) != len(axis)):
+                raise ValueError("swipe_axis must contain 2..12 distinct selected electrodes in physical order")
+            object.__setattr__(self, "swipe_axis", tuple(axis))
 
 
 def load_mpr121_config(device_dir: str, board_id: str) -> Optional[MPR121Config]:

--- a/hal/drivers/button_actions.py
+++ b/hal/drivers/button_actions.py
@@ -468,14 +468,12 @@ def swipe_action(source: str = "touch"):
 def mic_toggle_action(source: str = "touch"):
     """Map a resolved double tap to the mic mute toggle.
 
-    Lamp has no hardware mic switch (`_hw_mic_switch_muted` is None here), so
-    this is the only physical path to the microphone. The mic-muted LED is the
-    whole user-facing confirmation — a muted mic has no audible acknowledgement
-    — and both routes below repaint it themselves.
+    Respect the configured hardware switch when present. The mic-muted LED
+    reflects the resulting state, and both routes below repaint it themselves.
     """
-    # The HW kill switch is the authority on boards that have one. Lamp reports
-    # None and falls through; a board that does have the switch must not have it
-    # overridden by a touch gesture. Guarding here as well as in unmute_mic
+    # The HW kill switch is the authority when configured. Devices without one
+    # report None and fall through; touch gestures cannot override a muted
+    # physical switch. Guarding here as well as in unmute_mic
     # keeps the refusal quiet rather than raising the route's 409.
     if state._hw_mic_switch_muted is True:
         logger.info("%s double tap ignored -- HW mic switch is off", source)

--- a/hal/drivers/mic_button.py
+++ b/hal/drivers/mic_button.py
@@ -1,109 +1,26 @@
-"""Dedicated mic-mute slide switch on PD1 (Intern v2 Pro only).
+"""Configured level-driven mic-mute slide switch.
 
-Wiring is a SPST slide switch, not a momentary push button — one position
-bridges PD1 to GND, the other leaves it floating (pull-up wins). We track
-level, not edges: the switch position IS the mute state, so pressing/
-releasing has no meaning here. Every edge flips the mic to whatever the
-new level dictates, and we also re-sync at HAL start-up so a boot with
-the switch already in the "muted" position ends up with a muted mic
-without waiting for the user to toggle it.
-
-Polarity:
-- LOW  (0) → switch shorted to GND → mic MUTED
-- HIGH (1) → switch open (pull-up)   → mic UNMUTED
-Flip `_LEVEL_MUTED` below if the physical wiring is the opposite.
-
-Web admin coexistence: `/api/hardware/voice/mute` (+ /voice/unmute) share
-the same `state._mic_muted` variable. If a user mutes via the web while
-the switch is in "unmute" position, the discrepancy stands until the
-next physical throw — the switch is the authority on the *next* edge,
-not continuously. That matches how a hardware kill-switch is expected
-to behave.
-
-Device gating: Intern v2 Pro and Lamp share the same board (OrangePi
-sun60iw2) but ship different hardware kits — only Intern v2 Pro has a
-switch physically wired to PD1. Lamp's PD1 is either unpopulated or used
-for something else, so claiming it there would either float and log spam
-on stray edges, or actively collide with another driver. We gate on
-DEVICE_TYPE (the same env the OS resolves at boot — see
-server._resolve_device_type) rather than the board profile so the wiring
-declaration follows the physical kit, not the SoC.
-
-Pin choice: PE1 was the obvious candidate from the header silkscreen but
-it's already claimed by SPI3_CLK for the WS2812 LED strip (see
-boards.json led.spi_bus=3). PD1 sits next to the TTP223 touch lines
-(PD0/PD2/PD4 at chip0 lines 96/98/100) and is unclaimed on this board,
-so we route the switch there instead.
-
-PD1 wiring:
-- PD = pinctrl bank 3 on Allwinner sun60iw2 → chip 0 lines 96–127
-- PD1 = chip 0, line 97
-- Debounce mirrors the primary wake button (200 ms) — same OrangePi
-  contact-bounce characteristics; slide-switch contacts also bounce
-  briefly during the throw.
+Wiring and timing are injected from the device configuration. Boot synchronizes
+mic state with the switch; edges reconcile after settling. The watchdog only
+reconciles changed physical levels so software-only mute remains untouched.
 """
 
 import logging
-import os
 import threading
 import time
 
 import hal.app_state as state
+from hal.board.mic_button import MicButtonConfig
 
 logger = logging.getLogger(__name__)
 
-# PD1 = pinctrl bank 3 (PD) + line 1 → gpiochip0 line 97 on Allwinner
-# sun60iw2. Only wired on Intern v2 Pro; see the module docstring.
-_MIC_BTN_CHIP = 0
-_MIC_BTN_LINE = 97
-# Settle time after the LAST edge before we re-read the pin. Slide switch
-# contacts bounce for a few ms during the throw; 60 ms covers the bounce
-# tail without introducing a noticeable delay for the operator. This is
-# the settle window, NOT a "drop-if-within" filter — see _on_edge for the
-# timer-restart pattern that makes rapid flips reliable.
-_MIC_BTN_SETTLE_SEC = 0.06
-
-# GPIO level that means "muted". Flip if the physical wiring inverts.
-_LEVEL_MUTED = 0
-
-# Watchdog reconcile period. lgpio's edge-callback thread has been observed
-# to stall silently under sustained edge storms (the HAL process stays up,
-# routes still respond, but no more edges fire). Reading the pin every
-# _WATCHDOG_SEC and driving state to match the level guarantees the mic
-# state converges to the switch's physical position even if we miss every
-# edge for a while — cheap safety net, not a replacement for the callback.
-_WATCHDOG_SEC = 30.0
-
-# Device types that ship with a mic-mute switch physically wired to PD1.
-# Add here when a new device model gets the switch — the driver stays the
-# same, only the whitelist grows. Cross-check the wiring before adding: a
-# device on the same board but different kit could have PD1 in use for
-# something else, in which case claiming it here would misfire.
-_DEVICES_WITH_MIC_BUTTON = frozenset({"intern-v2"})
-
-
-def _resolve_device_type() -> str:
-    """Same resolution order as server._resolve_device_type — env first,
-    then config.json — so the driver agrees with the rest of HAL about
-    which body it's running on. Kept local (rather than imported from
-    server) to avoid an import cycle: server imports drivers, not the
-    other way around."""
-    dev = os.environ.get("DEVICE_TYPE")
-    if dev:
-        return dev
-    try:
-        from hal.config import _os_cfg_get
-
-        cfg = _os_cfg_get("device_type")
-        if cfg:
-            return str(cfg)
-    except Exception:
-        pass
-    return ""
-
 
 class MicButtonHandler:
-    def __init__(self):
+    def __init__(self, config: MicButtonConfig | None):
+        self._config = config
+        self._stopped = threading.Event()
+        self._stopped.set()
+        self._watchdog_thread: threading.Thread | None = None
         self._lgpio = None
         self._handle = None
         self._callback = None
@@ -129,54 +46,57 @@ class MicButtonHandler:
         self._last_known_level: int | None = None
 
     def start(self):
-        dev = _resolve_device_type()
-        if dev not in _DEVICES_WITH_MIC_BUTTON:
-            logger.info(
-                "Mic switch disabled: device_type=%r (only wired on %s)",
-                dev or "<unset>",
-                ", ".join(sorted(_DEVICES_WITH_MIC_BUTTON)),
-            )
+        if self._config is None:
+            logger.info("Mic switch disabled: no device wiring configured")
+            return
+        if not self._stopped.is_set():
+            return
+        if self._watchdog_thread is not None and self._watchdog_thread.is_alive():
+            logger.warning("Mic switch start skipped: previous watchdog is still stopping")
             return
 
         import lgpio
 
         self._lgpio = lgpio
+        self._stopped.clear()
 
         try:
-            self._handle = lgpio.gpiochip_open(_MIC_BTN_CHIP)
+            self._handle = lgpio.gpiochip_open(self._config.chip)
         except Exception as e:
-            logger.warning("Mic switch gpiochip_open(%d) failed: %s", _MIC_BTN_CHIP, e)
+            logger.warning("Mic switch gpiochip_open(%d) failed: %s", self._config.chip, e)
+            self.stop()
             return
 
         try:
             lgpio.gpio_claim_alert(
-                self._handle, _MIC_BTN_LINE, lgpio.BOTH_EDGES, lgpio.SET_PULL_UP
+                self._handle, self._config.line, lgpio.BOTH_EDGES, lgpio.SET_PULL_UP
             )
             self._callback = lgpio.callback(
-                self._handle, _MIC_BTN_LINE, lgpio.BOTH_EDGES, self._on_edge
+                self._handle, self._config.line, lgpio.BOTH_EDGES, self._on_edge
             )
         except Exception as e:
             logger.warning(
-                "Mic switch claim line %d failed: %s -- disabled", _MIC_BTN_LINE, e
+                "Mic switch claim line %d failed: %s -- disabled", self._config.line, e
             )
+            self.stop()
             return
 
         # Sync boot-time state to the switch's current position. Without this,
         # a device that boots with the switch already in "muted" would run
         # with the mic hot until the user throws it once and back.
         try:
-            initial_level = lgpio.gpio_read(self._handle, _MIC_BTN_LINE)
+            initial_level = lgpio.gpio_read(self._handle, self._config.line)
         except Exception as e:
             logger.warning("Mic switch initial read failed: %s", e)
-            initial_level = 1  # default to unmuted if read fails
+            initial_level = 1 - self._config.muted_level  # default to unmuted if read fails
 
         logger.info(
-            "Mic mute switch ready on gpiochip%d line %d (PD1, initial level=%d, settle %d ms, watchdog %ds)",
-            _MIC_BTN_CHIP,
-            _MIC_BTN_LINE,
+            "Mic mute switch ready on gpiochip%d line %d (initial level=%d, settle %d ms, watchdog %ds)",
+            self._config.chip,
+            self._config.line,
             initial_level,
-            int(_MIC_BTN_SETTLE_SEC * 1000),
-            int(_WATCHDOG_SEC),
+            int(self._config.settle_s * 1000),
+            int(self._config.watchdog_s),
         )
 
         # Boot-time sync runs SYNCHRONOUSLY (unlike the edge handler which
@@ -188,14 +108,42 @@ class MicButtonHandler:
         # (~tens of ms at most) so blocking start() here is worth it.
         self._last_known_level = initial_level
         with self._apply_lock:
-            self._apply_state_locked(initial_level == _LEVEL_MUTED)
+            self._apply_state_locked(initial_level == self._config.muted_level)
 
         # Watchdog: periodic pin re-read + reconcile. Self-heals if the
         # lgpio edge-callback thread stalls silently. Daemon so it dies with
-        # the process; no explicit stop needed.
-        threading.Thread(
+        # the process; stop() also cancels and joins the watchdog.
+        self._watchdog_thread = threading.Thread(
             target=self._watchdog_loop, daemon=True, name="mic-switch-watchdog"
-        ).start()
+        )
+        self._watchdog_thread.start()
+
+    def stop(self):
+        """Cancel asynchronous work before releasing the GPIO handle."""
+        self._stopped.set()
+        with self._timer_lock:
+            if self._settle_timer is not None:
+                self._settle_timer.cancel()
+                self._settle_timer = None
+        if self._callback is not None:
+            try:
+                self._callback.cancel()
+            except Exception as exc:
+                logger.warning("Mic switch callback cancel failed: %s", exc)
+            finally:
+                self._callback = None
+        if self._watchdog_thread is not None:
+            self._watchdog_thread.join(timeout=2.0)
+            if not self._watchdog_thread.is_alive():
+                self._watchdog_thread = None
+        with self._apply_lock:
+            if self._handle is not None:
+                try:
+                    self._lgpio.gpiochip_close(self._handle)
+                except Exception as exc:
+                    logger.warning("Mic switch gpiochip_close failed: %s", exc)
+                finally:
+                    self._handle = None
 
     def _on_edge(self, chip, gpio, level, tick):
         # Restart the settle timer on every edge. The `level` param from
@@ -207,9 +155,11 @@ class MicButtonHandler:
         self._last_edge_ts = time.monotonic()
         logger.info("[mic-switch-trace] EDGE fired (level=%d, tick=%d)", level, tick)
         with self._timer_lock:
+            if self._stopped.is_set():
+                return
             if self._settle_timer is not None:
                 self._settle_timer.cancel()
-            t = threading.Timer(_MIC_BTN_SETTLE_SEC, self._reconcile)
+            t = threading.Timer(self._config.settle_s, self._reconcile)
             t.daemon = True
             t.name = "mic-switch-settle"
             self._settle_timer = t
@@ -220,32 +170,36 @@ class MicButtonHandler:
         settle Timer (after an edge storm quiets) and from the watchdog.
         Runs under _apply_lock so concurrent triggers can't race the
         underlying mute_mic() / unmute_mic() routes."""
+        t_lock_want = time.monotonic()
+        with self._apply_lock:
+            if self._stopped.is_set():
+                return
+            logger.info(
+                "[mic-switch-trace] APPLY_LOCK acquired (waited=%.0fms)",
+                (time.monotonic() - t_lock_want) * 1000,
+            )
+            self._reconcile_locked()
+
+    def _reconcile_locked(self):
         t_recon = time.monotonic()
         since_edge = (t_recon - self._last_edge_ts) if self._last_edge_ts else -1
         try:
-            current_level = self._lgpio.gpio_read(self._handle, _MIC_BTN_LINE)
+            current_level = self._lgpio.gpio_read(self._handle, self._config.line)
         except Exception as e:
             logger.warning("Mic switch reconcile read failed: %s", e)
             return
         logger.info(
             "[mic-switch-trace] RECONCILE pin_level=%d muted=%s (settle_wait=%.0fms since last edge)",
             current_level,
-            current_level == _LEVEL_MUTED,
+            current_level == self._config.muted_level,
             since_edge * 1000 if since_edge >= 0 else -1,
         )
-        t_lock_want = time.monotonic()
-        with self._apply_lock:
-            t_lock_got = time.monotonic()
-            logger.info(
-                "[mic-switch-trace] APPLY_LOCK acquired (waited=%.0fms)",
-                (t_lock_got - t_lock_want) * 1000,
-            )
-            self._apply_state_locked(current_level == _LEVEL_MUTED)
-            self._last_known_level = current_level
-            logger.info(
-                "[mic-switch-trace] APPLY_STATE done (total_edge→done=%.0fms)",
-                (time.monotonic() - self._last_edge_ts) * 1000 if self._last_edge_ts else -1,
-            )
+        self._apply_state_locked(current_level == self._config.muted_level)
+        self._last_known_level = current_level
+        logger.info(
+            "[mic-switch-trace] APPLY_STATE done (total_edge→done=%.0fms)",
+            (time.monotonic() - self._last_edge_ts) * 1000 if self._last_edge_ts else -1,
+        )
 
     def _watchdog_loop(self):
         """Periodic pin re-read to catch missed edges (lgpio callback thread
@@ -256,10 +210,12 @@ class MicButtonHandler:
         pin never moved from its idle position, but our state did — verified
         2026-07-24: user muted via web, watchdog auto-unmuted 28s later because
         pin_level=1 while state._mic_muted=True."""
-        while True:
-            time.sleep(_WATCHDOG_SEC)
+        while not self._stopped.wait(self._config.watchdog_s):
             try:
-                current = self._lgpio.gpio_read(self._handle, _MIC_BTN_LINE)
+                with self._apply_lock:
+                    if self._stopped.is_set():
+                        return
+                    current = self._lgpio.gpio_read(self._handle, self._config.line)
             except Exception as e:
                 logger.warning("Mic switch watchdog read failed: %s", e)
                 continue
@@ -291,19 +247,21 @@ class MicButtonHandler:
         or music started meanwhile."""
         deadline = time.monotonic() + 5.0
         while time.monotonic() < deadline:
-            if state._hw_mic_switch_muted is True or state._mic_muted:
+            if self._stopped.is_set() or state._hw_mic_switch_muted is True or state._mic_muted:
                 return
             if state._music_playing:
                 return
             if not state._tts_speaking:
                 break
-            time.sleep(0.1)
+            if self._stopped.wait(0.1):
+                return
         else:
             logger.info("mic switch unmute listening cue: TTS never quiesced -- skipping")
             return
         # Small settle after TTS end so the wave's teardown restore lands
         # first; painting into a live restore path races the effect thread.
-        time.sleep(0.15)
+        if self._stopped.wait(0.15):
+            return
         if state._hw_mic_switch_muted is True or state._mic_muted:
             return
         try:

--- a/hal/drivers/mpr121.py
+++ b/hal/drivers/mpr121.py
@@ -165,6 +165,185 @@ class _GestureRecognizer:
         return events
 
 
+# The release grace joins a finger handoff without turning it into two taps.
+SWIPE_RELEASE_S = 0.120
+SWIPE_MAX_GAP_S = 0.150
+SWIPE_MIN_TRAVEL_S = 0.060
+
+
+class _SpatialGestureRecognizer:
+    """Debounce electrode footprints before resolving travel versus a button."""
+
+    def __init__(self, config):
+        self._axis = config.swipe_axis
+        self._selected = config.electrodes
+        # A 30 ms per-pad filter erases measured 10-20 ms travel steps.
+        # Require consecutive samples for footprints, while retaining the
+        # configured union-contact debounce for button presses and boot holds.
+        self._delay = min(config.debounce_ms / 1000, 0.005)
+        self._contact_delay = config.debounce_ms / 1000
+        self._raw_active = False
+        self._contact_since = 0.0
+        self._button = _GestureRecognizer(0)
+        self._raw = {}
+        self._stable = set()
+        self._seeded = False
+        self._armed = False
+        self._cycle = False
+        self._release_at = None
+        self._gesture_id = 0
+        self._clear_cycle()
+
+    def _clear_cycle(self):
+        self._cycle = False
+        self._seen = set()
+        self._outside = set()
+        self._previous_positions = set()
+        self._origin = None
+        self._last_center = None
+        self._last_move = None
+        self._started = None
+        self._direction = 0
+        self._peak = 0
+        self._moving = False
+        self._invalid = False
+        self._release_at = None
+
+    def cancel(self):
+        self._button.cancel()
+        self._clear_cycle()
+        self._armed = False
+
+    def _finish(self, now, active=False):
+        events = []
+        if self._moving:
+            span = min(3, len(self._axis) - 1)
+            valid = (not self._invalid and self._peak >= span
+                     and self._last_move - self._started >= SWIPE_MIN_TRAVEL_S)
+            logger.info("MPR121 event=swipe_resolved gesture_id=%d direction=%s displacement=%.2f valid=%s",
+                        self._gesture_id, self._direction, self._peak, valid)
+            if valid:
+                events.append(_GestureEvent("swipe", self._gesture_id))
+            # Restart the button detector only after the spatial cycle ends.
+            self._button = _GestureRecognizer(0)
+            self._button.update(False, now)
+        else:
+            events.extend(self._button.update(False, self._release_at))
+            if not active:
+                events.extend(self._button.update(False, now))
+        self._clear_cycle()
+        return events
+
+    def update(self, mask, now):
+        active = {i for i in self._selected if mask & (1 << i)}
+        if not self._seeded:
+            self._seeded = True
+            self._raw_active = bool(active)
+            self._contact_since = now
+            self._stable = active
+            self._raw = {i: (i in active, now) for i in self._selected}
+            self._armed = not active
+            self._button.update(bool(active), now)
+            return []
+        events = []
+        if bool(active) != self._raw_active:
+            self._raw_active = bool(active)
+            self._contact_since = now
+            if active:
+                events.append(_GestureEvent("invalidate", self._gesture_id))
+        for i in self._selected:
+            value = i in active
+            previous, since = self._raw[i]
+            if value != previous:
+                self._raw[i] = (value, now)
+                since = now
+            if now - since >= self._delay:
+                if value:
+                    self._stable.add(i)
+                else:
+                    self._stable.discard(i)
+        stable = self._stable
+        if not self._armed:
+            if not stable and not active and now - self._contact_since >= self._contact_delay:
+                self._armed = True
+                self._button = _GestureRecognizer(0)
+                self._button.update(False, now)
+            return events
+        # Resolve an old contact before looking at the next one. Raw contact
+        # blocks release only inside the handoff grace, never indefinitely.
+        if self._cycle and self._release_at is not None:
+            if now - self._release_at >= SWIPE_RELEASE_S:
+                events.extend(self._finish(now, bool(active)))
+            elif stable:
+                positions = {self._axis.index(i) for i in stable if i in self._axis}
+                if self._contact_since - self._release_at < self._contact_delay:
+                    self._release_at = None
+                elif not self._moving and positions <= self._seen:
+                    events.extend(self._finish(now, bool(active)))
+                else:
+                    self._release_at = None
+        if stable:
+            positions = {self._axis.index(i) for i in stable if i in self._axis}
+            if not self._cycle:
+                if not active or now - self._contact_since < self._contact_delay:
+                    return events
+                self._cycle = True
+                self._gesture_id += 1
+                self._started = self._last_move = now
+                self._outside = stable - set(self._axis)
+                self._seen = positions.copy()
+                self._previous_positions = positions.copy()
+                self._origin = sum(positions) / len(positions) if positions else None
+                self._last_center = self._origin
+            elif ((positions and self._origin is None)
+                  or (self._origin is not None and stable - set(self._axis) - self._outside)):
+                # Mixing an undeclared pad into a spatial contact cannot prove
+                # a swipe, and must never extend it into a destructive hold.
+                self._moving = self._invalid = True
+                self._button.cancel()
+                events += [_GestureEvent("invalidate", self._gesture_id),
+                           _GestureEvent("release", self._gesture_id)]
+            elif positions and self._origin is not None:
+                center = sum(positions) / len(positions)
+                arrivals = positions - self._previous_positions
+                self._previous_positions = positions.copy()
+                new = positions - self._seen
+                displacement = center - self._origin
+                if new:
+                    if abs(center - self._last_center) > 3:
+                        self._invalid = True
+                    if now - self._last_move > SWIPE_MAX_GAP_S:
+                        self._invalid = True
+                    self._last_move = now
+                    self._seen.update(positions)
+                if new and abs(displacement) >= 1 and not self._moving:
+                    self._moving = True
+                    self._direction = 1 if displacement > 0 else -1
+                    self._button.cancel()
+                    events += [_GestureEvent("invalidate", self._gesture_id),
+                               _GestureEvent("release", self._gesture_id)]
+                if self._moving:
+                    progress = displacement * self._direction
+                    if arrivals and progress < self._peak - 1:
+                        self._invalid = True
+                    # Releases alone shift the centroid but prove no travel.
+                    if new:
+                        self._peak = max(self._peak, progress)
+                self._last_center = center
+            if not self._moving:
+                edge_time = self._contact_since if self._button._press_start is None else now
+                if not active:
+                    edge_time = max(since for value, since in self._raw.values() if not value)
+                events.extend(self._button.update(True, edge_time))
+        elif self._cycle:
+            if self._release_at is None:
+                # Use raw edge time, so grace/debounce cannot promote a hold.
+                self._release_at = max(since for value, since in self._raw.values() if not value)
+        elif not active:
+            events.extend(self._button.update(False, now))
+        return events
+
+
 def single_click_action(*, source, announce):
     from hal.drivers.button_actions import single_click_action as action
     action(source=source, announce=announce)
@@ -185,6 +364,11 @@ def hold_release_action(held_s, *, source):
     action(held_s, source=source)
 
 
+def swipe_action(*, source):
+    from hal.drivers.button_actions import swipe_action as action
+    action(source=source)
+
+
 class MPR121Handler:
     def __init__(self, config: MPR121Config):
         self._config = config
@@ -194,12 +378,21 @@ class MPR121Handler:
         self._pending = queue.Queue(maxsize=2)
         self._poll_thread = None
         self._action_thread = None
-        self._detector = _GestureRecognizer(config.debounce_ms)
+        self._detector = self._new_detector()
         self._last_raw_mask = None
         self._generation = 0
         self._action_busy = False
         self._gesture_lock = threading.Lock()
         self._hold_led = None
+
+    def _new_detector(self):
+        if self._config.swipe_axis is not None:
+            return _SpatialGestureRecognizer(self._config)
+        return _GestureRecognizer(self._config.debounce_ms)
+
+    def _sample(self):
+        touched = self._read_touched()
+        return self._last_raw_mask if self._config.swipe_axis is not None else touched
 
     def _feedback(self):
         with self._gesture_lock:
@@ -267,20 +460,21 @@ class MPR121Handler:
             self._config.touch_threshold, self._config.release_threshold,
             self._config.autoconfig, self._config.poll_ms, self._config.debounce_ms,
         )
+        logger.info("MPR121 event=swipe_config axis=%s release_ms=120 max_gap_ms=150 min_travel_ms=60 footprint_debounce_ms=5", self._config.swipe_axis)
         self._last_raw_mask = None
         if self._hold_led is not None:
             self._hold_led.stop()
         self._hold_led = None
         self._stop.clear()
         self._pending = queue.Queue(maxsize=2)
-        self._detector = _GestureRecognizer(self._config.debounce_ms)
+        self._detector = self._new_detector()
         try:
             self._bus = I2CBus(self._config.bus)
             self._initialize()
             # Allow conversions/autoconfiguration to settle before seeding the
             # boot-held suppression from the first reported electrode state.
             time.sleep(0.1)
-            self._detector.update(self._read_touched(), time.monotonic())
+            self._detector.update(self._sample(), time.monotonic())
             self._action_thread = threading.Thread(target=self._dispatch, daemon=True, name="mpr121-actions")
             self._poll_thread = threading.Thread(target=self._poll, daemon=True, name="mpr121-poll")
             self._action_thread.start()
@@ -325,11 +519,11 @@ class MPR121Handler:
             elif event.kind == "release":
                 if self._hold_led is not None:
                     self._hold_led.release()
-            elif event.kind in ("single", "cue", "triple", "hold"):
+            elif event.kind in ("single", "cue", "triple", "hold", "swipe"):
                 with self._gesture_lock:
                     if self._stop.is_set():
                         return
-                    if event.kind in ("hold", "triple") and (self._action_busy or not self._pending.empty()):
+                    if event.kind in ("hold", "triple", "swipe") and (self._action_busy or not self._pending.empty()):
                         logger.warning("MPR121 event=action_discarded gesture_id=%d action=%s reason=action_worker_busy", event.gesture_id, event.kind)
                         continue
                     try:
@@ -344,7 +538,7 @@ class MPR121Handler:
         logger.info("MPR121 event=worker_started worker=poll")
         try:
             while not self._stop.wait(self._config.poll_ms / 1000):
-                self._process_touch(self._read_touched(), time.monotonic())
+                self._process_touch(self._sample(), time.monotonic())
         except Exception:
             logger.exception("MPR121 polling stopped after hardware error")
             self._stop.set()
@@ -363,6 +557,10 @@ class MPR121Handler:
             announce_listening_cue(source="MPR121")
         elif event.kind == "triple":
             triple_click_action(source="MPR121")
+        elif event.kind == "swipe":
+            if self._hold_led is not None and self._hold_led.commit(0) is False:
+                return
+            swipe_action(source="MPR121")
         elif event.kind == "hold":
             if self._feedback().commit(event.held_s) is False:
                 logger.info("MPR121 event=action_discarded gesture_id=%d action=hold reason=feedback_cancelled", event.gesture_id)
@@ -379,7 +577,7 @@ class MPR121Handler:
                     continue
                 with self._gesture_lock:
                     valid = not self._stop.is_set() and generation == self._generation
-                    if event.kind in ("hold", "triple") and time.monotonic() - queued_at > DOUBLE_CLICK_WINDOW:
+                    if event.kind in ("hold", "triple", "swipe") and time.monotonic() - queued_at > DOUBLE_CLICK_WINDOW:
                         valid = False
                     if valid:
                         self._action_busy = True

--- a/hal/server.py
+++ b/hal/server.py
@@ -298,6 +298,7 @@ if "display" in _declared:
 _gpio_button_handlers = []
 _ttp223_handler = None
 _mpr121_handler = None
+_mic_button_handler = None
 
 # Set the moment lifespan shutdown begins — late async initializers (sensing-init)
 # check it so they don't start services nobody will stop.
@@ -364,7 +365,7 @@ def _sim_audio_probe(sd_module) -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global _gpio_button_handlers, _ttp223_handler, _mpr121_handler
+    global _gpio_button_handlers, _ttp223_handler, _mpr121_handler, _mic_button_handler
 
     # --- Phase 0: Borrow the hardware from whoever owns it ---
     # Empty unless ROBOT.md declares an `owner:`. Where one exists it holds
@@ -942,16 +943,14 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"TTP223 init failed: {e}")
 
-    # Dedicated mic-mute push button (OrangePi sun60 PE1 today). One press =
-    # one mute↔unmute flip via HAL voice routes. Silent skip on boards that
-    # don't declare `mic_button` in boards.json.
+    # Slide-switch position controls mic mute; missing config preserves legacy gating.
     try:
         from hal.drivers.mic_button import MicButtonHandler
 
-        _mic_button_handler = MicButtonHandler()
+        _mic_button_handler = MicButtonHandler(_mic_button_config)
         _mic_button_handler.start()
     except Exception as e:
-        logger.warning(f"Mic button init failed: {e}")
+        logger.warning(f"Mic switch init failed: {e}")
 
     # Restore Bluetooth headset route if the user had one active before reboot.
     # Best effort — silent fallback to the device speaker/mic if anything goes wrong.
@@ -1023,6 +1022,8 @@ async def lifespan(app: FastAPI):
 
     _lifespan_stopping.set()
     _thermal_stop.set()
+    if _mic_button_handler is not None:
+        _mic_button_handler.stop()
     for handler in _gpio_button_handlers:
         handler.stop()
     _gpio_button_handlers = []
@@ -1313,6 +1314,14 @@ from hal.board.gpio_button import load_button_configs
 
 _gpio_button_configs = (
     [] if _board_id == "sim" else load_button_configs(_device_dir, _board_id)
+)
+
+from hal.board.mic_button import load_mic_button_config
+
+_mic_button_config = (
+    None if _board_id == "sim" else load_mic_button_config(
+        _device_dir, _board_id, _resolve_device_type(),
+    )
 )
 
 from hal.board.mpr121 import load_mpr121_config

--- a/hal/test/test_mic_button.py
+++ b/hal/test/test_mic_button.py
@@ -1,0 +1,175 @@
+"""Configured mic switch behavior without GPIO, route or thread side effects."""
+
+from unittest import mock
+
+import pytest
+
+import hal.app_state as state
+from hal.board.mic_button import MicButtonConfig
+from hal.drivers.mic_button import MicButtonHandler
+
+
+@pytest.fixture
+def hardware():
+    gpio = mock.Mock()
+    gpio.gpiochip_open.return_value = 12
+    gpio.gpio_read.return_value = 1
+    with (
+        mock.patch.dict("sys.modules", {"lgpio": gpio}),
+        mock.patch("hal.drivers.mic_button.threading.Thread") as thread,
+        mock.patch("hal.drivers.mic_button.threading.Timer") as timer,
+    ):
+        thread.return_value.is_alive.return_value = False
+        yield gpio, thread, timer
+
+
+def test_disabled_switch_does_not_import_or_claim_gpio(hardware):
+    gpio, thread, _ = hardware
+    handler = MicButtonHandler(None)
+    handler.start()
+    handler.stop()
+    assert not gpio.mock_calls
+    thread.assert_not_called()
+
+
+@pytest.mark.parametrize("muted_level,level,expected", [(0, 0, True), (0, 1, False), (1, 1, True), (1, 0, False)])
+def test_injected_wiring_and_synchronous_boot_sync(hardware, muted_level, level, expected):
+    gpio, thread, _ = hardware
+    gpio.gpio_read.return_value = level
+    handler = MicButtonHandler(MicButtonConfig(chip=3, line=42, muted_level=muted_level))
+    handler._apply_state_locked = mock.Mock()
+    handler.start()
+    gpio.gpiochip_open.assert_called_once_with(3)
+    gpio.gpio_claim_alert.assert_called_once_with(12, 42, gpio.BOTH_EDGES, gpio.SET_PULL_UP)
+    gpio.gpio_read.assert_called_once_with(12, 42)
+    handler._apply_state_locked.assert_called_once_with(expected)
+    assert handler._last_known_level == level
+    thread.return_value.start.assert_called_once_with()
+    handler.stop()
+
+
+@pytest.mark.parametrize("muted_level", [0, 1])
+def test_failed_initial_read_keeps_legacy_unmuted_default(hardware, muted_level):
+    gpio, _, _ = hardware
+    gpio.gpio_read.side_effect = OSError("read unavailable")
+    handler = MicButtonHandler(MicButtonConfig(muted_level=muted_level))
+    handler._apply_state_locked = mock.Mock()
+    handler.start()
+    handler._apply_state_locked.assert_called_once_with(False)
+    assert handler._last_known_level == 1 - muted_level
+    handler.stop()
+
+
+def test_edge_restarts_configured_settle_then_reads_current_level(hardware):
+    gpio, _, timer = hardware
+    handler = MicButtonHandler(MicButtonConfig(line=43, settle_s=0.12, muted_level=1))
+    handler._apply_state_locked = mock.Mock()
+    handler.start()
+    handler._apply_state_locked.reset_mock()
+    handler._on_edge(0, 43, 0, 100)
+    handler._on_edge(0, 43, 0, 101)
+    assert timer.call_count == 2
+    timer.assert_called_with(0.12, handler._reconcile)
+    timer.return_value.cancel.assert_called_once_with()
+    handler._apply_state_locked.assert_not_called()
+    gpio.gpio_read.return_value = 1  # Current level wins over edge payload.
+    timer.call_args.args[1]()
+    handler._apply_state_locked.assert_called_once_with(True)
+    gpio.gpio_read.assert_called_with(12, 43)
+    handler.stop()
+
+
+@pytest.mark.parametrize("physical_level,expected_calls", [(1, 0), (0, 1)])
+def test_watchdog_only_reconciles_changed_level(hardware, physical_level, expected_calls):
+    gpio, _, _ = hardware
+    handler = MicButtonHandler(MicButtonConfig(watchdog_s=8.5))
+    handler._apply_state_locked = mock.Mock()
+    handler.start()
+    handler._apply_state_locked.reset_mock()
+    gpio.gpio_read.return_value = physical_level
+    with (
+        mock.patch.object(handler._stopped, "wait", side_effect=[False, True]) as wait,
+        mock.patch.object(state, "_mic_muted", True),
+    ):
+        handler._watchdog_loop()
+        assert state._mic_muted is True
+    assert wait.call_args_list == [mock.call(8.5), mock.call(8.5)]
+    assert handler._apply_state_locked.call_count == expected_calls
+    handler.stop()
+
+
+def test_stop_cancels_work_and_releases_handle_once(hardware):
+    gpio, thread, timer = hardware
+    handler = MicButtonHandler(MicButtonConfig())
+    handler._apply_state_locked = mock.Mock()
+    handler.start()
+    handler._on_edge(0, 97, 0, 1)
+    handler.stop()
+    handler.stop()
+    timer.return_value.cancel.assert_called_once_with()
+    gpio.callback.return_value.cancel.assert_called_once_with()
+    thread.return_value.join.assert_called_once_with(timeout=2.0)
+    gpio.gpiochip_close.assert_called_once_with(12)
+    reads = gpio.gpio_read.call_count
+    handler._apply_state_locked.reset_mock()
+    handler._on_edge(0, 97, 1, 2)
+    handler._reconcile()
+    assert timer.call_count == 1
+    assert gpio.gpio_read.call_count == reads
+    handler._apply_state_locked.assert_not_called()
+
+
+def test_failed_claim_closes_open_handle(hardware):
+    gpio, thread, _ = hardware
+    gpio.gpio_claim_alert.side_effect = OSError("busy")
+    handler = MicButtonHandler(MicButtonConfig())
+    handler.start()
+    gpio.gpiochip_close.assert_called_once_with(12)
+    thread.assert_not_called()
+    assert handler._stopped.is_set()
+
+
+def test_boot_publishes_hardware_lock_even_when_software_already_matches(hardware):
+    gpio, _, _ = hardware
+    gpio.gpio_read.return_value = 0
+    handler = MicButtonHandler(MicButtonConfig())
+    with (
+        mock.patch.object(state, "_mic_muted", True),
+        mock.patch.object(state, "_hw_mic_switch_muted", None),
+    ):
+        handler.start()
+        assert state._hw_mic_switch_muted is True
+    handler.stop()
+
+
+def test_stop_continues_cleanup_when_gpio_operations_fail(hardware, caplog):
+    gpio, thread, _ = hardware
+    handler = MicButtonHandler(MicButtonConfig())
+    handler._apply_state_locked = mock.Mock()
+    handler.start()
+    gpio.callback.return_value.cancel.side_effect = OSError("cancel unavailable")
+    gpio.gpiochip_close.side_effect = OSError("close unavailable")
+    handler.stop()
+    handler.stop()
+    thread.return_value.join.assert_called_once_with(timeout=2.0)
+    gpio.gpiochip_close.assert_called_once_with(12)
+    assert handler._callback is None
+    assert handler._handle is None
+    assert "callback cancel failed" in caplog.text
+    assert "gpiochip_close failed" in caplog.text
+
+
+def test_start_waits_for_previous_watchdog_to_exit(hardware):
+    gpio, thread, _ = hardware
+    handler = MicButtonHandler(MicButtonConfig())
+    handler._apply_state_locked = mock.Mock()
+    handler.start()
+    thread.return_value.is_alive.return_value = True
+    handler.stop()
+    handler.start()
+    assert gpio.gpiochip_open.call_count == 1
+    assert handler._stopped.is_set()
+    thread.return_value.is_alive.return_value = False
+    handler.start()
+    assert gpio.gpiochip_open.call_count == 2
+    handler.stop()

--- a/hal/test/test_mic_button_config.py
+++ b/hal/test/test_mic_button_config.py
@@ -1,0 +1,60 @@
+"""Microphone switch configuration preserves legacy Intern wiring and gating."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hal.board.mic_button import MicButtonConfig, load_mic_button_config
+
+
+def test_missing_file_and_board_keep_intern_defaults_only(tmp_path):
+    for contents in (None, {"boards": {}}):
+        if contents is not None:
+            (tmp_path / "mic_button.json").write_text(json.dumps(contents))
+        for board in ("orangepi_sun60", "raspberry_pi_5"):
+            assert load_mic_button_config(tmp_path, board, "intern-v2") == MicButtonConfig()
+            assert load_mic_button_config(tmp_path, board, "lamp") is None
+            assert load_mic_button_config(tmp_path, board, "") is None
+
+
+def test_shipped_intern_matches_legacy_and_lamp_is_not_enabled():
+    root = Path(__file__).resolve().parents[2] / "robots"
+    assert load_mic_button_config(root / "intern-v2", "orangepi_sun60", "intern-v2") == MicButtonConfig()
+    assert not (root / "lamp" / "mic_button.json").exists()
+    assert load_mic_button_config(root / "lamp", "orangepi_sun60", "lamp") is None
+
+
+def test_device_override_and_explicit_disable(tmp_path):
+    path = tmp_path / "mic_button.json"
+    path.write_text(json.dumps({"boards": {
+        "orangepi_sun60": {"chip": 2, "line": 8, "muted_level": 1,
+                            "settle_s": .1, "watchdog_s": 5},
+        "raspberry_pi_5": {"enabled": False},
+    }}))
+    assert load_mic_button_config(tmp_path, "orangepi_sun60", "intern-v2") == MicButtonConfig(2, 8, .1, 1, 5)
+    assert load_mic_button_config(tmp_path, "raspberry_pi_5", "intern-v2") is None
+
+
+@pytest.mark.parametrize("entry", [
+    {"chip": 0}, {"chip": -1, "line": 97}, {"chip": True, "line": 97},
+    {"chip": 0, "line": "97"}, {"chip": 0, "line": 97, "muted_level": 2},
+    {"chip": 0, "line": 97, "muted_level": False},
+    {"chip": 0, "line": 97, "settle_s": -1},
+    {"chip": 0, "line": 97, "settle_s": float("nan")},
+    {"chip": 0, "line": 97, "watchdog_s": 0},
+    {"chip": 0, "line": 97, "watchdog_s": float("inf")},
+    {"chip": 0, "line": 97, "watchdog_s": True},
+    {"enabled": "false"}, {"chip": 0, "line": 97, "unknown": 1},
+])
+def test_invalid_declarations_do_not_silently_fall_back(tmp_path, entry):
+    (tmp_path / "mic_button.json").write_text(json.dumps({"boards": {"orangepi_sun60": entry}}))
+    with pytest.raises(ValueError, match="mic_button.json"):
+        load_mic_button_config(tmp_path, "orangepi_sun60", "intern-v2")
+
+
+@pytest.mark.parametrize("contents", ["{", "null", '{"boards": []}'])
+def test_invalid_file_rejected(tmp_path, contents):
+    (tmp_path / "mic_button.json").write_text(contents)
+    with pytest.raises(ValueError, match="mic_button.json"):
+        load_mic_button_config(tmp_path, "orangepi_sun60", "intern-v2")

--- a/hal/test/test_mic_button_config.py
+++ b/hal/test/test_mic_button_config.py
@@ -18,11 +18,12 @@ def test_missing_file_and_board_keep_intern_defaults_only(tmp_path):
             assert load_mic_button_config(tmp_path, board, "") is None
 
 
-def test_shipped_intern_matches_legacy_and_lamp_is_not_enabled():
+def test_intern_uses_fallback_and_lamp_declares_pin_11():
     root = Path(__file__).resolve().parents[2] / "robots"
     assert load_mic_button_config(root / "intern-v2", "orangepi_sun60", "intern-v2") == MicButtonConfig()
-    assert not (root / "lamp" / "mic_button.json").exists()
-    assert load_mic_button_config(root / "lamp", "orangepi_sun60", "lamp") is None
+    assert not (root / "intern-v2" / "mic_button.json").exists()
+    assert load_mic_button_config(root / "lamp", "orangepi_sun60", "lamp") == MicButtonConfig(chip=1, line=9)
+    assert load_mic_button_config(root / "lamp", "raspberry_pi_5", "lamp") is None
 
 
 def test_device_override_and_explicit_disable(tmp_path):

--- a/hal/test/test_mpr121.py
+++ b/hal/test/test_mpr121.py
@@ -300,7 +300,7 @@ class TestMPR121(unittest.TestCase):
         bus.close.assert_called_once()
 
     def test_busy_worker_rejects_destructive_outcomes(self):
-        for kind in ('hold', 'triple'):
+        for kind in ('hold', 'triple', 'swipe'):
             with self.subTest(kind=kind):
                 handler = self.make_handler()
                 handler._hold_led = feedback = mock.Mock()
@@ -321,29 +321,31 @@ class TestMPR121(unittest.TestCase):
         self.assertTrue(handler._pending.empty())
 
     def test_expired_destructive_outcome_never_executes(self):
-        handler = self.make_handler()
-        handler._pending.put_nowait((handler._generation, _GestureEvent('triple', 1, count=3), time.monotonic() - 1))
-        with mock.patch.object(handler, '_execute') as execute, \
-                self.assertLogs('hal.drivers.mpr121', level='INFO') as logs:
-            handler._action_thread = threading.Thread(target=handler._dispatch)
-            handler._action_thread.start()
-            # Observing an empty queue means the worker has consumed the request;
-            # stop then joins it before assertions about execution/logging.
-            deadline = time.monotonic() + 1
-            while not handler._pending.empty() and time.monotonic() < deadline:
-                threading.Event().wait(.001)
-            handler.stop()
-        execute.assert_not_called()
-        self.assertTrue(any('reason=stale_expired_or_stopping' in item for item in logs.output))
+        for kind in ("triple", "hold", "swipe"):
+            handler = self.make_handler()
+            handler._pending.put_nowait((handler._generation, _GestureEvent(kind, 1, count=3), time.monotonic() - 1))
+            with mock.patch.object(handler, '_execute') as execute, \
+                    self.assertLogs('hal.drivers.mpr121', level='INFO') as logs:
+                handler._action_thread = threading.Thread(target=handler._dispatch)
+                handler._action_thread.start()
+                # Observing an empty queue means the worker has consumed the request;
+                # stop then joins it before assertions about execution/logging.
+                deadline = time.monotonic() + 1
+                while not handler._pending.empty() and time.monotonic() < deadline:
+                    threading.Event().wait(.001)
+                handler.stop()
+            execute.assert_not_called()
+            self.assertTrue(any('reason=stale_expired_or_stopping' in item for item in logs.output))
 
     def test_stop_discards_pending_actions(self):
-        handler = self.make_handler()
-        handler._pending.put_nowait((handler._generation, _GestureEvent('triple', 1, count=3), time.monotonic()))
-        with mock.patch.object(handler, '_execute') as execute:
-            handler.stop()
-            handler._dispatch()
-        self.assertTrue(handler._pending.empty())
-        execute.assert_not_called()
+        for kind in ("triple", "hold", "swipe"):
+            handler = self.make_handler()
+            handler._pending.put_nowait((handler._generation, _GestureEvent(kind, 1, count=3), time.monotonic()))
+            with mock.patch.object(handler, '_execute') as execute:
+                handler.stop()
+                handler._dispatch()
+            self.assertTrue(handler._pending.empty())
+            execute.assert_not_called()
 
     def test_queue_capacity_is_bounded_without_affecting_gesture_count(self):
         handler = self.make_handler()

--- a/hal/test/test_mpr121_config.py
+++ b/hal/test/test_mpr121_config.py
@@ -56,3 +56,16 @@ class TestMPR121Config(unittest.TestCase):
                     path.write_text(value)
                     with self.assertRaisesRegex(ValueError, "mpr121.json"):
                         load_mpr121_config(directory, "orangepi_sun60")
+
+    def test_swipe_axis_json_round_trip_and_rejection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mpr121.json"
+            path.write_text(json.dumps({"boards": {"orangepi_sun60": {
+                "bus": 0, "electrodes": [2, 4, 6], "swipe_axis": [6, 4, 2],
+            }}}))
+            self.assertEqual(load_mpr121_config(directory, "orangepi_sun60").swipe_axis, (6, 4, 2))
+            path.write_text(json.dumps({"boards": {"orangepi_sun60": {
+                "bus": 0, "electrodes": [2, 4], "swipe_axis": [2, 6],
+            }}}))
+            with self.assertRaisesRegex(ValueError, "swipe_axis"):
+                load_mpr121_config(directory, "orangepi_sun60")

--- a/hal/test/test_mpr121_swipe.py
+++ b/hal/test/test_mpr121_swipe.py
@@ -1,0 +1,153 @@
+"""Spatial MPR121 gestures, including measured hardware mask traces."""
+
+import unittest
+from unittest import mock
+
+from hal.board.mpr121 import MPR121Config
+from hal.drivers.mpr121 import MPR121Handler, _GestureEvent, _SpatialGestureRecognizer
+
+ACTIONS = {"single", "cue", "triple", "hold", "swipe"}
+
+
+def replay(samples, axis=tuple(range(12)), debounce_ms=30):
+    detector = _SpatialGestureRecognizer(MPR121Config(bus=0, swipe_axis=axis, debounce_ms=debounce_ms, poll_ms=1))
+    detector.update(0, -1)
+    events = []
+    index = 0
+    mask = 0
+    for tick in range(int((samples[-1][0] + .7) * 1000) + 1):
+        now = tick / 1000
+        while index < len(samples) and samples[index][0] <= now:
+            mask = samples[index][1]
+            index += 1
+        events.extend(detector.update(mask, now))
+    return events
+
+
+def kinds(events):
+    return [e.kind for e in events if e.kind in ACTIONS]
+
+
+class TestSpatialGestures(unittest.TestCase):
+    def test_both_directions_overlap_and_partial_strip(self):
+        for direction in (1, -1):
+            order = range(8) if direction == 1 else range(11, 3, -1)
+            samples = [(1 + i * .04, (1 << pad) | (1 << (pad + direction)))
+                       for i, pad in enumerate(order)]
+            samples.append((1.4, 0))
+            self.assertEqual(kinds(replay(samples)), ["swipe"])
+
+    def test_two_pads_handoff_and_independent_taps(self):
+        self.assertEqual(kinds(replay([(1, 1), (1.05, 0), (1.09, 2), (1.16, 0)], axis=(0, 1))), ["swipe"])
+        result = kinds(replay([(1, 1), (1.06, 0), (1.3, 2), (1.36, 0)], axis=(0, 1)))
+        self.assertNotIn("swipe", result)
+
+    def test_stationary_cluster_and_simultaneous_whole_hand(self):
+        for mask in (1, 15, 4095):
+            self.assertEqual(kinds(replay([(1, mask), (1.08, mask & ~2), (1.1, 0)])), ["single", "cue"])
+
+    def test_hold_thresholds_and_no_early_led_tier(self):
+        for duration in (1.999, 2, 4.999, 5, 9.999, 10):
+            events = replay([(1, 15), (1 + duration, 0)])
+            actions = [e for e in events if e.kind in ACTIONS]
+            if duration < 2:
+                self.assertEqual([e.kind for e in actions], ["single", "cue"])
+                self.assertFalse(any(e.kind == "hold_tier" for e in events))
+            else:
+                self.assertEqual([e.kind for e in actions], ["hold"])
+                self.assertAlmostEqual(actions[0].held_s, duration)
+
+    def test_reversal_and_slow_drag_never_fall_back_to_hold(self):
+        for samples in (
+            [(1, 1), (1.07, 2), (1.14, 4), (1.21, 8), (1.28, 16),
+             (1.35, 8), (1.42, 4), (1.49, 2), (1.56, 1), (1.65, 0)],
+            [(1, 1), (4, 2), (7, 4), (11, 8), (15, 0)],
+            [(1, 1), (2, 2), (15, 0)],
+        ):
+            self.assertEqual(kinds(replay(samples)), [])
+
+    def test_stationary_chatter_and_unselected_electrodes(self):
+        self.assertEqual(kinds(replay([(1, 1), (1.002, 0)])), [])
+        config = MPR121Config(bus=0, electrodes=(0, 1), swipe_axis=(0, 1))
+        detector = _SpatialGestureRecognizer(config)
+        self.assertEqual(detector.update(1 << 11, 0), [])
+        self.assertEqual(detector.update(1 << 11, 10), [])
+
+    def test_boot_hold_and_cancel(self):
+        detector = _SpatialGestureRecognizer(MPR121Config(bus=0, swipe_axis=(0, 1)))
+        for mask, now in ((1, 0), (2, 1), (2, 10), (0, 11), (0, 11.04)):
+            self.assertEqual(kinds(detector.update(mask, now)), [])
+        detector.update(1, 12)
+        detector.update(1, 12.04)
+        detector.cancel()
+        self.assertEqual(kinds(detector.update(0, 30)), [])
+
+    def test_shared_action_and_led_barrier(self):
+        handler = MPR121Handler(MPR121Config(bus=0, swipe_axis=(0, 1)))
+        feedback = mock.Mock()
+        handler._hold_led = feedback
+        with mock.patch("hal.drivers.button_actions.swipe_action") as action:
+            handler._execute(_GestureEvent("swipe", 1))
+            feedback.commit.assert_called_once_with(0)
+            action.assert_called_once_with(source="MPR121")
+            feedback.commit.return_value = False
+            handler._execute(_GestureEvent("swipe", 2))
+            self.assertEqual(action.call_count, 1)
+
+    def test_optional_axis_validation(self):
+        self.assertIsNone(MPR121Config(bus=0).swipe_axis)
+        self.assertEqual(MPR121Config(bus=0, swipe_axis=[2, 1, 0]).swipe_axis, (2, 1, 0))
+        for axis in ([1], [0, 0], [0, 12], [True, 2], "01"):
+            with self.assertRaises(ValueError):
+                MPR121Config(bus=0, swipe_axis=axis)
+        with self.assertRaises(ValueError):
+            MPR121Config(bus=0, electrodes=(0, 1), swipe_axis=(0, 2))
+
+    def test_recorded_hardware_traces_at_10ms_poll(self):
+        # Relative seconds and raw electrode masks from the actual Lamp.
+        traces = [
+            [(0.000000, 0x00f), (0.068565, 0x00d), (0.080512, 0x000)],
+            [(0.000000, 0xc00), (0.032394, 0xe00), (0.108233, 0xf00), (0.140405, 0xd00), (0.151704, 0x780), (0.194663, 0x3c0), (0.223980, 0x1c0), (0.235201, 0x1e0), (0.246512, 0x0f0), (0.268403, 0x070), (0.279260, 0x078), (0.290454, 0x038), (0.301521, 0x03c), (0.323502, 0x01c), (0.338959, 0x01e), (0.350452, 0x00f), (0.372375, 0x007), (0.384148, 0x003), (0.395206, 0x001), (0.407554, 0x000)],
+            [(0.000000, 0x001), (0.064855, 0x003), (0.097039, 0x007), (0.109994, 0x006), (0.121576, 0x00e), (0.132669, 0x00c), (0.156368, 0x01c), (0.169716, 0x018), (0.181015, 0x030), (0.192587, 0x070), (0.203921, 0x060), (0.215169, 0x0c0), (0.226225, 0x180), (0.247988, 0x100), (0.259447, 0x000)],
+            [(0.000000, 0x300), (0.046940, 0x100), (0.058170, 0x180), (0.069253, 0x080), (0.080455, 0x0c0), (0.091656, 0x060), (0.102706, 0x020), (0.113845, 0x030), (0.124995, 0x018), (0.146249, 0x006), (0.159542, 0x003), (0.170677, 0x001), (0.181714, 0x000)],
+            [(0.000000, 0x01e), (0.012110, 0x01f), (0.055090, 0x00f), (0.066287, 0x00a), (0.077446, 0x000)],
+        ]
+        expected = [["single", "cue"], ["swipe"], ["swipe"], ["swipe"], ["single", "cue"]]
+        for phase in (0, .005):
+            for samples, outcome in zip(traces, expected):
+                detector = _SpatialGestureRecognizer(MPR121Config(bus=0, swipe_axis=tuple(range(12))))
+                detector.update(0, -1)
+                index = 0
+                mask = 0
+                events = []
+                for tick in range(int((samples[-1][0] + .7) * 100) + 1):
+                    now = tick / 100 + phase
+                    while index < len(samples) and samples[index][0] <= now:
+                        mask = samples[index][1]
+                        index += 1
+                    events.extend(detector.update(mask, now))
+                self.assertEqual(kinds(events), outcome)
+
+    def test_raw_touch_blocks_pending_triple_deadline(self):
+        samples = [(1, 1), (1.06, 0), (1.2, 1), (1.26, 0),
+                   (1.4, 1), (1.46, 0), (1.85, 1), (4, 0)]
+        self.assertEqual(kinds(replay(samples)), ["single", "hold"])
+
+    def test_swipe_cancels_pending_triple(self):
+        samples = [(1, 1), (1.06, 0), (1.2, 1), (1.26, 0),
+                   (1.4, 1), (1.46, 0), (1.7, 1), (1.76, 2),
+                   (1.82, 4), (1.88, 8), (1.94, 16), (2.02, 0)]
+        self.assertEqual(kinds(replay(samples)), ["single", "swipe"])
+
+    def test_mixed_axis_and_off_axis_drag_cannot_reset(self):
+        for first, second in ((1 << 11, 1), (1, 1 << 11)):
+            self.assertEqual(kinds(replay([(1, first), (2, first | second), (12, 0)], axis=(0, 1))), [])
+
+    def test_release_chatter_preserves_stationary_hold(self):
+        events = replay([(1, 1), (1.5, 0), (1.51, 1), (3.2, 0)])
+        actions = [e for e in events if e.kind in ACTIONS]
+        self.assertEqual([e.kind for e in actions], ["hold"])
+        self.assertAlmostEqual(actions[0].held_s, 2.2)
+
+    def test_distant_independent_touches_are_not_swipes(self):
+        self.assertEqual(kinds(replay([(1, 1), (1.06, 0), (1.08, 1 << 11), (1.15, 0)])), [])

--- a/robots/intern-v2/mic_button.json
+++ b/robots/intern-v2/mic_button.json
@@ -1,0 +1,11 @@
+{
+  "boards": {
+    "orangepi_sun60": {
+      "chip": 0,
+      "line": 97,
+      "settle_s": 0.06,
+      "muted_level": 0,
+      "watchdog_s": 30
+    }
+  }
+}

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -80,7 +80,8 @@ levels so software mute is preserved while the switch stays still. Intern v2
 has no mic JSON and keeps its original chip 0 / line 97 code fallback. Lamp
 without this JSON remains disabled. Keep Lamp's primary-button JSON installed
 to avoid its legacy pin 11 fallback overlapping this switch. The Lamp mic
-configuration is ready in the repo but has not yet been deployed for live testing.
+configuration was deployed on 2026-09-11; startup confirmed chip1/line9 ready
+and initial LOW applied mute. Live toggle testing is pending.
 
 ## Gesture map
 
@@ -324,7 +325,8 @@ Logs record swipe direction, displacement and verdict alongside action dispatch.
 Tests replay measured mask sequences plus synthetic gesture/lifecycle cases;
 the runtime and swipe JSON were deployed to Lamp `lamp-0c4e` on 2026-09-11.
 Startup confirmed MPR121 ready with the configured axis, GPIO buttons and TTP223
-ready, and the Lamp mic switch disabled. Live gesture testing is pending.
+ready, and the Lamp mic switch ready on chip1/line9 after its JSON was installed.
+Live gesture testing is pending.
 
 Debounced `hold_tier` events feed the same `HoldLEDFeedback` component as
 GPIO, sharing `BUTTON_LED_PRESETS`, blinking, release cleanup and final action

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -239,6 +239,7 @@ does not modify boot overlays automatically:
       "bus": 0,
       "address": 90,
       "electrodes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      "swipe_axis": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
       "touch_threshold": 2,
       "release_threshold": 1,
       "autoconfig": true,
@@ -249,7 +250,7 @@ does not modify boot overlays automatically:
 }
 ```
 
-`bus` is required for an enabled entry. The other values above are defaults;
+`bus` is required for an enabled entry. The other values above except `swipe_axis` are defaults;
 address 90 means `0x5A` (allowed addresses: 90–93). Selected electrodes must be
 unique numbers from 0–11, with at least one selected. Thresholds must satisfy
 `0 <= release_threshold < touch_threshold <= 255`. Polling accepts 1–1000 ms;
@@ -275,16 +276,42 @@ functions:
 
 | Gesture | MPR121 action |
 |---|---|
-| First short release in a click burst | `single_click_action(source="MPR121", announce=False)` immediately stops tracking/audio, unmutes as permitted and plays the ack chime. |
+| First short release in a click burst | `single_click_action(source="MPR121", announce=False)` stops tracking/audio after contact resolution, unmutes as permitted and plays the ack chime. |
 | 1, 2 or 4+ short taps, then 0.4 s quiet | Play the listening cue; repeated taps do not repeat the initial single-click action. |
 | Exactly 3 short taps, then 0.4 s quiet | `triple_click_action` reboots instead of playing the listening cue. |
 | Hold 2–<5 s, then release | `hold_release_action` enters sleepy. |
 | Hold 5–<10 s, then release | `hold_release_action` shuts down. |
 | Hold ≥10 s, then release | `hold_release_action` performs factory reset. |
+| Swipe either direction, then release | `swipe_action` sleeps; no click or destructive action for this moving contact. |
 
 A short contact lasts less than 2 s. The click window does not resolve while
 any selected electrode remains touched. Releasing a hold clears the pending
 click burst. Destructive actions never commit while held.
+
+### MPR121 swipe to sleep
+
+`swipe_axis` is an optional ordered list of 2–12 distinct electrodes from
+`electrodes`. Lamp declares E0…E11 based on recorded travel E11→E0, E0→E8,
+and E9→E0; this establishes ordering, not which end physically faces left.
+Both directions call `swipe_action(source="MPR121")` from `button_actions.py`,
+the same sleep action as TTP223. A swipe need not cross the entire strip.
+Missing/null `swipe_axis` disables only swipe detection and preserves legacy
+click/hold recognition. Install HAL support before deploying JSON with this field.
+
+Contact debounce remains 30 ms by default; the spatial footprint uses up to 5 ms
+stability (normally consecutive 10 ms polls) to retain fast electrode transitions.
+The detector follows the debounced contact footprint instead of counting every
+overlapping electrode as a separate tap. Stationary multi-electrode touches
+retain click/hold behavior. Once travel is detected, pending tap/hold outcomes
+and hold LED feedback are canceled for that contact; a valid swipe sleeps once
+after release. Reversed or invalid travel does not trigger reboot/shutdown/reset.
+A release grace of 120 ms joins brief electrode handoffs, so tap/hold actions
+with swipe enabled resolve after that grace. Boot-held contacts remain ignored.
+Logs record swipe direction, displacement and verdict alongside action dispatch.
+Tests replay measured mask sequences plus synthetic gesture/lifecycle cases;
+the runtime and swipe JSON were deployed to Lamp `lamp-0c4e` on 2026-09-11.
+Startup confirmed MPR121 ready with the configured axis, GPIO buttons and TTP223
+ready, and the Lamp mic switch disabled. Live gesture testing is pending.
 
 Debounced `hold_tier` events feed the same `HoldLEDFeedback` component as
 GPIO, sharing `BUTTON_LED_PRESETS`, blinking, release cleanup and final action

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -16,6 +16,7 @@ Lamp supports mechanical buttons, TTP223 touchpads and an optional MPR121 capaci
 |---|---|---|
 | Primary GPIO button | gpiochip0 BCM 17 (pull-up, active-LOW) | Physical pin 37 / PD4 / gpiochip0 line 100 (pull-up, active-LOW) |
 | Reset GPIO button | not wired | Physical pin 35 / PD3 / gpiochip0 line 99 (pull-up, active-LOW); hold ≥5 s then release to factory-reset |
+| Mic slide switch | not wired | Physical pin 11 / PL9 / gpiochip1 line 9; pull-up, LOW=mute, HIGH=unmute |
 | TTP223 | not wired | Two pads: S1 at physical pin 29 / PD0 / gpiochip0 line 96; S3 at physical pin 33 / PD2 / gpiochip0 line 98. **Pull-up, active-LOW** (pads rest HIGH; a touch is the falling edge). |
 
 Mechanical button wiring belongs to the device: `robots/lamp/gpio_button.json`
@@ -68,6 +69,18 @@ Board detection reads `/proc/device-tree/model`:
 - `"raspberry pi 5"` → Pi 5
 - `"raspberry pi 4"` → Pi 4
 - unknown or unsupported hardware → rejected by the HAL startup board gate
+
+### Microphone slide switch
+
+`robots/lamp/mic_button.json` declares chip 1 / line 9 under `orangepi_sun60`,
+with `settle_s: 0.06`, `muted_level: 0`, and `watchdog_s: 30`. The shared
+`mic_button.py` driver tracks switch position, synchronizes at boot, and applies
+mute/unmute after contacts settle. The watchdog only reconciles changed GPIO
+levels so software mute is preserved while the switch stays still. Intern v2
+has no mic JSON and keeps its original chip 0 / line 97 code fallback. Lamp
+without this JSON remains disabled. Keep Lamp's primary-button JSON installed
+to avoid its legacy pin 11 fallback overlapping this switch. The Lamp mic
+configuration is ready in the repo but has not yet been deployed for live testing.
 
 ## Gesture map
 

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -75,7 +75,8 @@ sau khi tiếp điểm ổn định. Watchdog chỉ đồng bộ lại khi GPIO 
 bằng phần mềm khi công tắc đứng yên. Intern v2 không có JSON mic, giữ fallback
 chip 0 / line 97 cũ trong code. Lamp thiếu JSON này vẫn tắt mic switch. Cần giữ
 JSON nút chính của Lamp để fallback pin 11 cũ không trùng công tắc này.
-Cấu hình mic Lamp đã sẵn sàng trong repo, chưa deploy để live test.
+Cấu hình mic Lamp đã deploy ngày 2026-09-11; startup xác nhận chip1/line9 ready
+và LOW ban đầu áp dụng mute. Chờ live test thao tác gạt.
 
 ## Bảng cử chỉ
 
@@ -315,7 +316,7 @@ chờ này. Contact giữ từ lúc boot vẫn bị bỏ qua. Log ghi hướng, 
 kết quả swipe và thực thi action. Test phát lại chuỗi mask đã đo cùng các ca
 cử chỉ/vòng đời giả lập. Runtime và JSON swipe đã deploy lên Lamp `lamp-0c4e`
 ngày 2026-09-11; startup xác nhận MPR121 ready với trục cấu hình, GPIO và TTP223
-ready, mic switch Lamp vẫn tắt. Chờ live test cử chỉ.
+ready, mic switch Lamp ready trên chip1/line9 sau khi cài JSON. Chờ live test cử chỉ.
 
 Event `hold_tier` đã debounce truyền vào cùng `HoldLEDFeedback` với GPIO,
 dùng chung `BUTTON_LED_PRESETS`, xử lý nháy, dọn phản hồi khi nhả và phản hồi

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -16,6 +16,7 @@ Lamp hỗ trợ các nút cơ học, touchpad TTP223 và bộ điều khiển c�
 |---|---|---|
 | Nút GPIO chính | gpiochip0 BCM 17 (pull-up, active-LOW) | Pin vật lý 37 / PD4 / gpiochip0 line 100 (pull-up, active-LOW) |
 | Nút GPIO reset | không wire | Pin vật lý 35 / PD3 / gpiochip0 line 99 (pull-up, active-LOW); giữ ≥5 s rồi nhả để factory-reset |
+| Công tắc gạt mic | không wire | Pin vật lý 11 / PL9 / gpiochip1 line 9; pull-up, LOW=mute, HIGH=unmute |
 | TTP223 | không wire | Hai pad: S1 tại pin vật lý 29 / PD0 / gpiochip0 line 96; S3 tại pin vật lý 33 / PD2 / gpiochip0 line 98. **Pull-up, active-LOW** (pad nghỉ ở mức HIGH; chạm là edge xuống). |
 
 Wiring nút cơ thuộc về từng device: `robots/lamp/gpio_button.json` và
@@ -64,6 +65,17 @@ Board được detect qua `/proc/device-tree/model`:
 - `"raspberry pi 5"` → Pi 5
 - `"raspberry pi 4"` → Pi 4
 - phần cứng không nhận diện được hoặc không được hỗ trợ → bị board gate từ chối khi HAL khởi động
+
+### Công tắc gạt microphone
+
+`robots/lamp/mic_button.json` khai báo chip 1 / line 9 trong `orangepi_sun60`,
+với `settle_s: 0.06`, `muted_level: 0`, `watchdog_s: 30`. Driver dùng chung
+`mic_button.py` theo dõi vị trí công tắc, đồng bộ lúc boot và thực hiện mute/unmute
+sau khi tiếp điểm ổn định. Watchdog chỉ đồng bộ lại khi GPIO đổi mức, giữ mute
+bằng phần mềm khi công tắc đứng yên. Intern v2 không có JSON mic, giữ fallback
+chip 0 / line 97 cũ trong code. Lamp thiếu JSON này vẫn tắt mic switch. Cần giữ
+JSON nút chính của Lamp để fallback pin 11 cũ không trùng công tắc này.
+Cấu hình mic Lamp đã sẵn sàng trong repo, chưa deploy để live test.
 
 ## Bảng cử chỉ
 

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -233,6 +233,7 @@ trước khi dùng; HAL không tự sửa boot overlay:
       "bus": 0,
       "address": 90,
       "electrodes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      "swipe_axis": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
       "touch_threshold": 2,
       "release_threshold": 1,
       "autoconfig": true,
@@ -243,7 +244,7 @@ trước khi dùng; HAL không tự sửa boot overlay:
 }
 ```
 
-`bus` bắt buộc với entry bật. Các giá trị còn lại ở trên là mặc định;
+`bus` bắt buộc với entry bật. Các giá trị còn lại ở trên trừ `swipe_axis` là mặc định;
 địa chỉ 90 nghĩa là `0x5A` (cho phép 90–93). Electrode được chọn phải là
 các số không trùng từ 0–11, có ít nhất một electrode. Ngưỡng phải thỏa
 `0 <= release_threshold < touch_threshold <= 255`. Polling cho phép 1–1000 ms;
@@ -268,16 +269,41 @@ MPR121 dùng chung ngưỡng cử chỉ từ `hal/drivers/button_gestures.py` v�
 
 | Cử chỉ | Action MPR121 |
 |---|---|
-| Lần nhả ngắn đầu tiên trong chuỗi click | `single_click_action(source="MPR121", announce=False)` lập tức dừng tracking/audio, unmute khi được phép và phát ack chime. |
+| Lần nhả ngắn đầu tiên trong chuỗi click | `single_click_action(source="MPR121", announce=False)` dừng tracking/audio sau khi phân giải contact, unmute khi được phép và phát ack chime. |
 | 1, 2 hoặc 4+ tap ngắn, rồi yên 0.4 s | Phát cue nghe; các tap lặp không gọi lại action single-click ban đầu. |
 | Đúng 3 tap ngắn, rồi yên 0.4 s | `triple_click_action` reboot thay vì phát cue nghe. |
 | Giữ 2–<5 s rồi nhả | `hold_release_action` vào sleepy. |
 | Giữ 5–<10 s rồi nhả | `hold_release_action` shutdown. |
 | Giữ ≥10 s rồi nhả | `hold_release_action` factory reset. |
+| Vuốt một trong hai hướng rồi nhả | `swipe_action` sleep; contact di chuyển này không gọi click hoặc action destructive. |
 
 Contact ngắn kéo dài dưới 2 s. Cửa sổ click không phân giải khi còn bất kỳ
 electrode được chọn nào đang chạm. Nhả sau giữ xóa chuỗi click đang chờ.
 Action destructive không chạy khi còn giữ.
+
+### Vuốt MPR121 để sleep
+
+`swipe_axis` là list tùy chọn gồm 2–12 electrode khác nhau, thuộc `electrodes`,
+được xếp theo thứ tự trên dải. Lamp khai báo E0…E11 dựa trên chuỗi log E11→E0,
+E0→E8 và E9→E0; xác định được thứ tự, chưa gán đầu nào là bên trái vật lý.
+Cả hai hướng gọi `swipe_action(source="MPR121")` trong `button_actions.py`,
+cùng action sleep với TTP223. Không cần vuốt hết toàn bộ dải. Thiếu/null
+`swipe_axis` chỉ tắt nhận diện vuốt, giữ nhận diện click/hold cũ.
+Cài HAL hỗ trợ trước khi deploy JSON có trường này.
+
+Debounce contact vẫn mặc định 30 ms; vùng chạm dùng tối đa 5 ms ổn định
+(thường là hai poll liên tiếp cách 10 ms) để giữ các chuyển tiếp electrode nhanh.
+Detector theo dõi vùng chạm đã debounce thay vì đếm mỗi electrode chạm chồng
+thành một tap. Chạm nhiều electrode nhưng đứng yên vẫn giữ hành vi click/hold.
+Khi phát hiện di chuyển, hủy kết quả tap/hold đang chờ và phản hồi LED giữ cho
+contact đó; vuốt hợp lệ gọi sleep một lần sau khi nhả. Di chuyển đảo chiều hoặc
+không hợp lệ không gọi reboot/shutdown/reset. Chờ nhả 120 ms để nối các đoạn
+chuyển tiếp ngắn giữa electrode; khi bật swipe, tap/hold phân giải sau khoảng
+chờ này. Contact giữ từ lúc boot vẫn bị bỏ qua. Log ghi hướng, độ dịch chuyển,
+kết quả swipe và thực thi action. Test phát lại chuỗi mask đã đo cùng các ca
+cử chỉ/vòng đời giả lập. Runtime và JSON swipe đã deploy lên Lamp `lamp-0c4e`
+ngày 2026-09-11; startup xác nhận MPR121 ready với trục cấu hình, GPIO và TTP223
+ready, mic switch Lamp vẫn tắt. Chờ live test cử chỉ.
 
 Event `hold_tier` đã debounce truyền vào cùng `HoldLEDFeedback` với GPIO,
 dùng chung `BUTTON_LED_PRESETS`, xử lý nháy, dọn phản hồi khi nhả và phản hồi

--- a/robots/lamp/mic_button.json
+++ b/robots/lamp/mic_button.json
@@ -1,8 +1,8 @@
 {
   "boards": {
     "orangepi_sun60": {
-      "chip": 0,
-      "line": 97,
+      "chip": 1,
+      "line": 9,
       "settle_s": 0.06,
       "muted_level": 0,
       "watchdog_s": 30

--- a/robots/lamp/mpr121.json
+++ b/robots/lamp/mpr121.json
@@ -22,7 +22,21 @@
       "release_threshold": 1,
       "autoconfig": true,
       "poll_ms": 10,
-      "debounce_ms": 30
+      "debounce_ms": 30,
+      "swipe_axis": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ]
     }
   }
 }


### PR DESCRIPTION
Lamp gains a configurable microphone slide switch on physical pin 11 (PL9, gpiochip1/line9) and MPR121 swipe-to-sleep in both directions.

Mic wiring, polarity, settling and watchdog timing move into the device JSON loader. Only Lamp ships mic_button.json; Intern v2 continues using the unchanged code fallback (gpiochip0/line97, LOW=mute, 60 ms settle, 30 s watchdog). Preserve boot synchronization, settled-edge reads and software mute coexistence. Clean up callbacks, timers, watchdog and GPIO handles on shutdown.

MPR121 reads an optional ordered swipe_axis; Lamp enables E0–E11 based on recorded electrode travel. Resolve partial-strip movement in either direction through the existing shared swipe_action. Stationary contacts retain click/hold behavior; moving, reversed or invalid trajectories cannot become reboot/shutdown/reset. Missing swipe_axis preserves the previous recognizer. Update English and Vietnamese docs.

Validation:
- Focused input suite: 207 tests and 70 subtests passed.
- Mic/config/action tests rerun after moving JSON to Lamp: 50 passed.
- HAL lint clean across 358 files; git diff --check clean.
- Three recorded swipe traces and two stationary touch traces replay at 10 ms polling with two sampling phases.
- Runtime and swipe JSON deployed to Lamp 172.168.20.242; startup confirms MPR121, both GPIO buttons and TTP223 ready. Live gesture validation remains pending. Final Lamp mic JSON for pin 11 also deployed: startup confirms gpiochip1/line9 ready and initial LOW applied mute. Live toggle validation remains pending.

Install the updated HAL before device configuration containing swipe_axis; older strict loaders reject unknown fields.
