### PR TITLE
hal: lock Lamp mic, camera and speaker with privacy switch

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -76,7 +76,15 @@ detected automatically. Malformed configuration, duplicate input names, and
 duplicate chip/line pairs are rejected before GPIO is claimed. Simulation
 skips hardware buttons.
 
-The privacy switch currently controls microphone mute only; camera behavior is unchanged.
+The privacy switch always controls microphone mute. Optional boolean fields
+`disable_camera_on_mute` and `mute_speaker_on_mute` also lock camera capture
+and speaker output; both default to `false`. Lamp enables both in its JSON,
+while Intern keeps its microphone-only fallback and ships no privacy JSON.
+HAL keeps opted-in peripherals closed until the first GPIO read; read/claim
+failure leaves them locked. The camera capture wrapper, camera routes,
+auto-wake helpers and audio output gates share `hal/privacy.py`. Unlock restores
+the prior camera/speaker preferences; temporary locks do not overwrite their
+boot-scoped persisted preferences.
 The loader accepts legacy `mic_button.json` only when `privacy_button.json` is absent,
 so HAL can be updated before the device JSON is renamed.
 The microphone slide switch uses device-owned `privacy_button.json`, initially

--- a/docs/vi/overview_vi.md
+++ b/docs/vi/overview_vi.md
@@ -74,7 +74,14 @@ chọn rồi restart HAL; hệ thống không tự phát hiện đổi dây cắ
 tên input trùng hoặc cặp chip/line trùng bị từ chối trước khi claim GPIO.
 Chế độ mô phỏng bỏ qua nút phần cứng.
 
-Công tắc privacy hiện chỉ điều khiển mute microphone; hành vi camera không đổi.
+Công tắc privacy luôn điều khiển mute microphone. Hai trường boolean tùy chọn
+`disable_camera_on_mute` và `mute_speaker_on_mute` khóa thêm camera và speaker;
+cả hai mặc định `false`. Lamp bật cả hai trong JSON, còn Intern giữ fallback
+chỉ mute mic và không kèm JSON privacy. HAL giữ các thiết bị đã chọn ở trạng thái
+khóa cho tới lần đọc GPIO đầu tiên; lỗi đọc/claim thì tiếp tục khóa. Wrapper
+capture camera, camera routes, auto-wake và các đường phát âm thanh dùng chung
+`hal/privacy.py`. Mở khóa khôi phục trạng thái camera/speaker trước đó; khóa
+tạm thời không ghi đè tùy chọn đã lưu trong sidecar theo boot.
 Loader chỉ đọc file cũ `mic_button.json` khi chưa có `privacy_button.json`,
 để có thể cập nhật HAL trước khi đổi tên JSON của device.
 Công tắc gạt microphone dùng `privacy_button.json` do device quản lý, hiện chỉ

--- a/hal/app_state.py
+++ b/hal/app_state.py
@@ -13,7 +13,7 @@ import threading
 import time
 from typing import Optional
 
-from hal import config
+from hal import config, privacy
 from hal.presets import (
     AMBIENT_RESTING_LED,
     ambient_resting_is_dark,
@@ -540,7 +540,9 @@ def _persist_mic_state():
 
 
 def _persist_speaker_state():
-    _save_boot_sidecar(_SPEAKER_STATE_PATH, {"muted": _speaker_muted})
+    _save_boot_sidecar(_SPEAKER_STATE_PATH, {
+        "muted": privacy.speaker_before if privacy.speaker_muted else _speaker_muted,
+    })
 
 
 def _persist_sleep_state():
@@ -575,7 +577,7 @@ def start_voice_service(reason: str) -> bool:
 
     Returns True when the pipeline was actually started.
     """
-    if voice_service is None:
+    if voice_service is None or privacy.mic_locked():
         return False
     if _enrolling:
         logger.info("voice_service.start skipped (%s) -- enrollment owns the mic", reason)
@@ -623,7 +625,8 @@ def _wake_sleepy_peripherals():
     """Restore only mic/speaker states that sleepy itself muted."""
     global _sleepy_auto_muted_mic, _sleepy_auto_muted_speaker, _mic_muted, _speaker_muted
     if _sleepy_auto_muted_speaker:
-        _speaker_muted = False
+        if not privacy.speaker_muted:
+            _speaker_muted = False
         _sleepy_auto_muted_speaker = False
     if _sleepy_auto_muted_mic:
         _sleepy_auto_muted_mic = False
@@ -637,7 +640,8 @@ def _wake_sleepy_peripherals():
 def _persist_camera_state():
     _save_boot_sidecar(
         _CAMERA_STATE_PATH,
-        {"disabled": _camera_disabled, "manual_override": _camera_manual_override},
+        {"disabled": privacy.camera_before if privacy.camera_muted else _camera_disabled,
+         "manual_override": _camera_manual_override},
     )
 
 
@@ -1471,9 +1475,12 @@ def _apply_emotion_led_display(
     return led_color
 
 
+@privacy.serialized
 def _auto_camera_off(reason: str) -> bool:
     """Auto-disable camera. Respects manual override + active tracking."""
     global _camera_disabled
+    if privacy.camera_muted:
+        return False
     if _camera_manual_override:
         logger.debug(
             "Auto camera off skipped -- manual override active (reason: %s)", reason
@@ -1494,9 +1501,12 @@ def _auto_camera_off(reason: str) -> bool:
     return True
 
 
+@privacy.serialized
 def _auto_camera_on(reason: str) -> bool:
     """Auto-enable camera. Respects manual override."""
     global _camera_disabled
+    if privacy.camera_muted:
+        return False
     if _camera_manual_override:
         logger.debug(
             "Auto camera on skipped -- manual override active (reason: %s)", reason

--- a/hal/board/privacy_button.py
+++ b/hal/board/privacy_button.py
@@ -13,6 +13,8 @@ class PrivacyButtonConfig:
     settle_s: float = 0.06
     muted_level: int = 0
     watchdog_s: float = 30.0
+    disable_camera_on_mute: bool = False
+    mute_speaker_on_mute: bool = False
 
 
 def load_privacy_button_config(device_dir: str, board_id: str,
@@ -52,6 +54,9 @@ def load_privacy_button_config(device_dir: str, board_id: str,
             if not {"chip", "line"} <= set(values):
                 raise ValueError(f"{board}: chip and line are required")
             config = PrivacyButtonConfig(**values)
+            for name in ("disable_camera_on_mute", "mute_speaker_on_mute"):
+                if type(getattr(config, name)) is not bool:
+                    raise ValueError(f"{board}: {name} must be boolean")
             for name in ("chip", "line"):
                 value = getattr(config, name)
                 if type(value) is not int or value < 0:

--- a/hal/drivers/button_actions.py
+++ b/hal/drivers/button_actions.py
@@ -301,13 +301,15 @@ def _grant_wakeword_focus(source: str):
         logger.warning("%s single click -- wake-word focus grant failed: %s", source, e)
 
 
-def single_click_action(source: str = "button", announce: bool = True, chime: bool = True):
+def single_click_action(source: str = "button", announce: bool = True, chime: bool = True,
+                        unmute_output: bool = True):
     """Stop active tracking and in-flight speech / unmute mic + speaker.
 
     Then open the wake-word window (if wake word is on) and announce the
     listening cue.
     announce=False skips the cue (caller fires announce_listening_cue later).
-    chime=False skips the ack ping (caller already chimed at gesture start)."""
+    chime=False skips the ack ping (caller already chimed at gesture start).
+    unmute_output=False leaves speaker restoration to the privacy switch."""
     # Stopping movement is safe even with the hardware mic kill switch off: it
     # does not wake or unmute the microphone, but still lets the user cancel an
     # active follow session with the same direct-attention gesture.
@@ -354,7 +356,7 @@ def single_click_action(source: str = "button", announce: bool = True, chime: bo
     # is recording: that mute is a transient guard against TTS bleeding into the
     # captured WAV (see routes/speaker.py record-enroll), not a user preference.
     # Must run before the _tts_available() check below so the cue can play.
-    if state._speaker_muted and not state._enrolling:
+    if unmute_output and state._speaker_muted and not state._enrolling:
         logger.info("%s single click -- unmuting speaker", source)
         t = time.monotonic()
         unmute_speaker()

--- a/hal/drivers/privacy_button.py
+++ b/hal/drivers/privacy_button.py
@@ -11,6 +11,7 @@ import time
 
 import hal.app_state as state
 from hal.board.privacy_button import PrivacyButtonConfig
+from hal import privacy
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,10 @@ class PrivacyButtonHandler:
             initial_level = lgpio.gpio_read(self._handle, self._config.line)
         except Exception as e:
             logger.warning("Mic switch initial read failed: %s", e)
-            initial_level = 1 - self._config.muted_level  # default to unmuted if read fails
+            # Extended privacy fails closed; preserve legacy microphone fallback.
+            initial_level = (self._config.muted_level if (
+                self._config.disable_camera_on_mute or self._config.mute_speaker_on_mute
+            ) else 1 - self._config.muted_level)
 
         logger.info(
             "Mic mute switch ready on gpiochip%d line %d (initial level=%d, settle %d ms, watchdog %ds)",
@@ -288,7 +292,14 @@ class PrivacyButtonHandler:
         # still needs to advertise "HW-locked" to the web.
         state._hw_mic_switch_muted = muted
 
+        extended = self._config and (
+            self._config.disable_camera_on_mute or self._config.mute_speaker_on_mute
+        )
+        if extended and muted:
+            privacy.apply(True, self._config)
         if state._mic_muted == muted:
+            if extended and not muted:
+                privacy.apply(False, self._config)
             return
 
         from hal.routes.voice import mute_mic, stop_tts
@@ -328,7 +339,19 @@ class PrivacyButtonHandler:
                 from hal.drivers.button_actions import single_click_action
 
                 t_sca = time.monotonic()
-                single_click_action("mic-switch")
+                if extended:
+                    # Wake while the peripheral gates remain closed, then restore
+                    # the user's camera/speaker preferences before playing the cue.
+                    try:
+                        single_click_action("privacy-switch", announce=False, chime=False,
+                                            unmute_output=False)
+                    finally:
+                        privacy.apply(False, self._config)
+                    from hal.drivers.button_actions import play_ack_chime, announce_listening_cue
+                    play_ack_chime("privacy-switch")
+                    announce_listening_cue("privacy-switch")
+                else:
+                    single_click_action("mic-switch")
                 logger.info("[mic-switch-trace] unmute step2 single_click_action done +%.0fms (cumul=%.0fms)", (time.monotonic() - t_sca) * 1000, (time.monotonic() - t0) * 1000)
                 # After unmute the natural resting look is warm-white
                 # ambient because _user_led_state is None on fresh boots —

--- a/hal/drivers/voice/backchannel.py
+++ b/hal/drivers/voice/backchannel.py
@@ -178,10 +178,11 @@ class Backchannel:
     def _play(self, text: str, session_epoch: int) -> None:
         """Play a short TTS cue directly, bypassing tts_service.speak()."""
         import hal.app_state as _state
+        from hal import privacy
         if not self._session_is_current(session_epoch):
             logger.info("Backchannel skipped: originating STT session ended before playback")
             return
-        if _state._speaker_muted:
+        if _state._speaker_muted or privacy.speaker_muted:
             return
         tts = self._tts
         if tts is None or tts._backend is None or not tts._backend.available or tts._sd is None:
@@ -233,6 +234,8 @@ class Backchannel:
                             "Backchannel skipped: originating STT session ended while "
                             "waiting for TTS output"
                         )
+                        return
+                    if _state._speaker_muted or privacy.speaker_muted:
                         return
                     stream = tts._ensure_stream(dst_rate)
                     stream.write(samples_2d)

--- a/hal/drivers/voice/music_service.py
+++ b/hal/drivers/voice/music_service.py
@@ -7,6 +7,7 @@ and output directly to ALSA device (bypassing sounddevice/PortAudio).
 
 import json
 import logging
+from hal import privacy
 import os
 import re
 import subprocess
@@ -328,6 +329,7 @@ class MusicService:
     def current_title(self) -> Optional[str]:
         return self._current_title
 
+    @privacy.serialized
     def play(self, query: str, on_started=None, person: str = "") -> bool:
         """Search YouTube and play first result. Returns True if started.
 
@@ -336,6 +338,8 @@ class MusicService:
         visual effects (e.g. groove animation) with actual audio start.
         person: who requested the music (for per-user history).
         """
+        if privacy.speaker_muted:
+            return False
         # Stop current playback if any
         if self._playing:
             self.stop()
@@ -356,11 +360,14 @@ class MusicService:
         thread.start()
         return True
 
+    @privacy.serialized
     def play_file(self, path: str, title: Optional[str] = None, on_started=None, person: str = "") -> bool:
         """Play a local audio file directly via ffmpeg. Returns True if started.
 
         on_started: optional callable fired once ffmpeg begins streaming.
         """
+        if privacy.speaker_muted:
+            return False
         if self._playing:
             self.stop()
             time.sleep(0.3)

--- a/hal/drivers/voice/tts/service.py
+++ b/hal/drivers/voice/tts/service.py
@@ -859,9 +859,9 @@ class TTSService:
         Lazy import avoids an app_state import cycle (app_state holds the
         TTSService instance)."""
         try:
-            from hal import app_state
+            from hal import app_state, privacy
 
-            return app_state._speaker_muted
+            return app_state._speaker_muted or privacy.speaker_muted
         except Exception:
             return False
 

--- a/hal/privacy.py
+++ b/hal/privacy.py
@@ -1,0 +1,140 @@
+"""Physical privacy policy shared by input handlers and peripheral consumers.
+
+Camera/speaker locks are temporary overlays on the user's existing preferences.
+They are configured per device, never inferred from a device name.
+"""
+
+from functools import wraps
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+lock = threading.RLock()
+camera_muted = False
+speaker_muted = False
+camera_before = None
+speaker_before = None
+
+
+def serialized(fn):
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        with lock:
+            return fn(*args, **kwargs)
+    return wrapped
+
+
+@serialized
+def apply(muted, config):
+    """Apply peripheral locks even when the microphone already matches."""
+    global camera_muted, speaker_muted, camera_before, speaker_before
+    from hal import app_state as state
+
+    want_camera = muted and config.disable_camera_on_mute
+    want_speaker = muted and config.mute_speaker_on_mute
+    # Publish both gates before potentially slow device teardown.
+    if want_camera and not camera_muted:
+        camera_before = state._camera_disabled
+    if want_speaker and not speaker_muted:
+        speaker_before = state._speaker_muted
+    camera_muted, speaker_muted = want_camera, want_speaker
+
+    if camera_muted:
+        state._camera_disabled = True
+    if speaker_muted:
+        state._speaker_muted = True
+
+    # Each peripheral is independent: a camera failure must not leave audio on.
+    actions = []
+    if speaker_muted:
+        actions.extend(("stop " + name, service.stop) for name, service in (
+            ("TTS", state.tts_service), ("music", state.music_service),
+        ) if service is not None)
+    elif speaker_before is not None:
+        state._speaker_muted = speaker_before
+        speaker_before = None
+
+    if camera_muted and state.camera_capture is not None:
+        actions.append(("stop camera", state.camera_capture.stop))
+    elif not camera_muted and camera_before is not None:
+        state._camera_disabled = camera_before
+        camera_before = None
+        if not state._camera_disabled and state.camera_capture is not None:
+            actions.append(("restore camera", state.camera_capture.start))
+
+    for name, action in actions:
+        try:
+            action()
+        except Exception:
+            logger.exception("Privacy switch: failed to %s", name)
+    state._persist_camera_state()
+    state._persist_speaker_state()
+    logger.info("Privacy switch: muted=%s camera_locked=%s speaker_locked=%s",
+                muted, camera_muted, speaker_muted)
+
+
+def mic_locked():
+    """Extra privacy guards apply only to devices opting into peripheral locks."""
+    from hal import app_state as state
+    return (camera_muted or speaker_muted) and state._hw_mic_switch_muted is True
+
+
+def prepare(config):
+    """Keep configured peripherals closed until the initial GPIO read completes."""
+    if config and (config.disable_camera_on_mute or config.mute_speaker_on_mute):
+        from hal import app_state as state
+        state._hw_mic_switch_muted = True
+        state._mic_muted = True
+        state._mic_muted_led = True
+        apply(True, config)
+
+
+class GuardedCamera:
+    """Gate every capture consumer, including temporary starts by realtime look."""
+
+    def __init__(self, capture):
+        object.__setattr__(self, "_capture", capture)
+
+    def __getattr__(self, name):
+        return getattr(self._capture, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._capture, name, value)
+
+    @serialized
+    def start(self):
+        if camera_muted:
+            logger.info("Camera start blocked by privacy switch")
+            return
+        self._capture.start()
+
+    @serialized
+    def stop(self):
+        self._capture.stop()
+        # Discard frames retained by the backend across stop/start.
+        self._capture.last_response = None
+
+    @property
+    def last_frame(self):
+        if camera_muted:
+            return None
+        frame = self._capture.last_frame
+        return None if camera_muted else frame
+
+    @property
+    def last_frame_ts(self):
+        return 0.0 if camera_muted else self._capture.last_frame_ts
+
+    @property
+    def last_response(self):
+        return None if camera_muted else self._capture.last_response
+
+    @property
+    def last_frame_description(self):
+        return None if camera_muted else self._capture.last_frame_description
+
+    def capture(self, *args, **kwargs):
+        if camera_muted:
+            return None
+        result = self._capture.capture(*args, **kwargs)
+        return None if camera_muted else result

--- a/hal/realtime/orchestrator.py
+++ b/hal/realtime/orchestrator.py
@@ -1628,8 +1628,9 @@ class RealtimeOrchestrator:
             from hal.drivers.camera.video_capture_device import capture_still
         except Exception:
             return None
+        from hal import privacy
         cap = getattr(state, "camera_capture", None)
-        if cap is None:
+        if cap is None or privacy.camera_muted:
             return None
         was_disabled: bool = bool(getattr(state, "_camera_disabled", False))
         try:
@@ -1648,6 +1649,8 @@ class RealtimeOrchestrator:
                 if was_disabled:
                     cap.stop()
             if frame is None:
+                return None
+            if privacy.camera_muted:
                 return None
             max_w: int = config.REALTIME_GEMINI_VISION_MAX_WIDTH
             h, w = frame.shape[:2]

--- a/hal/routes/camera.py
+++ b/hal/routes/camera.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 import hal.app_state as state
+from hal import privacy
 from hal.models import CameraInfoResponse, CameraZoomRequest, StatusResponse
 from hal.config import CAMERA_WIDTH, CAMERA_HEIGHT
 
@@ -62,10 +63,16 @@ def set_camera_zoom(req: CameraZoomRequest):
 
 
 @router.post("/camera/disable", response_model=StatusResponse)
+@privacy.serialized
 def disable_camera():
     """Stop the camera capture loop (manual). Sets manual override."""
     if not state.camera_capture:
         raise HTTPException(503, "Camera not available")
+    if privacy.camera_muted:
+        privacy.camera_before = True
+        state._camera_manual_override = True
+        state._persist_camera_state()
+        return {"status": "already_disabled"}
     if state._camera_disabled:
         return {"status": "already_disabled"}
     state._camera_disabled = True
@@ -77,8 +84,11 @@ def disable_camera():
 
 
 @router.post("/camera/enable", response_model=StatusResponse)
+@privacy.serialized
 def enable_camera():
     """Restart the camera capture loop (manual). Clears manual override."""
+    if privacy.camera_muted:
+        raise HTTPException(409, "Privacy switch is on -- flip the switch to enable camera")
     if not state.camera_capture:
         raise HTTPException(503, "Camera not available")
     if not state._camera_disabled:
@@ -105,6 +115,8 @@ def camera_snapshot(
     box. Upscaling above source is not allowed (just blurs without detail) —
     requests above source are clamped.
     """
+    if privacy.camera_muted:
+        raise HTTPException(409, "Privacy switch is on -- camera capture is blocked")
     if not state.camera_capture or cv2 is None:
         raise HTTPException(503, "Camera not available")
 
@@ -135,6 +147,9 @@ def camera_snapshot(
         if was_disabled:
             state.camera_capture.stop()
 
+    if privacy.camera_muted:
+        raise HTTPException(409, "Privacy switch is on -- camera capture is blocked")
+
     if width is not None or height is not None:
         src_h, src_w = frame.shape[:2]
         # Compute target scale honoring aspect ratio, clamped so we never
@@ -153,6 +168,8 @@ def camera_snapshot(
 
     _, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, quality])
 
+    if privacy.camera_muted:
+        raise HTTPException(409, "Privacy switch is on -- camera capture is blocked")
     if not save:
         return Response(content=buf.tobytes(), media_type="image/jpeg")
 
@@ -176,7 +193,7 @@ def camera_snapshot(
 @router.get("/camera/stream")
 def camera_stream():
     """MJPEG stream from the camera."""
-    if not state.camera_capture or cv2 is None or state._camera_disabled:
+    if not state.camera_capture or cv2 is None or state._camera_disabled or privacy.camera_muted:
         raise HTTPException(503, "Camera disabled" if state._camera_disabled else "Camera not available")
 
     stream_fps = float(os.environ.get("HAL_CAMERA_STREAM_FPS", "10"))
@@ -188,7 +205,7 @@ def camera_stream():
         state.camera_capture.acquire_consumer()
         try:
             last_sent_s = 0.0
-            while not state._camera_disabled:
+            while not state._camera_disabled and not privacy.camera_muted:
                 if min_interval_s > 0:
                     now_s = time.time()
                     elapsed_s = now_s - last_sent_s
@@ -225,6 +242,8 @@ def camera_stream():
                 _, buf = cv2.imencode(
                     ".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, int(stream_quality)]
                 )
+                if privacy.camera_muted:
+                    break
                 last_sent_s = time.time()
                 yield (
                     b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + buf.tobytes() + b"\r\n"

--- a/hal/routes/music.py
+++ b/hal/routes/music.py
@@ -6,6 +6,7 @@ import random
 from fastapi import APIRouter, HTTPException
 
 import hal.app_state as state
+from hal import privacy
 from hal.safety.policy import audio_quiet_now
 from hal.models import (
     MusicPlayRequest,
@@ -283,8 +284,12 @@ def audio_stop():
 
 
 @router.post("/speaker/mute", response_model=StatusResponse, tags=["Audio"])
+@privacy.serialized
 def mute_speaker():
     """Mute all audio output -- TTS, music, backchannel suppressed."""
+    if privacy.speaker_muted:
+        privacy.speaker_before = True
+        state._persist_speaker_state()
     if state._speaker_muted:
         return {"status": "already_muted"}
     state._speaker_muted = True
@@ -298,8 +303,11 @@ def mute_speaker():
 
 
 @router.post("/speaker/unmute", response_model=StatusResponse, tags=["Audio"])
+@privacy.serialized
 def unmute_speaker():
     """Unmute audio output."""
+    if privacy.speaker_muted:
+        raise HTTPException(409, "Privacy switch is on -- flip the switch to unmute speaker")
     if not state._speaker_muted:
         return {"status": "already_unmuted"}
     state._speaker_muted = False

--- a/hal/routes/scene.py
+++ b/hal/routes/scene.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException
 
 import hal.app_state as state
-from hal import config
+from hal import config, privacy
 from hal.models import (
     SceneListResponse,
     SceneRequest,
@@ -137,7 +137,7 @@ def activate_scene(req: SceneRequest):
             state.voice_service.stop()
         state._persist_mic_state()
         state.logger.info("Scene %s: mic muted", req.scene)
-    elif mic == "on" and state._mic_muted:
+    elif mic == "on" and state._mic_muted and not privacy.mic_locked():
         state._mic_muted = False
         state._mic_manual_override = False
         state.start_voice_service("scene:mic-on")
@@ -157,7 +157,7 @@ def activate_scene(req: SceneRequest):
             state.music_service.stop()
         state._persist_speaker_state()
         state.logger.info("Scene %s: speaker muted", req.scene)
-    elif spk == "on" and state._speaker_muted:
+    elif spk == "on" and state._speaker_muted and not privacy.speaker_muted:
         state._speaker_muted = False
         state._persist_speaker_state()
         state.logger.info("Scene %s: speaker unmuted", req.scene)
@@ -194,7 +194,7 @@ def deactivate_scene():
         state._auto_camera_on("scene:off")
 
     # Unmute mic + restart voice pipeline
-    if state._mic_muted:
+    if state._mic_muted and not privacy.mic_locked():
         state._mic_muted = False
         state._mic_manual_override = False
         state.start_voice_service("scene:off")
@@ -203,7 +203,7 @@ def deactivate_scene():
         state.logger.info("Scene off: mic unmuted")
 
     # Unmute speaker
-    if state._speaker_muted:
+    if state._speaker_muted and not privacy.speaker_muted:
         state._speaker_muted = False
         state._persist_speaker_state()
         state.logger.info("Scene off: speaker unmuted")

--- a/hal/routes/speaker.py
+++ b/hal/routes/speaker.py
@@ -37,6 +37,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 import hal.app_state as state
+from hal import privacy
 from hal import config
 from hal.drivers.voice.speaker_recognizer import (
     EmbeddingAPIUnavailableError,
@@ -424,6 +425,8 @@ def speaker_record_enroll(req: RecordEnrollRequest) -> EnrollResponse:
     enroll. ``voice_service`` is *paused* (not torn down) so we don't lose
     the configured tts/stt credentials — restart needs no extra args.
     """
+    if privacy.mic_locked():
+        raise HTTPException(409, "Privacy switch is on -- microphone recording is blocked")
     name = req.name.strip().lower()
     duration = req.duration_sec
     if not name:
@@ -515,14 +518,14 @@ def speaker_record_enroll(req: RecordEnrollRequest) -> EnrollResponse:
         # Restore speaker mute state — only relax the gate if we set it.
         # Don't overwrite a pre-existing mute the user/scene may have asked for.
         state._enrolling = False
-        if not prev_speaker_muted:
+        if not prev_speaker_muted and not privacy.speaker_muted:
             state._speaker_muted = False
         # Always restart the listener so passive recognition / wake word
         # doesn't stay broken after a failed enroll. This is the one caller
         # that bypasses state.start_voice_service(): it owns the stop above
         # and must restore the pipeline unconditionally. Safe because
         # _enrolling was already cleared, so the gate would pass anyway.
-        if was_running and state.voice_service is not None:
+        if was_running and state.voice_service is not None and not privacy.mic_locked():
             try:
                 state.voice_service.start()
             except Exception as e:

--- a/hal/server.py
+++ b/hal/server.py
@@ -367,6 +367,10 @@ def _sim_audio_probe(sd_module) -> None:
 async def lifespan(app: FastAPI):
     global _gpio_button_handlers, _ttp223_handler, _mpr121_handler, _privacy_button_handler
 
+    # Keep privacy-controlled peripherals closed until the GPIO boot sync.
+    from hal import privacy
+    privacy.prepare(_privacy_button_config)
+
     # --- Phase 0: Borrow the hardware from whoever owns it ---
     # Empty unless ROBOT.md declares an `owner:`. Where one exists it holds
     # /dev/video* and both ALSA PCMs, and nothing below can succeed until it
@@ -453,6 +457,8 @@ async def lifespan(app: FastAPI):
                     brightness=CAMERA_BRIGHTNESS,
                 )
             )
+            if _privacy_button_config and _privacy_button_config.disable_camera_on_mute:
+                cap = privacy.GuardedCamera(cap)
             if state._camera_disabled:
                 # Disabled state restored from the camera sidecar: keep the
                 # capture object (so /camera/enable can start it) but don't

--- a/hal/test/test_privacy.py
+++ b/hal/test/test_privacy.py
@@ -1,0 +1,213 @@
+"""Privacy overlays preserve preferences and cannot be bypassed by consumers."""
+
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException
+
+from hal import app_state as state, privacy
+from hal.board.privacy_button import PrivacyButtonConfig
+from hal.drivers.privacy_button import PrivacyButtonHandler
+from hal.routes import camera, music
+
+
+@pytest.fixture(autouse=True)
+def isolated(monkeypatch):
+    for key, value in {"camera_muted": False, "speaker_muted": False,
+                       "camera_before": None, "speaker_before": None}.items():
+        monkeypatch.setattr(privacy, key, value)
+    for key, value in {
+        "_camera_disabled": False, "_camera_manual_override": False,
+        "_speaker_muted": False, "_mic_muted": False,
+        "_hw_mic_switch_muted": None, "_mic_muted_led": False,
+        "camera_capture": mock.Mock(), "tts_service": mock.Mock(),
+        "music_service": mock.Mock(), "voice_service": mock.Mock(),
+        "_save_boot_sidecar": mock.Mock(),
+    }.items():
+        monkeypatch.setattr(state, key, value)
+
+
+def config():
+    return PrivacyButtonConfig(disable_camera_on_mute=True, mute_speaker_on_mute=True)
+
+
+@pytest.mark.parametrize("camera_disabled,speaker_muted", [(False, False), (True, False),
+                                                          (False, True), (True, True)])
+def test_lock_restore_preserves_preferences(camera_disabled, speaker_muted):
+    state._camera_disabled = camera_disabled
+    state._camera_manual_override = camera_disabled
+    state._speaker_muted = speaker_muted
+    privacy.apply(True, config())
+    assert state._camera_disabled and state._speaker_muted
+    state.camera_capture.stop.assert_called_once()
+    state.tts_service.stop.assert_called_once()
+    state.music_service.stop.assert_called_once()
+    # Reconciliation must not overwrite the original preferences with the locks.
+    privacy.apply(True, config())
+    assert privacy.camera_before == camera_disabled
+    assert privacy.speaker_before == speaker_muted
+    state._save_boot_sidecar.assert_any_call(state._CAMERA_STATE_PATH, {
+        "disabled": camera_disabled, "manual_override": camera_disabled,
+    })
+    state._save_boot_sidecar.assert_any_call(state._SPEAKER_STATE_PATH, {"muted": speaker_muted})
+    privacy.apply(False, config())
+    assert state._camera_disabled == camera_disabled
+    assert state._camera_manual_override == camera_disabled
+    assert state._speaker_muted == speaker_muted
+    assert state.camera_capture.start.call_count == (0 if camera_disabled else 1)
+
+
+def test_default_intern_handler_never_applies_peripheral_policy():
+    state._mic_muted = True
+    with mock.patch.object(privacy, "apply") as apply:
+        PrivacyButtonHandler(PrivacyButtonConfig())._apply_state_locked(True)
+    apply.assert_not_called()
+    assert state._hw_mic_switch_muted is True
+    assert not state._camera_disabled and not state._speaker_muted
+
+
+def test_lamp_locks_peripherals_when_mic_already_muted():
+    state._mic_muted = True
+    PrivacyButtonHandler(config())._apply_state_locked(True)
+    assert privacy.camera_muted and privacy.speaker_muted
+    assert state._camera_disabled and state._speaker_muted
+
+
+def test_prepare_fails_closed_before_camera_and_audio_start():
+    privacy.prepare(config())
+    assert privacy.mic_locked()
+    assert state._mic_muted and state._speaker_muted and state._camera_disabled
+    guarded = privacy.GuardedCamera(state.camera_capture)
+    guarded.start()
+    state.camera_capture.start.assert_not_called()
+
+
+@pytest.mark.parametrize("cfg", [None, PrivacyButtonConfig()])
+def test_prepare_does_not_change_intern_or_unconfigured_device(cfg):
+    privacy.prepare(cfg)
+    assert state._hw_mic_switch_muted is None
+    assert not state._mic_muted and not state._speaker_muted and not state._camera_disabled
+    assert not state.camera_capture.mock_calls
+
+
+def test_camera_failure_cannot_prevent_speaker_mute():
+    state.camera_capture.stop.side_effect = RuntimeError("camera failed")
+    privacy.apply(True, config())
+    assert privacy.camera_muted and privacy.speaker_muted
+    state.tts_service.stop.assert_called_once()
+    state.music_service.stop.assert_called_once()
+
+
+def test_software_cannot_unlock_or_take_snapshot():
+    privacy.apply(True, config())
+    for action in (camera.enable_camera, camera.camera_snapshot, music.unmute_speaker):
+        with pytest.raises(HTTPException) as error:
+            action()
+        assert error.value.status_code == 409
+    assert not state._auto_camera_on("wake")
+    assert not state._auto_camera_off("scene")
+    state.camera_capture.start.assert_not_called()
+
+
+def test_manual_disable_during_lock_remains_after_unlock():
+    privacy.apply(True, config())
+    camera.disable_camera()
+    music.mute_speaker()
+    privacy.apply(False, config())
+    assert state._camera_disabled and state._camera_manual_override and state._speaker_muted
+    state.camera_capture.start.assert_not_called()
+
+
+def test_guarded_camera_blocks_retained_frames_and_temporary_starts():
+    raw = mock.Mock(last_frame="old frame", last_response="old response", last_frame_ts=12)
+    guarded = privacy.GuardedCamera(raw)
+    assert guarded.last_frame == "old frame"
+    state.camera_capture = guarded
+    privacy.apply(True, config())
+    guarded.start()
+    assert guarded.last_frame is None
+    assert guarded.last_response is None
+    assert guarded.last_frame_description is None
+    assert guarded.last_frame_ts == 0
+    assert guarded.capture() is None
+    raw.start.assert_not_called()
+    raw.capture.assert_not_called()
+    assert raw.last_response is None
+    privacy.apply(False, config())
+    raw.start.assert_called_once()
+
+
+def test_guarded_camera_drops_capture_if_muted_during_read():
+    raw = mock.Mock()
+    def capture():
+        privacy.apply(True, config())
+        return "frame"
+    raw.capture.side_effect = capture
+    assert privacy.GuardedCamera(raw).capture() is None
+
+
+def test_sleep_wake_cannot_unmute_privacy_speaker(monkeypatch):
+    monkeypatch.setattr(state, "_sleepy_auto_muted_speaker", True)
+    monkeypatch.setattr(state, "_sleepy_auto_muted_mic", False)
+    privacy.apply(True, config())
+    state._wake_sleepy_peripherals()
+    assert state._speaker_muted
+
+
+def test_extended_unlock_restores_after_shared_wake_without_unmuting_output():
+    state._mic_muted = True
+    state._speaker_muted = True
+    handler = PrivacyButtonHandler(config())
+    handler._apply_state_locked(True)
+    with (
+        mock.patch("hal.drivers.button_actions.single_click_action") as click,
+        mock.patch("hal.drivers.button_actions.play_ack_chime"),
+        mock.patch("hal.drivers.button_actions.announce_listening_cue"),
+        mock.patch.object(state, "_clear_mic_muted_led"),
+        mock.patch("hal.drivers.privacy_button.threading.Thread"),
+    ):
+        handler._apply_state_locked(False)
+    click.assert_called_once_with("privacy-switch", announce=False, chime=False, unmute_output=False)
+    assert not privacy.camera_muted and not privacy.speaker_muted
+    assert state._speaker_muted
+
+
+def test_direct_audio_consumers_respect_speaker_lock():
+    from hal.drivers.voice.music_service import MusicService
+    from hal.drivers.voice.tts.service import TTSService
+    privacy.apply(True, config())
+    # Even if another caller changed the software flag, the hardware lock wins.
+    state._speaker_muted = False
+    assert TTSService._speaker_muted()
+    player = MusicService.__new__(MusicService)
+    assert player.play("song") is False
+    assert player.play_file("/unused.wav") is False
+
+
+@pytest.mark.parametrize("camera_option,speaker_option", [(True, False), (False, True)])
+def test_optional_peripherals_are_independent(camera_option, speaker_option):
+    cfg = PrivacyButtonConfig(disable_camera_on_mute=camera_option,
+                              mute_speaker_on_mute=speaker_option)
+    privacy.apply(True, cfg)
+    assert state._camera_disabled == camera_option
+    assert state._speaker_muted == speaker_option
+    assert state.camera_capture.stop.call_count == int(camera_option)
+    assert state.tts_service.stop.call_count == int(speaker_option)
+    privacy.apply(False, cfg)
+    assert not state._camera_disabled and not state._speaker_muted
+
+
+def test_scene_release_cannot_reopen_privacy_peripherals(monkeypatch):
+    from hal.routes import scene
+    monkeypatch.setattr(state, "_active_scene", "night")
+    monkeypatch.setattr(state, "animation_service", None)
+    monkeypatch.setattr(state, "rgb_service", None)
+    monkeypatch.setattr(state, "_save_user_led_state", mock.Mock())
+    monkeypatch.setattr(scene, "_persist_scene", mock.Mock())
+    state._hw_mic_switch_muted = True
+    state._mic_muted = True
+    privacy.apply(True, config())
+    scene.deactivate_scene()
+    assert state._mic_muted and state._speaker_muted and state._camera_disabled
+    state.camera_capture.start.assert_not_called()
+    state.voice_service.start.assert_not_called()

--- a/hal/test/test_privacy_button.py
+++ b/hal/test/test_privacy_button.py
@@ -60,6 +60,20 @@ def test_failed_initial_read_keeps_legacy_unmuted_default(hardware, muted_level)
     handler.stop()
 
 
+@pytest.mark.parametrize("muted_level", [0, 1])
+def test_extended_privacy_initial_read_failure_stays_muted(hardware, muted_level):
+    gpio, _, _ = hardware
+    gpio.gpio_read.side_effect = OSError("read unavailable")
+    handler = PrivacyButtonHandler(PrivacyButtonConfig(
+        muted_level=muted_level, disable_camera_on_mute=True, mute_speaker_on_mute=True,
+    ))
+    handler._apply_state_locked = mock.Mock()
+    handler.start()
+    handler._apply_state_locked.assert_called_once_with(True)
+    assert handler._last_known_level == muted_level
+    handler.stop()
+
+
 def test_edge_restarts_configured_settle_then_reads_current_level(hardware):
     gpio, _, timer = hardware
     handler = PrivacyButtonHandler(PrivacyButtonConfig(line=43, settle_s=0.12, muted_level=1))

--- a/hal/test/test_privacy_button_config.py
+++ b/hal/test/test_privacy_button_config.py
@@ -22,7 +22,9 @@ def test_intern_uses_fallback_and_lamp_declares_pin_11():
     root = Path(__file__).resolve().parents[2] / "robots"
     assert load_privacy_button_config(root / "intern-v2", "orangepi_sun60", "intern-v2") == PrivacyButtonConfig()
     assert not (root / "intern-v2" / "privacy_button.json").exists()
-    assert load_privacy_button_config(root / "lamp", "orangepi_sun60", "lamp") == PrivacyButtonConfig(chip=1, line=9)
+    assert load_privacy_button_config(root / "lamp", "orangepi_sun60", "lamp") == PrivacyButtonConfig(
+        chip=1, line=9, disable_camera_on_mute=True, mute_speaker_on_mute=True,
+    )
     assert load_privacy_button_config(root / "lamp", "raspberry_pi_5", "lamp") is None
 
 
@@ -38,6 +40,8 @@ def test_device_override_and_explicit_disable(tmp_path):
 
 
 @pytest.mark.parametrize("entry", [
+    {"chip": 0, "line": 97, "disable_camera_on_mute": "true"},
+    {"chip": 0, "line": 97, "mute_speaker_on_mute": 1},
     {"chip": 0}, {"chip": -1, "line": 97}, {"chip": True, "line": 97},
     {"chip": 0, "line": "97"}, {"chip": 0, "line": 97, "muted_level": 2},
     {"chip": 0, "line": 97, "muted_level": False},

--- a/robots/lamp/docs/physical-controls.md
+++ b/robots/lamp/docs/physical-controls.md
@@ -83,6 +83,28 @@ to avoid its legacy pin 11 fallback overlapping this switch. The Lamp mic
 configuration was deployed on 2026-09-11; startup confirmed chip1/line9 ready
 and initial LOW applied mute. Live toggle testing is pending.
 
+#### Lamp privacy peripherals
+
+`privacy_button.json` sets `disable_camera_on_mute: true` and
+`mute_speaker_on_mute: true`. The pin 11 toggle therefore mutes the mic, stops
+camera capture and stops/suppresses speaker output (TTS, music and backchannel).
+The existing red mic-muted indicator remains the privacy indicator.
+
+While locked, camera enable/snapshot and speaker unmute return HTTP 409; camera
+streaming, realtime look, scene/wake and temporary capture starts cannot reopen
+the camera or speaker. Cached camera frames are hidden from capture consumers.
+At HAL startup the configured peripherals remain closed until GPIO synchronizes;
+a failed initial read/claim keeps privacy locked.
+
+Unlock uses the existing microphone wake/listening flow and restores camera and
+speaker to their previous states. A camera or speaker already disabled before
+locking stays disabled; an explicit manual disable during the lock is also
+preserved. The listening cue only plays when the restored speaker is unmuted.
+Preferences survive HAL restarts within the same boot, without saving the
+temporary privacy lock as a manual mute. Both options default to false for
+other devices; Intern retains its existing microphone-only fallback without JSON.
+Deploy the updated HAL before uploading JSON with these new fields.
+
 ## Gesture map
 
 | Gesture | Primary GPIO button | TTP223 touchpad |

--- a/robots/lamp/docs/vi/physical-controls_vi.md
+++ b/robots/lamp/docs/vi/physical-controls_vi.md
@@ -78,6 +78,27 @@ JSON nút chính của Lamp để fallback pin 11 cũ không trùng công tắc 
 Cấu hình mic Lamp đã deploy ngày 2026-09-11; startup xác nhận chip1/line9 ready
 và LOW ban đầu áp dụng mute. Chờ live test thao tác gạt.
 
+#### Các thiết bị được khóa bởi privacy trên Lamp
+
+`privacy_button.json` đặt `disable_camera_on_mute: true` và
+`mute_speaker_on_mute: true`. Toggle pin 11 vì vậy mute mic, dừng capture camera
+và dừng/chặn phát speaker (TTS, nhạc và backchannel). Đèn đỏ mic-muted hiện có
+tiếp tục làm đèn báo privacy.
+
+Khi khóa, camera enable/snapshot và speaker unmute trả HTTP 409; camera stream,
+realtime look, scene/wake và việc tạm bật camera để chụp không thể mở lại camera
+hay speaker. Các consumer capture không đọc được frame camera lưu đệm. Lúc HAL
+khởi động, các thiết bị đã cấu hình vẫn khóa cho tới khi đồng bộ GPIO; lỗi
+đọc/claim ban đầu thì tiếp tục giữ privacy khóa.
+
+Mở khóa dùng luồng wake/listening microphone hiện có và khôi phục camera/speaker
+về trạng thái trước đó. Camera hoặc speaker đã tắt trước khi khóa thì vẫn tắt;
+lệnh tắt thủ công trong lúc khóa cũng được giữ lại. Cue listening chỉ phát khi
+speaker khôi phục về unmute. Tùy chọn được giữ qua restart HAL trong cùng boot,
+không lưu khóa privacy tạm thời thành mute thủ công. Hai tùy chọn mặc định false
+cho device khác; Intern giữ fallback chỉ mute mic, không cần JSON.
+Cập nhật HAL trước khi upload JSON có các trường mới này.
+
 ## Bảng cử chỉ
 
 | Cử chỉ | Nút GPIO chính | Touchpad TTP223 |

--- a/robots/lamp/privacy_button.json
+++ b/robots/lamp/privacy_button.json
@@ -5,7 +5,9 @@
       "line": 9,
       "settle_s": 0.06,
       "muted_level": 0,
-      "watchdog_s": 30
+      "watchdog_s": 30,
+      "disable_camera_on_mute": true,
+      "mute_speaker_on_mute": true
     }
   }
 }


### PR DESCRIPTION
Lamp’s physical privacy switch now mutes the microphone, stops camera capture, and suppresses speaker output. Unlock restores the previous camera and speaker preferences, including manual disables made while locked.

Add device options `disable_camera_on_mute` and `mute_speaker_on_mute`, both defaulting to false. Only Lamp enables them; Intern v2 retains its microphone-only code fallback without a JSON file. Shared guards cover camera enable/snapshot/stream and realtime capture, scene/wake, and speaker playback/unmute. Startup keeps configured peripherals locked until GPIO is read; initial read/claim failure keeps them locked. English and Vietnamese docs describe the behavior.

Validation: 126 focused tests passed, including Intern fallback, startup, restoration, camera/API guards, audio consumers, and scene/wake regressions. HAL lint and git diff --check passed. No device deployment or hardware live test performed.

Deployment: update HAL before uploading the Lamp JSON containing the new fields.
