### PR TITLE
Add SCD41 CO2 component and per-sensor environment logging

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -372,6 +372,15 @@ OS commands: reboot plays its cue; shutdown plays its cue and releases servos.
 This request/reply does not generate agent events. The separate OS worker handles
 sustained changes; see [Lamp environment sensing](../robots/lamp/docs/environment-sensing.md#os-change-policy-and-agent-access).
 
+The shared snapshot can combine SEN55 and SCD41 without a new MQTT kind.
+SCD41 contributes only `sample.co2_ppm`; `components` holds independent
+status/error/timing/sample diagnostics, `sources` maps metrics to components,
+and `metric_timestamps` carries their observation times. Group `ready` means
+at least one fresh metric; `partial` indicates an enabled component is
+unavailable. Check individual sources rather than treating the group's newest
+timestamp as the age of every metric. A failed sensor does not discard healthy
+readings. Disabled/absent SCD41 does not produce an inferred CO₂ value.
+
 **`environment.status`:** send on `fa_channel`:
 
 ```json

--- a/docs/os-server.md
+++ b/docs/os-server.md
@@ -52,6 +52,11 @@ as `environment.update` to `/api/sensing/event`. Its top-level `environment`
 config is read/written through admin `GET`/`PUT /api/device/config`: evaluation
 10 seconds, sustain 60 seconds, cooldown 900 seconds, retry 60 seconds, maximum
 sample age 10 seconds by default. Metric deltas and warm-up are configurable.
+SCD41 adds measured `co2_ppm` under the same capability, with default change
+200 ppm and warm-up 60 seconds. Explicit `metrics` maps still replace the map
+and retain the configured subset. Composite snapshots include `components`,
+`sources`, and `metric_timestamps`: freshness and continuity are checked per
+metric/source, so a failed SEN55 does not suppress healthy SCD41 CO₂.
 Disabling this policy drops automatic events (`dropped_disabled`); diagnostic
 status reads and HAL acquisition remain available.
 Capability, sleep and conversation-floor gates apply; busy queues coalesce to
@@ -59,7 +64,7 @@ the latest environment event with a 60-second expiry and recheck capability,
 sleep and policy enabled at replay. Queue acceptance is best-effort, not guaranteed notification delivery.
 The `environment` skill interprets measurements and consults `wellbeing` for
 proportionate advice. Hardware acquisition and OS change policy are separate;
-this feature does not enable Lamp's commented capability or disabled SEN55.
+this feature does not enable Lamp's commented capability or disabled SEN55/SCD41.
 See [Lamp environment sensing](../robots/lamp/docs/environment-sensing.md#os-change-policy-and-agent-access)
 for defaults, validation, payloads and use cases.
 

--- a/docs/vi/mqtt_vi.md
+++ b/docs/vi/mqtt_vi.md
@@ -362,6 +362,14 @@ cue và release servo.
 Request/reply này không tạo event cho agent. Worker OS riêng xử lý thay đổi
 kéo dài; xem [cảm biến môi trường Lamp](../../robots/lamp/docs/vi/environment-sensing_vi.md#chính-sách-thay-đổi-của-os-và-api-cho-agent).
 
+Snapshot chung có thể kết hợp SEN55 và SCD41 mà không thêm MQTT kind. SCD41
+chỉ đóng góp `sample.co2_ppm`; `components` giữ status/lỗi/timing/sample riêng,
+`sources` ánh xạ chỉ số đến component, `metric_timestamps` chứa thời điểm đo
+của từng chỉ số. Nhóm `ready` nghĩa là ít nhất một số đo còn mới; `partial`
+báo component đang bật nhưng không khả dụng. Kiểm tra từng nguồn, không dùng
+timestamp mới nhất của nhóm làm tuổi mọi chỉ số. Một sensor lỗi không loại
+số đo còn tốt. SCD41 tắt/thiếu không tạo CO₂ suy diễn.
+
 **`environment.status`:** gửi trên `fa_channel`:
 
 ```json

--- a/docs/vi/os-server_vi.md
+++ b/docs/vi/os-server_vi.md
@@ -50,7 +50,12 @@ Worker môi trường của OS đọc HAL độc lập và POST thay đổi kéo
 `environment.update` tới `/api/sensing/event`. Config `environment` cấp cao
 nhất đọc/ghi qua admin `GET`/`PUT /api/device/config`: mặc định đánh giá mỗi
 10 giây, duy trì 60 giây, cooldown 900 giây, retry 60 giây, tuổi mẫu tối đa
-10 giây. Delta và warm-up từng chỉ số cấu hình được. Tắt policy sẽ bỏ event
+10 giây. Delta và warm-up từng chỉ số cấu hình được. SCD41 thêm `co2_ppm` đo
+thật vào cùng capability, mặc định thay đổi 200 ppm và warm-up 60 giây. Map
+`metrics` khai báo tường minh vẫn thay toàn bộ map, giữ nguyên nhóm đã chọn.
+Snapshot tổng hợp có `components`, `sources`, `metric_timestamps`: kiểm tra
+độ mới/tính liên tục theo chỉ số và nguồn, nên SEN55 lỗi không chặn CO₂ SCD41
+còn tốt. Tắt policy sẽ bỏ event
 tự động (`dropped_disabled`); vẫn đọc được status chẩn đoán và HAL vẫn thu nhận.
 Áp dụng gate capability,
 sleep và conversation floor; queue lúc bận chỉ giữ event môi trường mới nhất,
@@ -58,7 +63,7 @@ hết hạn sau 60 giây, kiểm tra lại capability, sleep và policy enabled 
 lại. Nhận vào queue
 là best-effort, không bảo đảm giao thông báo. Skill `environment` diễn giải
 số đo và tham khảo `wellbeing` để gợi ý phù hợp. Thu nhận phần cứng tách biệt
-chính sách thay đổi ở OS; tính năng không bật capability đang comment hay SEN55
+chính sách thay đổi ở OS; tính năng không bật capability đang comment hay SEN55/SCD41
 đang tắt của Lamp. Xem [cảm biến môi trường Lamp](../../robots/lamp/docs/vi/environment-sensing_vi.md#chính-sách-thay-đổi-của-os-và-api-cho-agent)
 để biết mặc định, validation, payload và use case.
 

--- a/docs/vi/web-ui_vi.md
+++ b/docs/vi/web-ui_vi.md
@@ -706,7 +706,7 @@ Chat UI → POST /api/sensing/event → SensingHandler
 
 Mục Sensing khả dụng không cần bật debug khi device khai báo
 `vision` hoặc `environment` trong `GET /api/system/info` → `capabilities`.
-Các card sensing camera yêu cầu `vision`. Card chỉ đọc **Environment · SEN55**
+Các card sensing camera yêu cầu `vision`. Card chỉ đọc **Environment**
 yêu cầu khai báo rõ capability `environment`; card bị ẩn và không gửi request
 khi đang tải capabilities hoặc không có capability này.
 
@@ -719,16 +719,19 @@ và API status cho agent local được mô tả trong
 [tài liệu môi trường Lamp](../../robots/lamp/docs/vi/environment-sensing_vi.md#chính-sách-thay-đổi-của-os-và-api-cho-agent).
 
 Card hiển thị trạng thái cảm biến, thời điểm sample, trạng thái dữ liệu
-cũ, lỗi và tám số đo: nhiệt độ (°C), độ ẩm (%), PM1 / PM2.5 / PM4 / PM10
-(µg/m³), VOC index, NOx index. Giá trị chưa khả dụng hiện `—`, không hiện số 0.
+cũ, lỗi và số đo theo component được khai báo: nhiệt độ (°C), độ ẩm (%),
+PM1 / PM2.5 / PM4 / PM10 (µg/m³), VOC index, NOx index và CO₂ SCD41 (ppm).
+Nhãn nguồn chỉ rõ component; từng chỉ số có timestamp riêng. Component lỗi
+không che số đo còn tốt từ component khác. Giá trị chưa khả dụng hiện `—`, không hiện số 0.
 Số đo cũ cũng được thay bằng `—`; request thất bại được hiển thị là lỗi để
 không nhầm số đo trước đó với dữ liệu hiện tại. Không gán nhãn chất lượng không khí
-tốt/xấu, ngưỡng hay cảnh báo. Mục kỹ thuật thu gọn mặc định hiển thị bus I2C,
-thanh ghi trạng thái cảm biến và các mốc thời gian đọc/thử lại/đánh dấu cũ/
-phục hồi của HAL từ `status.timing`.
+tốt/xấu, ngưỡng hay cảnh báo. Mục kỹ thuật thu gọn hiển thị trạng thái, bus I2C,
+thanh ghi trạng thái và timing đọc/thử lại/đánh dấu cũ/phục hồi của từng
+component trong `status.components`. Vẫn hỗ trợ snapshot một sensor kiểu cũ
+với `status.timing` cấp cao nhất.
 
-Lamp vẫn để `environment` được comment trong `ROBOT.md` và SEN55 tắt trong
-`sen55.json`, nên card này ẩn cho đến khi capability được khai báo. Xem
+Lamp vẫn để `environment` được comment trong `ROBOT.md` và SEN55/SCD41 tắt trong
+file JSON tương ứng, nên card này ẩn cho đến khi capability được khai báo. Xem
 [tài liệu cảm biến môi trường của Lamp](../../robots/lamp/docs/vi/environment-sensing_vi.md)
 về đấu dây, bật cảm biến và contract dữ liệu HAL.
 
@@ -832,7 +835,7 @@ Kết quả cuối Harness được ghi vào flow JSONL bằng `harness_response
 `monitor/SensingSection.tsx` chỉ ghép các phần theo capability. Component nằm
 trong `monitor/sensing/`: mỗi card một file, dùng chung `CardHeader`, types và
 hàm định dạng. `useVisionSensing` poll một lần cho toàn bộ card vision;
-`useEnvironment` poll SEN55 độc lập. Client `visionApi.ts` và
+`useEnvironment` poll snapshot môi trường chung độc lập. Client `visionApi.ts` và
 `environmentApi.ts` quản lý request OS-server, kiểm tra response và lỗi;
 card không trực tiếp fetch. Cả hai dùng reverse proxy có xác thực
 `/api/hardware/*` sẵn có. Lỗi HTTP/response của vision hiển thị thông báo lỗi,

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -723,7 +723,7 @@ Chat UI → POST /api/sensing/event → SensingHandler
 
 The Sensing navigation entry is available without debug mode when the device declares `vision` or `environment` in
 `GET /api/system/info` → `capabilities`. Camera sensing cards require `vision`.
-The read-only **Environment · SEN55** card requires an explicit `environment`
+The read-only **Environment** card requires an explicit `environment`
 capability; it is hidden and sends no requests while capabilities are loading
 or when that capability is absent.
 
@@ -736,16 +736,19 @@ and local agent status API are described in
 [Lamp environmental sensing](../robots/lamp/docs/environment-sensing.md#os-change-policy-and-agent-access).
 
 The card shows sensor state, sample timestamp, stale status, errors,
-and eight measurements: temperature (°C), humidity (%), PM1 / PM2.5 / PM4 /
-PM10 (µg/m³), VOC index, and NOx index. Unavailable values appear as `—`, never
+and component-dependent measurements: temperature (°C), humidity (%), PM1 /
+PM2.5 / PM4 / PM10 (µg/m³), VOC index, NOx index, and SCD41 CO₂ (ppm).
+Source labels identify the component; each metric has its own timestamp.
+Unavailable components do not hide healthy readings from another component. Unavailable values appear as `—`, never
 zero. Stale measurements are also replaced with `—`; a request failure is shown
 as an error so previous readings cannot be mistaken for live data. No good/bad air
 quality labels, thresholds, or alerts are assigned. A collapsed technical
-section exposes I2C bus, sensor status register, and HAL polling/retry/staleness/
-recovery timings from `status.timing`.
+section exposes each component's state, I2C bus, sensor status register, and HAL
+polling/retry/staleness/recovery timings under `status.components`. Legacy
+single-sensor snapshots with top-level `status.timing` remain supported.
 
-Lamp still ships with `environment` commented out in `ROBOT.md` and SEN55
-disabled in `sen55.json`, so this card remains hidden until the capability is
+Lamp still ships with `environment` commented out in `ROBOT.md` and SEN55/SCD41
+disabled in their respective JSON configurations, so this card remains hidden until the capability is
 declared. See [Lamp environmental sensing](../robots/lamp/docs/environment-sensing.md)
 for wiring, enabling, and the HAL data contract.
 
@@ -848,7 +851,7 @@ Harness final delivery records `harness_response` in flow JSONL with the origina
 `monitor/SensingSection.tsx` only composes capability-gated sections. Components
 live under `monitor/sensing/`: one file per card, with shared `CardHeader`, types
 and formatters. `useVisionSensing` polls once for all vision cards;
-`useEnvironment` independently polls SEN55. The `visionApi.ts` and
+`useEnvironment` independently polls the shared environment snapshot. The `visionApi.ts` and
 `environmentApi.ts` clients own OS-server requests, response checks and errors;
 cards do not fetch directly. Both clients use the existing authenticated
 `/api/hardware/*` proxy. Vision HTTP/response failures show an error instead of

--- a/hal/board/environment.py
+++ b/hal/board/environment.py
@@ -1,0 +1,30 @@
+"""Device-owned component selection for the shared environment capability."""
+
+import json
+from pathlib import Path
+
+SUPPORTED_COMPONENTS = ("sen55", "scd41")
+
+
+def load_environment_components(device_dir: str) -> tuple[str, ...]:
+    """Older profiles without a component list retain their SEN55 backend."""
+    path = Path(device_dir) / "environment.json"
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        return ("sen55",)
+    try:
+        data = json.loads(text)
+        if not isinstance(data, dict) or set(data) != {"components"}:
+            raise ValueError("expected an object containing components")
+        components = data["components"]
+        if not isinstance(components, list) or any(
+            not isinstance(name, str) or name not in SUPPORTED_COMPONENTS
+            for name in components
+        ):
+            raise ValueError(f"components must be a list drawn from {SUPPORTED_COMPONENTS}")
+        if len(set(components)) != len(components):
+            raise ValueError("duplicate environment components")
+        return tuple(components)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid environment components at {path}: {exc}") from exc

--- a/hal/board/scd41.py
+++ b/hal/board/scd41.py
@@ -1,0 +1,68 @@
+"""Device-owned SCD41 wiring and acquisition options."""
+
+import json
+from dataclasses import dataclass, fields
+from pathlib import Path
+
+from hal.board.sen55 import SEN55Timing, validate_header_pins
+
+
+@dataclass(frozen=True)
+class SCD41Timing(SEN55Timing):
+    poll_interval_s: float = 5.0
+    stale_after_s: float = 15.0
+
+
+@dataclass(frozen=True)
+class SCD41Config:
+    bus: int
+    timing: SCD41Timing = SCD41Timing()
+    sda_pin: int | None = None
+    scl_pin: int | None = None
+    automatic_self_calibration: bool | None = None
+
+    def __post_init__(self):
+        validate_header_pins(self.sda_pin, self.scl_pin)
+        if type(self.bus) is not int or self.bus < 0:
+            raise ValueError("bus must be a nonnegative integer")
+        validate_calibration(self.automatic_self_calibration)
+
+
+def validate_calibration(value):
+    if value is not None and type(value) is not bool:
+        raise ValueError("automatic_self_calibration must be a boolean or null")
+
+
+def load_scd41_config(device_dir: str, board_id: str) -> SCD41Config | None:
+    """Validate all board entries, including disabled hardware declarations."""
+    path = Path(device_dir) / "scd41.json"
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        return None
+    try:
+        data = json.loads(text)
+        if not isinstance(data, dict) or set(data) != {"boards"} or not isinstance(data["boards"], dict):
+            raise ValueError("expected an object containing a 'boards' map")
+        configs = {}
+        allowed = {"enabled", "bus", "sda_pin", "scl_pin", "automatic_self_calibration"} | {f.name for f in fields(SCD41Timing)}
+        for board, entry in data["boards"].items():
+            if not isinstance(entry, dict) or set(entry) - allowed:
+                raise ValueError(f"{board}: invalid SCD41 configuration fields")
+            enabled = entry.get("enabled", True)
+            if type(enabled) is not bool:
+                raise ValueError(f"{board}: enabled must be a boolean")
+            timing = SCD41Timing(**{
+                f.name: entry[f.name] for f in fields(SCD41Timing) if f.name in entry
+            })
+            sda_pin, scl_pin = entry.get("sda_pin"), entry.get("scl_pin")
+            validate_header_pins(sda_pin, scl_pin)
+            calibration = entry.get("automatic_self_calibration")
+            validate_calibration(calibration)
+            config = SCD41Config(entry["bus"], timing, sda_pin, scl_pin, calibration) if entry.get("bus") is not None else None
+            if enabled and config is None:
+                raise ValueError(f"{board}: enabled SCD41 requires bus")
+            configs[board] = config if enabled else None
+        return configs.get(board_id)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid SCD41 wiring at {path}: {exc}") from exc

--- a/hal/drivers/environment/group.py
+++ b/hal/drivers/environment/group.py
@@ -1,0 +1,125 @@
+"""Compose independent sensor workers into one environmental snapshot."""
+
+import math
+from functools import partial
+
+from hal.board.environment import load_environment_components
+from hal.board.sen55 import load_sen55_config, SEN55Timing
+from hal.board.scd41 import load_scd41_config, SCD41Timing
+from hal.drivers.environment.sen55 import SEN55, FIELDS as SEN55_FIELDS
+from hal.drivers.environment.scd41 import SCD41
+from hal.drivers.environment.service import EnvironmentService
+
+
+# A component owns each public measurement; adding a sensor cannot silently
+# overwrite another sensor's temperature/humidity or change their provenance.
+COMPONENT_FIELDS = {"sen55": SEN55_FIELDS, "scd41": ("co2_ppm",)}
+
+
+def create_environment_group(device_dir, board_id, simulation=False):
+    registry = {
+        "sen55": (load_sen55_config, SEN55, SEN55Timing),
+        "scd41": (load_scd41_config, SCD41, SCD41Timing),
+    }
+    workers = {}
+    for name in load_environment_components(device_dir):
+        loader, driver, timing = registry[name]
+        cfg = None if simulation else loader(device_dir, board_id)
+        factory = driver
+        if name == "scd41" and cfg is not None:
+            factory = partial(driver, automatic_self_calibration=cfg.automatic_self_calibration)
+        workers[name] = EnvironmentService(
+            enabled=cfg is not None,
+            bus=cfg.bus if cfg else None,
+            timing=cfg.timing if cfg else timing(),
+            driver_factory=factory,
+            name=name,
+        )
+    return EnvironmentGroup(workers)
+
+
+def _finite(value):
+    return type(value) in (int, float) and math.isfinite(value)
+
+
+class EnvironmentGroup:
+    def __init__(self, components):
+        self.components = dict(components)
+
+    def start(self):
+        for worker in self.components.values():
+            worker.start()
+
+    def stop(self):
+        for worker in self.components.values():
+            worker.stop()
+
+    def snapshot(self):
+        components = {name: worker.snapshot() for name, worker in self.components.items()}
+        sample, sources, timestamps = {}, {}, {}
+        ages, errors, active = [], [], []
+        unavailable = False
+        for name, component in components.items():
+            fields = COMPONENT_FIELDS[name]
+            for field in fields:
+                sample[field] = None
+                sources[field] = name
+            if not component["enabled"]:
+                continue
+            active.append(component)
+            values = component.get("sample") or {}
+            stamp, age = values.get("timestamp"), component.get("age_s")
+            status = values.get("device_status")
+            valid = (
+                component["state"] == "ready" and not component["stale"]
+                and _finite(stamp) and stamp > 0
+                and _finite(age) and age >= 0
+                and (status is None or status == 0)
+            )
+            if component.get("last_error"):
+                errors.append(f"{name}: {component['last_error']}")
+            elif status is not None and status != 0:
+                errors.append(f"{name}: sensor status reports a fault ({status})")
+            added = False
+            if valid:
+                for field in fields:
+                    value = values.get(field)
+                    if _finite(value):
+                        sample[field] = value
+                        timestamps[field] = stamp
+                        added = True
+                if added:
+                    ages.append(age)
+            if not added:
+                unavailable = True
+
+        ready = bool(timestamps)
+        if ready:
+            sample["timestamp"] = max(timestamps.values())
+            state = "ready"
+        elif not active:
+            state = "disabled"
+        elif errors or any(c["state"] == "error" for c in active):
+            state = "error"
+        elif all(c["state"] == "stopped" for c in active):
+            state = "stopped"
+        else:
+            state = "starting"
+        result = {
+            "state": state, "enabled": bool(active), "stale": not ready,
+            "partial": ready and unavailable,
+            "last_error": "; ".join(errors) or None,
+            "sample": sample if ready else None,
+            "age_s": min(ages) if ages else None,
+            "components": components,
+            "sources": sources,
+            "metric_timestamps": timestamps,
+        }
+        # Keep single-component acquisition diagnostics convenient for legacy
+        # clients. Multi-component timings/buses live under components only.
+        if len(components) == 1:
+            only = next(iter(components.values()))
+            result.update(bus=only["bus"], timing=only["timing"])
+            if ready and "sen55" in components and "device_status" in only["sample"]:
+                sample["device_status"] = only["sample"]["device_status"]
+        return result

--- a/hal/drivers/environment/i2c.py
+++ b/hal/drivers/environment/i2c.py
@@ -1,0 +1,22 @@
+"""Sensirion word CRC framing shared by environmental I2C drivers."""
+
+
+def crc8(data: bytes) -> int:
+    crc = 0xFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = ((crc << 1) ^ (0x31 if crc & 0x80 else 0)) & 0xFF
+    return crc
+
+
+def decode_words(data: bytes, count: int, sensor: str = "SEN55") -> list[int]:
+    if len(data) != count * 3:
+        raise OSError(f"{sensor}: incomplete I2C response")
+    words = []
+    for offset in range(0, len(data), 3):
+        pair = data[offset:offset + 2]
+        if crc8(pair) != data[offset + 2]:
+            raise OSError(f"{sensor}: CRC mismatch")
+        words.append(int.from_bytes(pair, "big"))
+    return words

--- a/hal/drivers/environment/scd41.py
+++ b/hal/drivers/environment/scd41.py
@@ -1,0 +1,57 @@
+"""SCD41 periodic CO2 acquisition (Sensirion SCD4x datasheet section 3)."""
+
+import os
+import time
+
+from hal.drivers.environment.i2c import crc8, decode_words
+
+
+class SCD41:
+    """Single-worker Linux I2C driver; calibration is preserved unless configured."""
+
+    def __init__(self, bus: int, *, automatic_self_calibration: bool | None = None):
+        import fcntl
+
+        if automatic_self_calibration is not None and type(automatic_self_calibration) is not bool:
+            raise ValueError("automatic_self_calibration must be a boolean or null")
+        self._automatic_self_calibration = automatic_self_calibration
+        self._fd = os.open(f"/dev/i2c-{bus}", os.O_RDWR)
+        try:
+            fcntl.ioctl(self._fd, 0x0703, 0x62)  # I2C_SLAVE, not FORCE.
+        except BaseException:
+            os.close(self._fd)
+            raise
+
+    def _command(self, command: int, count: int = 0, delay: float = 0.001, word=None):
+        payload = command.to_bytes(2, "big")
+        if word is not None:
+            pair = word.to_bytes(2, "big")
+            payload += pair + bytes([crc8(pair)])
+        if os.write(self._fd, payload) != len(payload):
+            raise OSError("SCD41: incomplete I2C command")
+        time.sleep(delay)
+        if count:
+            return decode_words(os.read(self._fd, count * 3), count, "SCD41")
+        return []
+
+    def start(self):
+        # Recover a sensor left measuring after an unclean HAL shutdown.
+        self._command(0x3F86, delay=0.5)
+        if self._automatic_self_calibration is not None:
+            self._command(0x2416, word=int(self._automatic_self_calibration))
+        self._command(0x21B1)
+
+    def read(self):
+        if not self._command(0xE4B8, 1)[0] & 0x07FF:
+            return None
+        # Validate all three wire words, but publish only this component's CO2.
+        co2, _, _ = self._command(0xEC05, 3)
+        if co2 == 0:
+            return None
+        return {"timestamp": time.time(), "co2_ppm": co2}
+
+    def close(self):
+        try:
+            self._command(0x3F86, delay=0.5)
+        finally:
+            os.close(self._fd)

--- a/hal/drivers/environment/sen55.py
+++ b/hal/drivers/environment/sen55.py
@@ -3,32 +3,13 @@
 import os
 import time
 
+from hal.drivers.environment.i2c import crc8, decode_words
+
 
 FIELDS = (
     "pm1_0_ug_m3", "pm2_5_ug_m3", "pm4_0_ug_m3", "pm10_ug_m3",
     "humidity_pct", "temperature_c", "voc_index", "nox_index",
 )
-
-
-def crc8(data: bytes) -> int:
-    crc = 0xFF
-    for byte in data:
-        crc ^= byte
-        for _ in range(8):
-            crc = ((crc << 1) ^ (0x31 if crc & 0x80 else 0)) & 0xFF
-    return crc
-
-
-def decode_words(data: bytes, count: int) -> list[int]:
-    if len(data) != count * 3:
-        raise OSError("SEN55: incomplete I2C response")
-    words = []
-    for offset in range(0, len(data), 3):
-        pair = data[offset:offset + 2]
-        if crc8(pair) != data[offset + 2]:
-            raise OSError("SEN55: CRC mismatch")
-        words.append(int.from_bytes(pair, "big"))
-    return words
 
 
 class SEN55:

--- a/hal/drivers/environment/service.py
+++ b/hal/drivers/environment/service.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 class EnvironmentService:
-    def __init__(self, enabled=False, bus=None, driver_factory=SEN55, timing=None):
+    def __init__(self, enabled=False, bus=None, driver_factory=SEN55, timing=None, name="sen55"):
+        self.name = name
         self.timing = timing if timing is not None else SEN55Timing()
         self.enabled = enabled
         self.bus = bus
@@ -30,14 +31,19 @@ class EnvironmentService:
             self._state, self._error = state, error
 
     def start(self):
-        if not self.enabled or self._thread is not None:
+        if self._thread is not None:
+            return
+        if not self.enabled:
+            logger.info("[%s] disabled", self.name)
             return
         if self.bus is None or not str(self.bus).isascii() or not str(self.bus).isdecimal():
-            self._set_state("error", "SEN55 bus must be a nonnegative bus number")
+            self._set_state("error", f"{self.name} bus must be a nonnegative bus number")
+            logger.error("[%s] cannot start: invalid I2C bus %r", self.name, self.bus)
             return
         self.bus = int(self.bus)
         self._set_state("starting")
-        self._thread = threading.Thread(target=self._run, name="sen55", daemon=True)
+        logger.info("[%s] starting: bus=%s poll_interval_s=%s", self.name, self.bus, self.timing.poll_interval_s)
+        self._thread = threading.Thread(target=self._run, name=self.name, daemon=True)
         self._thread.start()
 
     def _run(self):
@@ -46,37 +52,47 @@ class EnvironmentService:
             try:
                 driver = self._factory(int(self.bus))
                 driver.start()
+                logger.info("[%s] measurement started: bus=%s", self.name, self.bus)
                 self._set_state("starting")
                 last_data = time.monotonic()
+                received = False
                 while not self._stop.wait(self.timing.poll_interval_s):
                     sample = driver.read()
+                    if sample is None:
+                        logger.info("[%s] waiting for data: bus=%s last_data_age_s=%.3f", self.name, self.bus, time.monotonic() - last_data)
                     if sample is None and time.monotonic() - last_data > self.timing.no_data_timeout_s:
-                        raise OSError(f"SEN55: no new data for {self.timing.no_data_timeout_s:g} seconds")
+                        raise OSError(f"{self.name}: no new data for {self.timing.no_data_timeout_s:g} seconds")
                     if sample is not None:
                         last_data = time.monotonic()
                         with self._lock:
                             self._sample = sample
                             self._sample_time = time.monotonic()
                             self._state, self._error = "ready", None
+                        if not received:
+                            logger.info("[%s] receiving data: fields=%s", self.name, ",".join(sample))
+                            received = True
+                        logger.info("[%s] sample=%s", self.name, sample)
             except Exception as exc:
                 self._set_state("error", str(exc))
-                logger.warning("SEN55 acquisition failed: %s", exc)
+                logger.warning("[%s] acquisition failed: %s; retry_interval_s=%s", self.name, exc, self.timing.retry_interval_s)
             finally:
                 if driver is not None:
                     try:
                         driver.close()
                     except Exception as exc:
-                        logger.warning("SEN55 close failed: %s", exc)
+                        logger.warning("[%s] close failed: %s", self.name, exc)
             if self._stop.wait(self.timing.retry_interval_s):
                 break
         self._set_state("stopped")
+        logger.info("[%s] stopped", self.name)
 
     def stop(self):
         self._stop.set()
         if self._thread is not None:
             self._thread.join(timeout=3.0)
             if self._thread.is_alive():
-                self._set_state("error", "SEN55 worker did not stop within 3 seconds")
+                self._set_state("error", f"{self.name} worker did not stop within 3 seconds")
+                logger.error("[%s] worker did not stop within 3 seconds", self.name)
                 return
         if self.enabled:
             self._set_state("stopped")

--- a/hal/server.py
+++ b/hal/server.py
@@ -1025,13 +1025,7 @@ async def lifespan(app: FastAPI):
         )
 
     if "environment" in _plan.mounted:
-        from hal.drivers.environment.service import EnvironmentService
-
-        state.environment_service = EnvironmentService(
-            enabled=_sen55_config is not None,
-            bus=_sen55_config.bus if _sen55_config is not None else None,
-            timing=_sen55_config.timing if _sen55_config is not None else None,
-        )
+        state.environment_service = _environment_group
         state.environment_service.start()
 
     yield
@@ -1349,12 +1343,14 @@ _mpr121_config = (
     None if _board_id == "sim" else load_mpr121_config(_device_dir, _board_id)
 )
 
-from hal.board.sen55 import load_sen55_config
+_environment_group = None
+if "environment" in _declared:
+    from hal.drivers.environment.group import create_environment_group
 
-_sen55_config = (
-    None if _simulation or "environment" not in _declared
-    else load_sen55_config(_device_dir, _board_id)
-)
+    _environment_group = create_environment_group(_device_dir, _board_id, _simulation)
+    logger.info("[environment] components=%s simulation=%s", list(_environment_group.components), _simulation)
+else:
+    logger.info("[environment] capability not declared; acquisition disabled")
 
 from hal.board.ttp223 import load_touch_config
 

--- a/hal/test/test_environment_group.py
+++ b/hal/test/test_environment_group.py
@@ -1,0 +1,151 @@
+"""Multiple environmental components retain independent freshness and faults."""
+
+import json
+import logging
+import time
+from dataclasses import asdict
+from unittest.mock import Mock
+
+import pytest
+
+from hal.board.environment import load_environment_components
+from hal.board.sen55 import SEN55Timing
+from hal.drivers.environment.group import EnvironmentGroup, create_environment_group
+from hal.drivers.environment.service import EnvironmentService
+
+
+def component(sample=None, *, enabled=True, stale=False, state="ready", error=None, age=1):
+    worker = Mock()
+    worker.snapshot.return_value = {
+        "enabled": enabled, "state": state, "stale": stale, "sample": sample,
+        "last_error": error, "age_s": age, "bus": 1, "timing": asdict(SEN55Timing()),
+    }
+    return worker
+
+
+def test_group_keeps_independent_data_and_provenance():
+    sen = component({"timestamp": 100, "temperature_c": 25, "pm2_5_ug_m3": 10, "device_status": 0})
+    scd = component({"timestamp": 98, "co2_ppm": 800, "temperature_c": 99}, age=3)
+    snap = EnvironmentGroup({"sen55": sen, "scd41": scd}).snapshot()
+    assert snap["state"] == "ready" and not snap["stale"]
+    assert snap["sample"]["temperature_c"] == 25
+    assert snap["sample"]["co2_ppm"] == 800
+    assert snap["sources"]["co2_ppm"] == "scd41"
+    assert snap["metric_timestamps"] == {"temperature_c": 100, "pm2_5_ug_m3": 100, "co2_ppm": 98}
+    assert snap["sample"]["timestamp"] == 100
+    assert "device_status" not in snap["sample"]
+    assert "bus" not in snap and "timing" not in snap
+
+
+@pytest.mark.parametrize("fault", ["stale", "error", "status", "missing", "timestamp"])
+def test_failed_sen55_does_not_remove_co2(fault):
+    sen = component({"timestamp": 100, "pm2_5_ug_m3": 10, "device_status": 0})
+    status = sen.snapshot.return_value
+    if fault == "stale":
+        status["stale"] = True
+    elif fault == "error":
+        status.update(state="error", last_error="I2C read failed")
+    elif fault == "status":
+        status["sample"]["device_status"] = 1
+    elif fault == "missing":
+        status["sample"] = None
+    else:
+        status["sample"]["timestamp"] = float("nan")
+    scd = component({"timestamp": 99, "co2_ppm": 900})
+    snap = EnvironmentGroup({"sen55": sen, "scd41": scd}).snapshot()
+    assert snap["partial"] and not snap["stale"]
+    assert snap["sample"]["pm2_5_ug_m3"] is None
+    assert snap["sample"]["co2_ppm"] == 900
+    assert "pm2_5_ug_m3" not in snap["metric_timestamps"]
+
+
+def test_failed_scd41_does_not_remove_sen55():
+    sen = component({"timestamp": 100, "pm2_5_ug_m3": 10})
+    scd = component({"timestamp": 90, "co2_ppm": 900}, state="error", error="unplugged")
+    snap = EnvironmentGroup({"sen55": sen, "scd41": scd}).snapshot()
+    assert snap["sample"]["pm2_5_ug_m3"] == 10
+    assert snap["sample"]["co2_ppm"] is None
+    assert snap["last_error"] == "scd41: unplugged"
+
+
+def test_single_sen55_retains_legacy_diagnostics():
+    sen = component({"timestamp": 100, "pm2_5_ug_m3": 10, "device_status": 0})
+    snap = EnvironmentGroup({"sen55": sen}).snapshot()
+    assert snap["bus"] == 1 and snap["timing"]["poll_interval_s"] == 1
+    assert snap["sample"]["device_status"] == 0
+
+
+def test_scd41_only_and_group_lifecycle():
+    scd = component({"timestamp": 100, "co2_ppm": 600, "humidity_pct": 70})
+    group = EnvironmentGroup({"scd41": scd})
+    group.start()
+    group.stop()
+    scd.start.assert_called_once()
+    scd.stop.assert_called_once()
+    snap = group.snapshot()
+    assert snap["sample"] == {"timestamp": 100, "co2_ppm": 600}
+    assert snap["bus"] == 1
+
+
+def test_all_disabled_or_stale():
+    assert EnvironmentGroup({}).snapshot()["state"] == "disabled"
+    disabled = component(enabled=False, state="disabled")
+    snap = EnvironmentGroup({"scd41": disabled}).snapshot()
+    assert snap["state"] == "disabled" and snap["sample"] is None
+    stale = component({"timestamp": 50, "co2_ppm": 900}, stale=True)
+    snap = EnvironmentGroup({"scd41": stale}).snapshot()
+    assert snap["stale"] and snap["sample"] is None
+
+
+def test_component_configuration_and_simulation(tmp_path):
+    assert load_environment_components(str(tmp_path)) == ("sen55",)
+    (tmp_path / "environment.json").write_text('{"components":["scd41"]}')
+    (tmp_path / "scd41.json").write_text('{"boards":{"test":{"bus":2,"automatic_self_calibration":false}}}')
+    group = create_environment_group(str(tmp_path), "test")
+    worker = group.components["scd41"]
+    assert worker.enabled and worker.bus == 2 and worker.timing.poll_interval_s == 5
+    assert worker._factory.keywords == {"automatic_self_calibration": False}
+    sim = create_environment_group(str(tmp_path), "test", simulation=True)
+    assert sim.snapshot()["state"] == "disabled"
+
+
+@pytest.mark.parametrize("value", [[], {}, {"components": None}, {"components": "scd41"},
+    {"components": ["unknown"]}, {"components": [True]}, {"components": ["sen55", "sen55"]},
+    {"components": [], "extra": 1}])
+def test_invalid_components_rejected(tmp_path, value):
+    (tmp_path / "environment.json").write_text(json.dumps(value))
+    with pytest.raises(ValueError, match="Invalid environment components"):
+        load_environment_components(str(tmp_path))
+
+
+def test_component_logs_have_stable_sensor_keys(caplog):
+    caplog.set_level(logging.INFO, logger="hal.drivers.environment.service")
+    EnvironmentService(name="scd41").start()
+    assert "[scd41] disabled" in caplog.text
+    driver = Mock()
+    driver.read.return_value = {"timestamp": 100, "co2_ppm": 700}
+    timing = SEN55Timing(poll_interval_s=0.01)
+    service = EnvironmentService(True, 1, lambda _: driver, timing, name="scd41")
+    service.start()
+    deadline = time.monotonic() + 1
+    while "[scd41] sample=" not in caplog.text and time.monotonic() < deadline:
+        time.sleep(0.01)
+    service.stop()
+    assert "[scd41] starting:" in caplog.text
+    assert "[scd41] receiving data:" in caplog.text
+    assert "[scd41] sample=" in caplog.text
+    assert "[scd41] stopped" in caplog.text
+
+
+def test_waiting_and_retry_logs_are_visible_at_info(caplog):
+    caplog.set_level(logging.INFO, logger="hal.drivers.environment.service")
+    driver = Mock()
+    driver.read.side_effect = [None, OSError("CRC mismatch")]
+    service = EnvironmentService(True, 1, lambda _: driver, SEN55Timing(poll_interval_s=0.01), name="sen55")
+    service.start()
+    deadline = time.monotonic() + 1
+    while "[sen55] acquisition failed:" not in caplog.text and time.monotonic() < deadline:
+        time.sleep(0.01)
+    service.stop()
+    assert "[sen55] waiting for data:" in caplog.text
+    assert "[sen55] acquisition failed: CRC mismatch; retry_interval_s=5" in caplog.text

--- a/hal/test/test_scd41.py
+++ b/hal/test/test_scd41.py
@@ -1,0 +1,128 @@
+"""Hardware-independent SCD41 protocol and device configuration checks."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from hal.board.scd41 import SCD41Timing, load_scd41_config
+from hal.drivers.environment.i2c import crc8
+from hal.drivers.environment.scd41 import SCD41
+
+
+def packet(*words):
+    return b"".join(w.to_bytes(2, "big") + bytes([crc8(w.to_bytes(2, "big"))]) for w in words)
+
+
+@pytest.fixture
+def driver():
+    with patch("os.open", return_value=7), patch("fcntl.ioctl") as ioctl:
+        sensor = SCD41(2)
+        ioctl.assert_called_once_with(7, 0x0703, 0x62)
+    return sensor
+
+
+def test_constructor_releases_fd_on_ioctl_failure():
+    with patch("os.open", return_value=7), patch("fcntl.ioctl", side_effect=OSError("missing")), patch("os.close") as close:
+        with pytest.raises(OSError, match="missing"):
+            SCD41(2)
+        close.assert_called_once_with(7)
+
+
+def test_periodic_start_and_stop_preserve_calibration(driver):
+    with patch("os.write", side_effect=lambda fd, data: len(data)) as write, patch("time.sleep") as sleep, patch("os.close") as close:
+        driver.start()
+        driver.close()
+    assert [call.args[1] for call in write.call_args_list] == [b"\x3f\x86", b"\x21\xb1", b"\x3f\x86"]
+    assert [call.args[0] for call in sleep.call_args_list] == [0.5, 0.001, 0.5]
+    close.assert_called_once_with(7)
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_explicit_asc_setting_has_crc_and_precedes_start(driver, enabled):
+    driver._automatic_self_calibration = enabled
+    with patch("os.write", side_effect=lambda fd, data: len(data)) as write, patch("time.sleep"):
+        driver.start()
+    assert [call.args[1] for call in write.call_args_list] == [
+        b"\x3f\x86", b"\x24\x16" + packet(int(enabled)), b"\x21\xb1",
+    ]
+
+
+def test_reads_co2_only_after_ready_with_all_words_crc_checked(driver):
+    with patch("os.write", return_value=2) as write, patch("os.read", side_effect=[packet(0x8001), packet(825, 26000, 31000)]), patch("time.sleep"), patch("time.time", return_value=123):
+        assert driver.read() == {"timestamp": 123, "co2_ppm": 825}
+    assert [call.args[1] for call in write.call_args_list] == [b"\xe4\xb8", b"\xec\x05"]
+
+
+def test_ready_ignores_upper_five_bits(driver):
+    with patch.object(driver, "_command", return_value=[0xF800]) as command:
+        assert driver.read() is None
+        command.assert_called_once_with(0xE4B8, 1)
+
+
+def test_zero_co2_is_not_a_sample(driver):
+    with patch.object(driver, "_command", side_effect=[[1], [0, 123, 456]]):
+        assert driver.read() is None
+
+
+@pytest.mark.parametrize("payload", [b"", packet(800, 25000, 30000)[:-1] + b"\x00"])
+def test_rejects_short_or_corrupt_unused_humidity_word(driver, payload):
+    with patch("os.write", return_value=2), patch("os.read", side_effect=[packet(1), payload]), patch("time.sleep"):
+        with pytest.raises(OSError, match="SCD41: (incomplete|CRC)"):
+            driver.read()
+
+
+def test_short_command_and_stop_error_release_fd(driver):
+    with patch("os.write", return_value=1), patch("os.close") as close:
+        with pytest.raises(OSError, match="incomplete I2C command"):
+            driver.close()
+    close.assert_called_once_with(7)
+
+
+def load_entry(tmp_path, entry):
+    (tmp_path / "scd41.json").write_text(json.dumps({"boards": {"orangepi_sun60": entry}}))
+    return load_scd41_config(str(tmp_path), "orangepi_sun60")
+
+
+def test_missing_and_disabled_unknown_wiring(tmp_path):
+    assert load_scd41_config(str(tmp_path), "orangepi_sun60") is None
+    assert load_entry(tmp_path, {"enabled": False, "bus": None, "sda_pin": None, "scl_pin": None}) is None
+
+
+def test_enabled_defaults_and_explicit_options(tmp_path):
+    config = load_entry(tmp_path, {"enabled": True, "bus": 2})
+    assert config.bus == 2
+    assert config.timing == SCD41Timing(5, 5, 15, 30)
+    assert config.automatic_self_calibration is None
+    config = load_entry(tmp_path, {"bus": 2, "sda_pin": 3, "scl_pin": 5, "automatic_self_calibration": False, "poll_interval_s": 10})
+    assert config.automatic_self_calibration is False
+    assert config.timing.poll_interval_s == 10
+
+
+@pytest.mark.parametrize("change", [
+    {"bus": None}, {"bus": -1}, {"bus": True}, {"bus": "2"},
+    {"enabled": "true"}, {"sda_pin": 3}, {"sda_pin": 3, "scl_pin": 3},
+    {"automatic_self_calibration": 1}, {"automatic_self_calibration": "false"},
+    {"poll_interval_s": None}, {"poll_interval_s": 0}, {"poll_interval_s": True},
+    {"poll_interval_s": float("nan")}, {"retry_interval_s": float("inf")},
+    {"stale_after_s": 5}, {"no_data_timeout_s": 5}, {"unknown": 1},
+])
+def test_invalid_config_rejected(tmp_path, change):
+    with pytest.raises(ValueError, match="Invalid SCD41 wiring"):
+        load_entry(tmp_path, {"enabled": True, "bus": 2, **change})
+
+
+def test_disabled_other_board_still_validated(tmp_path):
+    (tmp_path / "scd41.json").write_text(json.dumps({"boards": {
+        "orangepi_sun60": {"enabled": False},
+        "other": {"enabled": False, "automatic_self_calibration": 1},
+    }}))
+    with pytest.raises(ValueError, match="automatic_self_calibration"):
+        load_scd41_config(str(tmp_path), "orangepi_sun60")
+
+
+@pytest.mark.parametrize("data", ["{", "null", "[]", '{"boards": []}', '{"boards": {"x": null}}'])
+def test_malformed_document(tmp_path, data):
+    (tmp_path / "scd41.json").write_text(data)
+    with pytest.raises(ValueError, match="Invalid SCD41 wiring"):
+        load_scd41_config(str(tmp_path), "orangepi_sun60")

--- a/robots/contract/capabilities.md
+++ b/robots/contract/capabilities.md
@@ -81,14 +81,22 @@ asking: does it take the world **IN**, or does it drive the body **OUT**?
 
 ## Environmental acquisition
 
-`environment` is an optional, read-only HAL input. Its current backend is SEN55;
+`environment` is an optional, read-only HAL input. Its composite backend supports SEN55 and
+SCD41 under the same capability. Device-owned `environment.json` selects
+components; `sen55.json` and `scd41.json` independently configure acquisition.
+A missing component-selection file preserves legacy SEN55-only behavior.
+SCD41 adds measured `co2_ppm` only, leaving SEN55 temperature/humidity unchanged;
 `GET /environment/status` exposes acquisition state and freshness, while
 `GET /environment/sample` returns only a fresh sample (503 otherwise). Declaring
 the capability mounts its routes; acquisition additionally requires the HAL sensor
 configuration. The OS exposes read-only snapshots through its authenticated
 hardware HTTP proxy and MQTT `data` / `environment.status` request/reply, gated
-by the declared capability rather than the sensor model. No OS event, agent tool,
-alert threshold, or automatic reaction is introduced by this capability.
+by the declared capability rather than the sensor model. Composite status
+includes `components`, `sources`, and `metric_timestamps`; healthy readings
+remain available if another sensor fails. A group `ready` state does not make
+every component fresh. The OS separately applies configured sustained-change
+policy, emits `environment.update`, and exposes a loopback agent status API;
+these remain capability-gated and do not control actuators automatically.
 
 It has no actuator safety class and needs no new `SAFETY.md` bounds. Ambient sensor
 temperature is separate from `thermal.max_temp_c`, which protects the board using

--- a/robots/lamp/ROBOT.md
+++ b/robots/lamp/ROBOT.md
@@ -22,7 +22,7 @@ capabilities:
   audio:        { routes: [audio, speaker, voice], required: true }
   vision:       { routes: [camera], driver: opencv, required: true }
   sensing:      { routes: [sensing], required: true }
-  # environment:  { routes: [environment], driver: sen55, required: false }
+  # environment:  { routes: [environment], driver: composite, required: false }
   presence:     { required: true }
   motion:       { routes: [servo], driver: feetech, required: true, safety: SAFETY.md#motion }
   light:        { routes: [led, scene], driver: ws2812, required: true, safety: SAFETY.md#light }

--- a/robots/lamp/docs/environment-sensing.md
+++ b/robots/lamp/docs/environment-sensing.md
@@ -1,11 +1,13 @@
-# Environmental sensing — SEN55
+# Environmental sensing — SEN55 and SCD41
 
 SEN55 is an environmental sensor: particulate matter, humidity, temperature,
 and VOC/NOx indexes. HAL exposes it as an optional `environment` capability,
 with its own driver, lifecycle, and HTTP snapshots alongside camera and audio.
 The integration provides HAL acquisition, read-only web/MQTT snapshots, and
 configurable OS detection of sustained environmental changes for the agent.
-SEN55 does not measure touch, pressure, CO₂, CO or O₂.
+SEN55 does not measure touch, pressure, CO₂, CO or O₂. Optional SCD41 adds
+measured `co2_ppm` to the same capability; its temperature/humidity wire values
+are not published, so SEN55 remains their source.
 
 ## Current scope: readings and sustained-change events
 
@@ -58,10 +60,20 @@ not yet been verified in this integration.
 
 Lamp's `ROBOT.md` keeps the optional `environment` declaration commented out.
 HAL does not mount its endpoints or load its wiring until that line is uncommented.
-The prepared declaration uses driver `sen55`, `routes: [environment]`, and
+The prepared declaration uses driver `composite`, `routes: [environment]`, and
 `required: false`.
 
-Configuration belongs to the device in `robots/<device>/sen55.json`, using a
+Component selection belongs to `robots/<device>/environment.json`:
+
+```json
+{"components": ["sen55", "scd41"]}
+```
+
+Either component may be selected independently. A missing selection file keeps
+the legacy SEN55-only behavior; unknown or duplicate names are rejected. Each
+selected component has an independent worker and configuration.
+
+SEN55 configuration belongs to `robots/<device>/sen55.json`, using a
 `boards` map like `mpr121.json`. The target board is OrangePi (`orangepi_sun60`); Lamp ships its entry disabled
 (`{"enabled": false}`), without an assumed bus. A missing file
 or selected-board entry disables the sensor. Disabled entries may omit `bus` or set it to `null` while the bus is unknown.
@@ -88,13 +100,52 @@ HAL accesses `/dev/i2c-N` through Python's standard library; the process needs
 permission to open that device. No additional Python I2C package is needed.
 Simulation never accesses the hardware, even with an enabled entry.
 
-With default timing, the worker polls every 1 second and retries hardware failures after 5 seconds.
+With default timing, the SEN55 worker polls every 1 second and retries hardware failures after 5 seconds.
 No new data for more than 30 seconds triggers recovery through the same retry
 path. Shutdown stops the worker and releases the bus. Acquisition runs
 separately from the camera/microphone sensing loop. Camera/microphone privacy
 controls and sleep do not stop environmental acquisition. This capability
 adds no actuator policy or new `SAFETY.md` bounds; ambient temperature is not
 the SoC thermal reading.
+
+## SCD41 CO₂ component
+
+`robots/lamp/scd41.json` uses the same `boards` map. Its OrangePi entry is
+disabled with `bus`, `sda_pin`, and `scl_pin` set to `null` pending hardware
+confirmation. Enabling requires a nonnegative Linux bus number; header pins
+are optional metadata and do not configure pin-mux. Do not copy SEN55 wiring
+or supply voltage without confirming the SCD41 board/breakout. SCD41 uses I2C
+address `0x62`; SEN55 uses `0x69`, so sharing a bus is possible if the hardware
+team confirms compatible wiring, logic, power and bus configuration.
+
+The driver uses normal periodic measurement (one new result every 5 seconds),
+checks data readiness and CRC, and exposes only `co2_ppm`. Defaults are
+`poll_interval_s: 5`, `retry_interval_s: 5`, `stale_after_s: 15`, and
+`no_data_timeout_s: 30`. Changing HAL polling does not change this internal
+5-second measurement cadence.
+
+`automatic_self_calibration: null` preserves the sensor setting; `true`/`false`
+explicitly sets ASC in RAM before measurement. HAL does not persist settings
+or perform forced recalibration. Review ASC exposure requirements for the
+installation before choosing a value; a 60-second OS warm-up is not calibration.
+See the [SCD4x datasheet](https://sensirion.com/media/documents/48C4B7FB/67FE0194/CD_DS_SCD4x_Datasheet_D1.pdf).
+Actual SCD41 wiring and measurements have not been verified on hardware.
+
+HAL lifecycle logs use component keys `[sen55]` and `[scd41]`: disabled/start,
+measurement start, retry failures and stop are visible at INFO (failures may
+be WARNING or ERROR). Every valid sample is logged at INFO with timestamp and
+measured values; polls without a new sample log waiting state and last-data
+age. `[environment]` records selected components/simulation or missing capability.
+
+To follow logs on the device, use either its log file or systemd journal:
+
+```sh
+tail -F /var/log/hal/server.log | grep --line-buffered -E '\[(environment|sen55|scd41)\]'
+journalctl -u hal -f | grep --line-buffered -E '\[(environment|sen55|scd41)\]'
+```
+
+These are operator instructions; no device connection is performed by setup
+or by documenting these commands. Default root logging at INFO is sufficient.
 
 ## HAL API
 
@@ -103,16 +154,28 @@ controls. They are available when the robot loads the `environment` route.
 
 | Endpoint | Behavior |
 |---|---|
-| `GET /environment/status` | Reports state, `last_error`, latest `sample`, `age_s`, `stale`, and configured `timing`, including when disabled or unavailable |
+| `GET /environment/status` | Reports state, `last_error`, latest `sample`, `age_s`, `stale`, and per-component diagnostics, including when disabled or unavailable |
 | `GET /environment/sample` | Returns a fresh snapshot; HTTP 503 when unavailable or stale |
 | `GET /health` | The `environment` boolean reports whether a fresh sample is available |
 
-States are `disabled`, `starting`, `ready`, `error`, and `stopped`. A sample
-older than `stale_after_s` (default 5 seconds) is stale; any state other than `ready` is also stale,
-including `error`, `disabled`, and `stopped`. Without a sample, `sample` and `age_s` are
-`null` and `stale` is true. A retained sample in status is diagnostic;
-callers must check freshness. `ready` means data is available, not that gas
-sensor warm-up or adaptation has completed.
+States are `disabled`, `starting`, `ready`, `error`, and `stopped`. Each entry
+in `components` retains its own state, enabled flag, sample, error, age, bus
+and timing. Non-ready or expired component readings are unavailable; SEN55
+with a nonzero status register is also excluded from the combined sample.
+
+The group is `ready` and not stale when at least one component contributes a
+fresh value. `partial: true` means another enabled component is unavailable;
+a disabled component alone does not make the group partial. Healthy values
+remain usable when another sensor fails. With no usable sample, group `sample`
+and `age_s` are `null` and `stale` is true. The flat `sample` includes fields
+owned by selected components, with unavailable values set to `null`.
+
+`sources` maps each metric to its component; `metric_timestamps` records each
+usable metric's Unix timestamp. Group `sample.timestamp` and `age_s` describe
+the newest contributing data, not every metric. Consumers must check source
+status and metric freshness independently. Bus/timing are also exposed at the
+top level only for a single-component group. `ready` does not certify gas
+sensor warm-up or calibration.
 
 A sample contains:
 
@@ -123,7 +186,11 @@ A sample contains:
 | `humidity_pct` | Relative humidity in % |
 | `temperature_c` | Temperature in °C |
 | `voc_index`, `nox_index` | Unitless gas indexes, not ppm measurements |
-| `device_status` | Sensor status register bitmask |
+| `co2_ppm` | Measured carbon dioxide concentration in ppm, from SCD41 only |
+
+SEN55 `device_status` remains in `components.sen55.sample` for diagnostics;
+a SEN55-only group also retains `sample.device_status` for compatibility.
+It is not a combined CO₂ sensor status.
 
 Unavailable measurement values are JSON `null`; callers must not treat them
 as zero. OS change detection and agent interpretation are described below.
@@ -131,7 +198,7 @@ as zero. OS change detection and agent interpretation are described below.
 ## Local web view
 
 [Device → Sensing](../../../docs/web-ui.md#58-device--sensing) shows an
-**Environment · SEN55** card only when the device explicitly declares the
+**Environment** card only when the device explicitly declares the
 `environment` capability. Loading or missing capabilities do not trigger
 sensor requests. The Sensing menu is available without debug mode and
 supports devices with `vision`, `environment`, or both, and camera cards
@@ -140,11 +207,13 @@ remain gated by `vision`.
 The browser polls `GET /api/hardware/environment/status` every 3 seconds via
 the existing authenticated OS hardware proxy, which forwards to HAL
 `GET /environment/status`. This refresh interval is separate from the HAL
-polling configuration below. The card shows state, eight measurements, sample
+polling configuration below. The card shows state, available component fields
+(up to nine measurements including CO₂ in ppm), source labels, sample
 time, stale status, and errors. Missing or stale values appear as `—` and
 request failures are shown explicitly so old values are not presented as live
-readings. Bus, device status register, and timing configuration are in a
-collapsed technical section; timings come from `status.timing`. This is a read-only display with no good/bad
+readings. Component failures do not hide healthy readings. Bus, device status
+register, and timing configuration are in a collapsed technical section per
+component under `status.components`; legacy single-sensor snapshots remain supported. This is a read-only display with no good/bad
 thresholds or historical storage. OS → agent events come from the independent
 worker below, not browser refreshes.
 
@@ -170,7 +239,7 @@ See the [MQTT protocol](../../../docs/mqtt.md) for payloads and response rules.
 
 ## Timing configuration
 
-Each board entry accepts these optional timing fields (seconds). Omitted fields use these defaults. Values must be finite positive numbers; `stale_after_s` and `no_data_timeout_s` must exceed `poll_interval_s`. Restart HAL after editing. These control HAL polling, not the sensor’s internal sampling rate.
+Each board entry accepts these optional timing fields (seconds). The following defaults are for SEN55; SCD41 defaults are listed above. Values must be finite positive numbers; `stale_after_s` and `no_data_timeout_s` must exceed `poll_interval_s`. Restart HAL after editing. These control HAL polling, not the sensor’s internal sampling rate.
 
 ```json
 {
@@ -185,7 +254,7 @@ Each board entry accepts these optional timing fields (seconds). Omitted fields 
 
 OS interpretation is configured under the top-level `environment` object in
 `config/config.json`, through the existing admin `GET`/`PUT /api/device/config`.
-This is separate from HAL timing in `sen55.json`. Defaults are:
+This is separate from HAL timing in `sen55.json` and `scd41.json`. Defaults are:
 
 ```json
 {
@@ -204,7 +273,8 @@ This is separate from HAL timing in `sen55.json`. Defaults are:
       "temperature_c": {"delta": 2, "warmup_s": 60},
       "humidity_pct": {"delta": 10, "warmup_s": 60},
       "voc_index": {"delta": 50, "warmup_s": 3600},
-      "nox_index": {"delta": 20, "warmup_s": 21600}
+      "nox_index": {"delta": 20, "warmup_s": 21600},
+      "co2_ppm": {"delta": 200, "warmup_s": 60}
     }
   }
 }
@@ -224,9 +294,13 @@ retry must be at least the evaluation interval. Cooldown permits 0–604800
 seconds, warm-up 0–86400 seconds. Runtime edits apply on the next worker tick
 and reset detection baselines; they do not enable HAL hardware.
 
-Only fresh, enabled, ready snapshots with advancing timestamps qualify. The
-HAL `stale` flag and OS maximum age both apply. A nonzero `sample.device_status`
-suppresses detection and resets readings until the status is clean. After continuous valid readings
+Only fresh, enabled, ready readings with advancing timestamps qualify. The
+HAL `stale` flag and OS maximum age both apply per metric and source. For
+composite snapshots, `sources`, `components`, and `metric_timestamps` prevent
+a healthy sensor from making another sensor's old values appear current. A
+faulty SEN55 resets its own metrics without suppressing healthy SCD41 CO₂.
+Legacy single-sensor snapshots still use the top-level timestamp/status.
+After continuous valid readings
 for each metric's warm-up, the first value establishes a silent baseline.
 Changes must meet `delta` in the same direction for `sustain_s`; falling below
 that difference or reversing direction resets the pending duration. Null
@@ -236,8 +310,10 @@ OS gating period, not a certificate of sensor calibration.
 
 A qualifying event contains `[environment:update]` followed by JSON with
 `observed_at` (Unix seconds), `sample`, `changes` keyed by metric with
-`previous`, `previous_at` (baseline Unix seconds), `current`, signed `delta`,
-and `sustained_s`. The POST body carries the event as JSON text in `message`;
+`previous`, `previous_at` (baseline Unix seconds), `current`, `current_at`
+(current metric Unix seconds), `source`, signed `delta`, and `sustained_s`.
+Composite events also include `sources` and `metric_timestamps`; legacy
+single-sensor readings may omit provenance. The POST body carries the event as JSON text in `message`;
 the sensing formatter adds `[environment:update]` when forwarding to the agent.
 `previous` is the
 baseline established initially or after the last acknowledged event for that
@@ -286,7 +362,9 @@ not require camera observations, identity, activity logs or hydration counters.
   a timed recheck, start polling, or invent persistent history.
 
 VOC/NOx indices are relative, not ppm or chemical identification. SEN55 cannot
-support CO₂/O₂ claims. Instantaneous PM does not establish compliance with WHO
+support CO₂/O₂ claims. SCD41 supports CO₂ statements only when its measured
+`co2_ppm` is fresh; VOC/NOx must never be used to infer CO₂. Neither component
+measures O₂ or CO, or establishes a smoke/fire alarm. Instantaneous PM does not establish compliance with WHO
 24-hour or annual exposure guidelines. Consider outside conditions before
 suggesting ventilation and enclosure heat before interpreting temperature.
 The skills do not diagnose health, invent thresholds, resume unrelated tasks,

--- a/robots/lamp/docs/vi/environment-sensing_vi.md
+++ b/robots/lamp/docs/vi/environment-sensing_vi.md
@@ -1,10 +1,12 @@
-# Cảm biến môi trường — SEN55
+# Cảm biến môi trường — SEN55 và SCD41
 
 SEN55 đo môi trường: bụi, độ ẩm, nhiệt độ và chỉ số VOC/NOx. HAL cung cấp
 capability `environment` tùy chọn, có driver, vòng đời và HTTP snapshot riêng,
 cùng tầng với camera và audio. Tích hợp gồm thu nhận HAL, snapshot chỉ đọc qua
 web/MQTT và OS phát hiện thay đổi môi trường kéo dài theo cấu hình để gửi agent.
-SEN55 không đo chạm, lực, CO₂, CO hay O₂.
+SEN55 không đo chạm, lực, CO₂, CO hay O₂. Component SCD41 tùy chọn thêm
+`co2_ppm` đo thật vào cùng capability; không công bố nhiệt độ/độ ẩm đọc trên
+bus của SCD41, nên SEN55 vẫn là nguồn của hai chỉ số đó.
 
 ## Phạm vi hiện tại: số đo và sự kiện thay đổi kéo dài
 
@@ -57,10 +59,20 @@ số đo với SEN55 thật.
 
 Dòng khai báo tùy chọn `environment` trong `ROBOT.md` của Lamp đang được comment.
 HAL chưa mount API hoặc đọc cấu hình dây nối cho đến khi bỏ comment dòng này.
-Khai báo chuẩn bị sẵn dùng driver `sen55`, `routes: [environment]` và
+Khai báo chuẩn bị sẵn dùng driver `composite`, `routes: [environment]` và
 `required: false`.
 
-Cấu hình thuộc device tại `robots/<device>/sen55.json`, dùng map `boards`
+Chọn component tại `robots/<device>/environment.json`:
+
+```json
+{"components": ["sen55", "scd41"]}
+```
+
+Có thể chọn từng component độc lập. Thiếu file này giữ cách chạy cũ chỉ có
+SEN55; tên lạ hoặc trùng bị từ chối. Mỗi component được chọn có worker và
+cấu hình riêng.
+
+Cấu hình SEN55 thuộc device tại `robots/<device>/sen55.json`, dùng map `boards`
 như `mpr121.json`. Board mục tiêu là OrangePi (`orangepi_sun60`); Lamp có entry tắt
 (`{"enabled": false}`) cho board này và chưa giả định bus. Thiếu file hoặc
 entry của board đang chọn thì cảm biến tắt. Entry tắt có thể bỏ `bus` hoặc để `null` khi chưa biết bus.
@@ -86,12 +98,48 @@ kernel, cấu hình pin multiplexing và tốc độ bus theo board đó; tích 
 chuẩn Python; process cần quyền mở thiết bị này. Không cần thêm package I2C
 Python. Chế độ mô phỏng không bao giờ truy cập phần cứng, kể cả entry đã bật.
 
-Với thời gian mặc định, worker đọc mỗi 1 giây và thử lại sau 5 giây khi phần cứng lỗi. Không có dữ liệu
+Với thời gian mặc định, worker SEN55 đọc mỗi 1 giây và thử lại sau 5 giây khi phần cứng lỗi. Không có dữ liệu
 mới quá 30 giây sẽ kích hoạt phục hồi qua cùng luồng thử lại. Khi shutdown,
 HAL dừng worker và giải phóng bus. Thu nhận dữ liệu chạy riêng với vòng sensing
 camera/microphone. Privacy của camera/microphone và sleep không dừng thu nhận
 dữ liệu môi trường. Capability này không thêm chính sách actuator hay giới hạn
 `SAFETY.md` mới; nhiệt độ môi trường không phải nhiệt độ SoC.
+
+## Component CO₂ SCD41
+
+`robots/lamp/scd41.json` dùng cùng map `boards`. Entry OrangePi đang tắt,
+`bus`, `sda_pin`, `scl_pin` đều `null` chờ hardware xác nhận. Khi bật cần số
+bus Linux nguyên không âm; chân header là metadata tùy chọn, không cấu hình
+pin-mux. Không sao chép dây hay điện áp nguồn SEN55 khi chưa xác nhận board/
+breakout SCD41. SCD41 dùng I2C `0x62`, SEN55 dùng `0x69`, nên có thể chung bus
+nếu hardware xác nhận dây, logic, nguồn và cấu hình bus tương thích.
+
+Driver dùng đo định kỳ thông thường (mỗi 5 giây có kết quả mới), kiểm tra
+data-ready và CRC, chỉ công bố `co2_ppm`. Mặc định `poll_interval_s: 5`,
+`retry_interval_s: 5`, `stale_after_s: 15`, `no_data_timeout_s: 30`. Thay nhịp
+poll HAL không thay nhịp đo nội bộ 5 giây này.
+
+`automatic_self_calibration: null` giữ cài đặt cảm biến; `true`/`false` đặt
+ASC trong RAM trước khi đo. HAL không lưu cài đặt bền vững hay chạy forced
+recalibration. Xem điều kiện tiếp xúc không khí của ASC trước khi chọn giá trị;
+warm-up OS 60 giây không phải hiệu chuẩn. Xem [datasheet SCD4x](https://sensirion.com/media/documents/48C4B7FB/67FE0194/CD_DS_SCD4x_Datasheet_D1.pdf).
+Chưa kiểm chứng dây nối hay số đo SCD41 trên hardware thật.
+
+Log vòng đời HAL dùng key `[sen55]` và `[scd41]`: tắt/khởi động, mẫu hợp lệ
+đầu tiên, bắt đầu đo, lỗi thử lại và dừng hiển thị ở INFO (lỗi có thể dùng
+WARNING hoặc ERROR). Mỗi mẫu hợp lệ được log ở INFO với timestamp và số đo;
+lần poll chưa có mẫu mới log trạng thái chờ và tuổi dữ liệu gần nhất.
+`[environment]` ghi component đã chọn/simulation hoặc thiếu capability.
+
+Để theo dõi log trên device, dùng file log hoặc journal systemd:
+
+```sh
+tail -F /var/log/hal/server.log | grep --line-buffered -E '\[(environment|sen55|scd41)\]'
+journalctl -u hal -f | grep --line-buffered -E '\[(environment|sen55|scd41)\]'
+```
+
+Đây là hướng dẫn cho người vận hành; việc ghi tài liệu không thực hiện kết nối
+device. Root logging mặc định INFO đã đủ để thấy các dòng này.
 
 ## HAL API
 
@@ -100,16 +148,27 @@ hiện có. Chúng khả dụng khi robot nạp route `environment`.
 
 | Endpoint | Hành vi |
 |---|---|
-| `GET /environment/status` | Trả trạng thái, `last_error`, `sample` gần nhất, `age_s`, `stale` và cấu hình `timing`, kể cả khi tắt hoặc chưa khả dụng |
+| `GET /environment/status` | Trả trạng thái, `last_error`, `sample` gần nhất, `age_s`, `stale` và chẩn đoán từng component, kể cả khi tắt hoặc chưa khả dụng |
 | `GET /environment/sample` | Trả snapshot còn mới; HTTP 503 khi chưa khả dụng hoặc đã cũ |
 | `GET /health` | Boolean `environment` cho biết có sample còn mới hay không |
 
-Các trạng thái gồm `disabled`, `starting`, `ready`, `error`, `stopped`.
-Sample quá `stale_after_s` (mặc định 5 giây) là stale; mọi trạng thái khác `ready` cũng là stale,
-bao gồm `error`, `disabled`, `stopped`. Khi chưa có sample, `sample` và `age_s` là
-`null`, `stale` là true. Sample được giữ trong status phục vụ chẩn đoán;
-caller phải kiểm tra độ mới. `ready` nghĩa là đã có dữ liệu, không khẳng
-định cảm biến khí đã hoàn thành warm-up hay thích nghi.
+Các trạng thái gồm `disabled`, `starting`, `ready`, `error`, `stopped`. Mỗi
+entry trong `components` giữ state, enabled, sample, lỗi, tuổi mẫu, bus và
+timing riêng. Dữ liệu component không ready hoặc hết hạn không khả dụng;
+SEN55 có thanh ghi trạng thái khác zero cũng bị loại khỏi sample tổng hợp.
+
+Nhóm `ready` và không stale khi ít nhất một component đóng góp số đo còn mới.
+`partial: true` nghĩa là component khác đang bật nhưng không khả dụng; một
+component tắt không tự khiến nhóm partial. Số đo khỏe vẫn dùng được khi sensor
+khác lỗi. Không có số đo dùng được thì `sample`, `age_s` của nhóm là `null`,
+`stale` là true. `sample` phẳng gồm các trường thuộc component được chọn;
+giá trị không khả dụng là `null`.
+
+`sources` ánh xạ chỉ số đến component; `metric_timestamps` giữ Unix timestamp
+cho từng chỉ số dùng được. `sample.timestamp` và `age_s` cấp nhóm mô tả dữ liệu
+mới nhất, không đại diện mọi chỉ số. Consumer cần kiểm tra trạng thái nguồn
+và độ mới từng chỉ số. Bus/timing chỉ có thêm ở cấp cao nhất khi nhóm có một
+component. `ready` không chứng nhận warm-up hay hiệu chuẩn cảm biến khí.
 
 Một sample chứa:
 
@@ -120,7 +179,11 @@ Một sample chứa:
 | `humidity_pct` | Độ ẩm tương đối, % |
 | `temperature_c` | Nhiệt độ, °C |
 | `voc_index`, `nox_index` | Chỉ số khí không có đơn vị, không phải nồng độ ppm |
-| `device_status` | Bitmask thanh ghi trạng thái cảm biến |
+| `co2_ppm` | Nồng độ CO₂ đo thật, ppm, chỉ từ SCD41 |
+
+`device_status` của SEN55 nằm trong `components.sen55.sample` để chẩn đoán;
+nhóm chỉ có SEN55 vẫn giữ thêm `sample.device_status` để tương thích. Đây
+không phải trạng thái chung cho cảm biến CO₂.
 
 Giá trị đo chưa khả dụng được trả bằng JSON `null`; caller không được hiểu
 là số không. Phần dưới mô tả phát hiện thay đổi ở OS và diễn giải của agent.
@@ -128,7 +191,7 @@ là số không. Phần dưới mô tả phát hiện thay đổi ở OS và di�
 ## Hiển thị trên web local
 
 [Device → Sensing](../../../../docs/vi/web-ui_vi.md#58-device--sensing) chỉ hiện
-card **Environment · SEN55** khi device khai báo rõ capability `environment`.
+card **Environment** khi device khai báo rõ capability `environment`.
 Đang tải hoặc thiếu capability thì không gửi request tới cảm biến. Menu Sensing
 không yêu cầu bật debug; hỗ trợ device có `vision`, `environment`
 hoặc cả hai, còn card camera vẫn yêu cầu `vision`.
@@ -136,11 +199,12 @@ hoặc cả hai, còn card camera vẫn yêu cầu `vision`.
 Trình duyệt đọc `GET /api/hardware/environment/status` mỗi 3 giây qua proxy
 hardware của OS đã có xác thực, chuyển tới HAL `GET /environment/status`.
 Chu kỳ làm mới này độc lập với cấu hình nhịp đọc HAL bên dưới. Card hiển thị
-trạng thái, tám số đo, thời điểm sample, trạng thái dữ liệu cũ và lỗi.
+trạng thái, các trường của component có khai báo (tối đa chín số đo gồm CO₂
+ppm), nhãn nguồn, thời điểm sample, trạng thái dữ liệu cũ và lỗi.
 Giá trị thiếu hoặc cũ hiện `—`; request thất bại được hiển thị rõ để không
-trình bày số đo cũ như dữ liệu hiện tại. Bus, thanh ghi trạng thái cảm biến và
-cấu hình thời gian nằm trong mục kỹ thuật thu gọn mặc định; các mốc thời gian
-lấy từ `status.timing`. Đây là màn hình
+trình bày số đo cũ như dữ liệu hiện tại. Lỗi component không che số đo còn tốt.
+Bus, thanh ghi trạng thái và timing nằm trong mục kỹ thuật thu gọn theo từng
+component ở `status.components`; vẫn hỗ trợ snapshot một sensor kiểu cũ. Đây là màn hình
 chỉ đọc, không có ngưỡng tốt/xấu hay lưu lịch sử. Event OS → agent do worker
 độc lập bên dưới tạo, không do trình duyệt làm mới.
 
@@ -165,7 +229,7 @@ nên trả lỗi thiếu capability. Đây là request/reply, không stream hay 
 
 ## Cấu hình thời gian
 
-Mỗi entry board nhận các trường thời gian tùy chọn sau (giây). Bỏ qua trường nào thì dùng mặc định tương ứng. Giá trị phải là số dương hữu hạn; `stale_after_s` và `no_data_timeout_s` phải lớn hơn `poll_interval_s`. Khởi động lại HAL sau khi sửa. Đây là nhịp đọc của HAL, không thay đổi nhịp đo nội bộ của sensor.
+Mỗi entry board nhận các trường thời gian tùy chọn sau (giây). Mặc định bên dưới dành cho SEN55; mặc định SCD41 được nêu ở trên. Giá trị phải là số dương hữu hạn; `stale_after_s` và `no_data_timeout_s` phải lớn hơn `poll_interval_s`. Khởi động lại HAL sau khi sửa. Đây là nhịp đọc của HAL, không thay đổi nhịp đo nội bộ của sensor.
 
 ```json
 {
@@ -180,7 +244,7 @@ Mỗi entry board nhận các trường thời gian tùy chọn sau (giây). B�
 
 OS cấu hình diễn giải trong object `environment` cấp cao nhất của
 `config/config.json`, qua admin `GET`/`PUT /api/device/config` hiện có.
-Cấu hình này tách biệt thời gian HAL trong `sen55.json`. Giá trị mặc định:
+Cấu hình này tách biệt thời gian HAL trong `sen55.json` và `scd41.json`. Giá trị mặc định:
 
 ```json
 {
@@ -199,7 +263,8 @@ Cấu hình này tách biệt thời gian HAL trong `sen55.json`. Giá trị m�
       "temperature_c": {"delta": 2, "warmup_s": 60},
       "humidity_pct": {"delta": 10, "warmup_s": 60},
       "voc_index": {"delta": 50, "warmup_s": 3600},
-      "nox_index": {"delta": 20, "warmup_s": 21600}
+      "nox_index": {"delta": 20, "warmup_s": 21600},
+      "co2_ppm": {"delta": 200, "warmup_s": 60}
     }
   }
 }
@@ -218,9 +283,12 @@ duy trì và retry không nhỏ hơn chu kỳ đánh giá. Cooldown cho phép 0�
 giây, warm-up 0–86400 giây. Sửa lúc chạy áp dụng ở tick worker tiếp theo
 và reset baseline; không tự bật phần cứng HAL.
 
-Chỉ snapshot còn mới, enabled, ready và timestamp tiến lên mới đủ điều kiện.
-Cả cờ `stale` của HAL lẫn tuổi mẫu tối đa của OS đều được áp dụng. `sample.device_status`
-khác zero chặn phát hiện và reset số đo đến khi trạng thái sạch. Sau khi
+Chỉ số đo còn mới, enabled, ready và timestamp tiến lên mới đủ điều kiện.
+Cả cờ `stale` của HAL lẫn tuổi mẫu tối đa OS áp dụng cho từng chỉ số và nguồn.
+Snapshot tổng hợp dùng `sources`, `components`, `metric_timestamps` để sensor
+khỏe không khiến dữ liệu cũ của sensor khác có vẻ mới. SEN55 lỗi chỉ reset
+chỉ số của nó, không chặn CO₂ SCD41 còn tốt. Snapshot một sensor kiểu cũ vẫn
+dùng timestamp/status cấp cao nhất. Sau khi
 có số đo hợp lệ liên tục hết warm-up của từng chỉ số, giá trị đầu tiên tạo
 baseline im lặng. Chênh lệch phải đạt `delta` cùng chiều trong `sustain_s`;
 giảm dưới mức chênh lệch hoặc đảo chiều sẽ reset thời gian đang chờ.
@@ -230,7 +298,9 @@ Warm-up là thời gian chờ của OS, không chứng nhận cảm biến đã 
 
 Event đủ điều kiện gồm `[environment:update]` rồi JSON với `observed_at`
 (Unix giây), `sample`, `changes` theo tên chỉ số chứa `previous`, `current`,
-`previous_at` (Unix giây của baseline), `delta` có dấu, và `sustained_s`.
+`previous_at` (Unix giây của baseline), `current_at` (Unix giây của số đo hiện
+tại), `source`, `delta` có dấu, và `sustained_s`. Event tổng hợp còn chứa
+`sources`, `metric_timestamps`; số đo một sensor kiểu cũ có thể thiếu nguồn.
 Body POST chứa event dạng chuỗi JSON trong `message`; bộ định dạng sensing
 thêm `[environment:update]` khi chuyển cho agent.
 `previous` là baseline ban đầu hoặc sau event
@@ -280,7 +350,9 @@ cần quan sát camera, danh tính, log hoạt động hay bộ đếm uống n�
   hay bịa kho lịch sử bền vững.
 
 VOC/NOx là chỉ số tương đối, không phải ppm hay nhận diện hóa chất. SEN55
-không hỗ trợ kết luận CO₂/O₂. PM tức thời không chứng minh đáp ứng hướng dẫn
+không hỗ trợ kết luận CO₂/O₂. Chỉ dùng SCD41 để nói về CO₂ khi `co2_ppm` đo
+thật còn mới; không suy ra CO₂ từ VOC/NOx. Cả hai không đo O₂, CO hay tạo
+cảnh báo khói/cháy. PM tức thời không chứng minh đáp ứng hướng dẫn
 WHO về phơi nhiễm 24 giờ hoặc cả năm. Xét điều kiện ngoài trời trước khi gợi
 ý thông gió, và nhiệt vỏ máy trước khi diễn giải nhiệt độ. Skill không chẩn
 đoán sức khỏe, tự bịa ngưỡng, tiếp tục việc không liên quan hay điều khiển máy

--- a/robots/lamp/environment.json
+++ b/robots/lamp/environment.json
@@ -1,0 +1,3 @@
+{
+  "components": ["sen55", "scd41"]
+}

--- a/robots/lamp/scd41.json
+++ b/robots/lamp/scd41.json
@@ -1,0 +1,15 @@
+{
+  "boards": {
+    "orangepi_sun60": {
+      "enabled": false,
+      "bus": null,
+      "sda_pin": null,
+      "scl_pin": null,
+      "poll_interval_s": 5.0,
+      "retry_interval_s": 5.0,
+      "stale_after_s": 15.0,
+      "no_data_timeout_s": 30.0,
+      "automatic_self_calibration": null
+    }
+  }
+}

--- a/skills/environment/SKILL.md
+++ b/skills/environment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: environment
-description: Interpret environmental sensor readings and sustained changes for room comfort and air quality. Use for [environment:update] events, questions about room temperature, humidity or air quality, and checking changes after ventilation or air cleaning. Requires the environment capability. Link to wellbeing for considerate proactive advice; do not diagnose health conditions or infer CO2 or oxygen from other measurements.
+description: Interpret environmental sensor readings and sustained changes for room comfort and air quality. Use for [environment:update] events, questions about room temperature, humidity, measured CO2 or air quality, and checking changes after ventilation or air cleaning. Requires the environment capability. Link to wellbeing for considerate proactive advice; do not diagnose health conditions or infer CO2 or oxygen from other measurements.
 ---
 
 # Environment
@@ -19,7 +19,7 @@ This read-only route admits local device callers and checks the environment capa
 
 Use the existing snapshot in an automatic event unless it is stale or the user explicitly requests a fresh check. Do not run a polling loop, start a cron job, invent a history endpoint, or promise a timed follow-up: OS owns polling, thresholds, sustained-change detection and cooldowns.
 
-A usable snapshot has `enabled: true`, `state: "ready"`, `stale: false`, and a non-null `sample`. Check `age_s` and `sample.timestamp` before describing it as current. Disabled, starting, stopped, error, missing or stale data is unavailable, not zero pollution. Say so briefly on a direct question; stay silent on an unusable automatic event. Individual null or absent measurements are unknown: retain the other valid readings.
+A usable snapshot has `enabled: true`, `state: "ready"`, `stale: false`, and a non-null `sample`. Check `age_s` and `sample.timestamp` before describing it as current. Disabled, starting, stopped, error, missing or stale data is unavailable, not zero pollution. Say so briefly on a direct question; stay silent on an unusable automatic event. Individual null or absent measurements are unknown: retain the other valid readings. For a multi-component snapshot, `sources[metric]` identifies its entry in `components`; check that component's state, age and stale flag, plus `metric_timestamps[metric]`. The aggregate timestamp may belong to another sensor and does not establish freshness for every field. One failed component does not invalidate another healthy component.
 
 | Sample field | Meaning |
 |---|---|
@@ -27,8 +27,9 @@ A usable snapshot has `enabled: true`, `state: "ready"`, `stale: false`, and a n
 | `temperature_c` | Temperature near the installed sensor, °C |
 | `humidity_pct` | Relative humidity, % |
 | `voc_index`, `nox_index` | Relative gas indices, not gas concentrations |
+| `co2_ppm` | Measured carbon dioxide concentration, ppm, when a CO₂ component is available |
 
-SEN55 supplies these fields, not CO₂, CO or O₂. Never infer oxygen shortage, CO₂ buildup, impaired cognition, a gas leak, a fire, or a medical condition from them. A future sensor can provide other fields; interpret them only with a documented measurement and unit.
+SEN55 supplies PM, temperature, humidity and gas indices; SCD41 adds measured `co2_ppm` only in this integration. CO₂ is distinct from CO and O₂; neither component measures those. Use CO₂ only when its own reading is fresh, never estimate it from VOC/NOx. Do not infer oxygen shortage, impaired cognition, a gas leak, a fire or a medical condition from environmental readings. Missing CO₂ does not prevent using valid SEN55 measurements.
 
 VOC Index adapts to recent history (roughly 24 hours, baseline 100); NOx Index uses a different baseline (1). Neither baseline certifies safe air. Do not identify a chemical, smell or pollution source from either index. Describe an increase relative to previous readings. Do not convert indices into ppm or apply concentration guidelines to them. Instantaneous PM readings cannot establish compliance with 24-hour or annual WHO exposure guidelines. Sensor temperature may be affected by the enclosure and nearby electronics; do not present it as body temperature or a guaranteed room-wide measurement.
 
@@ -36,13 +37,13 @@ VOC Index adapts to recent history (roughly 24 hours, baseline 100); NOx Index u
 
 `[environment:update]` is followed by an OS-generated JSON object containing
 `observed_at` (Unix seconds), `sample` (measurements and timestamp), `changes`
-(keyed by metric, each with `previous`, `previous_at`, `current`, `delta`), and `sustained_s`.
+(keyed by metric, each with `previous`, `previous_at`, `current`, `current_at`, `delta` and optional `source`), `sustained_s`, and per-metric `sources` / `metric_timestamps`. Older events may omit the added provenance fields.
 Use the numeric change facts rather than guessing a trend from one raw sample.
 Do not assume the event has the full status envelope or all metrics. A delayed
 event describes its observation time, not necessarily the current room; obtain
 current status before giving time-sensitive advice. `previous` is the detector's
 previous acknowledged baseline and `previous_at` is its Unix timestamp;
-`current` is the latest sample, not a rolling
+`current_at` is that metric's observation time; `observed_at` is the newest valid reading in the snapshot and may belong to a different component. For older single-sensor events without `current_at`, use `observed_at`. `current` is the latest sample, not a rolling
 average. `sustained_s` describes consecutive qualifying readings, not a health
 exposure assessment. Missing context does not
 justify invented thresholds, durations, health classifications or user activity.
@@ -58,6 +59,7 @@ Do not route environmental updates to sensing's camera/presence reaction matrix 
 ## Useful, proportionate advice
 
 - Increased particles: suggest checking an identifiable source or using an available particle filter. Do not assume cooking, smoking, occupancy or a fire without supporting context.
+- Measured CO₂ increase: describe its value and supported trend; suggest checking ventilation when outside conditions allow. A recirculating fan or HEPA particle filter does not lower CO₂ by itself. The configured CO₂ delta is a change trigger, not a health limit; do not claim a cognitive effect or diagnose symptoms from a reading.
 - Gas-index changes: suggest checking recent activities or sources; ventilation may help when outdoor conditions allow. A HEPA particle filter does not remove every gas.
 - Temperature or humidity: offer a modest comfort adjustment when supported by readings and user preferences. Do not diagnose dehydration, illness, sleep quality or productivity from the sensor.
 - Do not blindly recommend opening a window when outside pollution or weather is unknown. Phrase that condition explicitly when relevant.
@@ -77,6 +79,8 @@ When speaking proactively, offer one useful observation and at most one action i
 |---|---|
 | “How is the room?”; temperature valid, VOC null | Report temperature and other valid readings; VOC is unavailable. Do not turn null into zero. |
 | “Why am I tired?” | Do not attribute fatigue to the sensor readings. If a room check is requested, describe only supported environmental facts. |
+| CO₂ component stale; PM fresh | Report PM if useful; CO₂ is unavailable. Do not reuse the aggregate timestamp to call CO₂ current. |
+| CO₂ rises after a particle purifier starts | Explain that particle filtration does not address CO₂; consider ventilation conditionally, without assuming occupancy or health effects. |
 | VOC Index returns to 100 | Describe the relative change if relevant; never say pollution has cleared or air is safe. |
 | Automatic change while context says the user is asleep or wants quiet | `NO_REPLY`; do not wake them, trigger guard mode or emit an emotion marker. |
 | “I turned the purifier on; is it helping?” | Read current status and compare with a real earlier value if available. Without one, give the current reading and explain the missing comparison. Do not promise a timed recheck. |

--- a/skills/wellbeing/SKILL.md
+++ b/skills/wellbeing/SKILL.md
@@ -7,7 +7,7 @@ description: "Proactive coaching across hydration, breaks, meals, posture and en
 
 ## Environmental care
 
-For room air quality, temperature, humidity, `[environment:update]` events, or a
+For room air quality, measured CO₂, temperature, humidity, `[environment:update]` events, or a
 comparison after ventilation/air cleaning, use `skills/environment/SKILL.md` for
 measurements and interpretation. When already consulting this section from
 that skill, apply these care rules and finish there; do not recursively reload
@@ -30,6 +30,10 @@ improvement can merit a short acknowledgment when it follows an actual user
 concern/action; do not congratulate every decrease or say the air is now safe.
 Keep observations separate from health claims and never infer concentration,
 fatigue, dehydration, disease, CO₂ or oxygen shortage from the available indices.
+A fresh measured `co2_ppm` may support a conditional ventilation suggestion,
+but does not establish the cause of tiredness or impaired concentration.
+Particle filtration alone does not lower CO₂. Missing CO₂ does not invalidate
+other fresh environmental measurements.
 No environment-specific wellbeing log action exists: do not POST these events
 as activities or misuse hydration/break/posture nudge actions.
 

--- a/system/environment/detector.go
+++ b/system/environment/detector.go
@@ -10,14 +10,19 @@ import (
 )
 
 type Snapshot struct {
-	State   string              `json:"state"`
-	Enabled bool                `json:"enabled"`
-	Stale   bool                `json:"stale"`
-	AgeS    *float64            `json:"age_s"`
-	Sample  map[string]*float64 `json:"sample"`
+	State            string              `json:"state"`
+	Enabled          bool                `json:"enabled"`
+	Stale            bool                `json:"stale"`
+	AgeS             *float64            `json:"age_s"`
+	Sample           map[string]*float64 `json:"sample"`
+	Components       map[string]Snapshot `json:"components,omitempty"`
+	Sources          map[string]string   `json:"sources,omitempty"`
+	MetricTimestamps map[string]float64  `json:"metric_timestamps,omitempty"`
 }
 
 type Change struct {
+	CurrentAt  float64 `json:"current_at"`
+	Source     string  `json:"source,omitempty"`
 	Previous   float64 `json:"previous"`
 	PreviousAt float64 `json:"previous_at"`
 	Current    float64 `json:"current"`
@@ -25,10 +30,12 @@ type Change struct {
 }
 
 type Event struct {
-	ObservedAt float64             `json:"observed_at"`
-	Sample     map[string]*float64 `json:"sample"`
-	Changes    map[string]Change   `json:"changes"`
-	SustainedS float64             `json:"sustained_s"`
+	ObservedAt       float64             `json:"observed_at"`
+	Sample           map[string]*float64 `json:"sample"`
+	Changes          map[string]Change   `json:"changes"`
+	SustainedS       float64             `json:"sustained_s"`
+	Sources          map[string]string   `json:"sources,omitempty"`
+	MetricTimestamps map[string]float64  `json:"metric_timestamps,omitempty"`
 }
 
 func (e Event) Message() string {
@@ -37,6 +44,9 @@ func (e Event) Message() string {
 }
 
 type metricState struct {
+	source     string
+	lastSample float64
+	lastFresh  time.Time
 	first      time.Time
 	baseline   *float64
 	baselineAt float64
@@ -49,8 +59,6 @@ type metricState struct {
 type Detector struct {
 	cfg          config.EnvironmentConfig
 	metrics      map[string]*metricState
-	lastSample   float64
-	lastFresh    time.Time
 	lastAccepted time.Time
 	lastAttempt  time.Time
 }
@@ -63,48 +71,80 @@ func finite(v float64) bool { return !math.IsNaN(v) && !math.IsInf(v, 0) }
 
 func (d *Detector) ResetReadings() {
 	d.metrics = make(map[string]*metricState)
-	d.lastSample = 0
-	d.lastFresh = time.Time{}
+}
+
+// reading validates freshness against the producing component, never the newest
+// timestamp of a different sensor. Legacy single-sensor snapshots remain valid.
+func (d *Detector) reading(s Snapshot, key string) (value *float64, stamp float64, source string) {
+	owner := s
+	if s.Components != nil {
+		source = s.Sources[key]
+		var ok bool
+		owner, ok = s.Components[source]
+		if !ok || source == "" {
+			return nil, 0, source
+		}
+	}
+	ts := owner.Sample["timestamp"]
+	value = s.Sample[key]
+	status := owner.Sample["device_status"]
+	if !s.Enabled || s.State != "ready" || s.Stale || !owner.Enabled || owner.State != "ready" || owner.Stale || owner.AgeS == nil || !finite(*owner.AgeS) || *owner.AgeS < 0 || *owner.AgeS > d.cfg.MaxSampleAgeS || ts == nil || !finite(*ts) || *ts <= 0 || value == nil || !finite(*value) || (status != nil && (!finite(*status) || *status != 0)) {
+		return nil, 0, source
+	}
+	if s.Components != nil {
+		metricStamp, ok := s.MetricTimestamps[key]
+		componentValue := owner.Sample[key]
+		if !ok || metricStamp != *ts || componentValue == nil || *componentValue != *value {
+			return nil, 0, source
+		}
+	}
+	return value, *ts, source
 }
 
 func (d *Detector) Observe(now time.Time, s Snapshot) *Event {
-	stamp := s.Sample["timestamp"]
-	if status := s.Sample["device_status"]; status != nil && *status != 0 {
-		d.ResetReadings()
-		return nil
+	event := &Event{Sample: make(map[string]*float64), Changes: make(map[string]Change), SustainedS: d.cfg.SustainS, Sources: make(map[string]string), MetricTimestamps: make(map[string]float64)}
+	for key := range s.Sample {
+		if key == "timestamp" || key == "device_status" {
+			continue
+		}
+		value, stamp, source := d.reading(s, key)
+		event.Sample[key] = value
+		if value != nil {
+			event.MetricTimestamps[key] = stamp
+			if source != "" {
+				event.Sources[key] = source
+			}
+			if stamp > event.ObservedAt {
+				event.ObservedAt = stamp
+			}
+		}
 	}
-	if !s.Enabled || s.State != "ready" || s.Stale || s.AgeS == nil || !finite(*s.AgeS) || *s.AgeS < 0 || *s.AgeS > d.cfg.MaxSampleAgeS || stamp == nil || !finite(*stamp) || *stamp <= 0 {
-		d.ResetReadings()
-		return nil
-	}
-	// An outage or a restarted sensor cannot inherit an in-progress change.
-	if !d.lastFresh.IsZero() && now.Sub(d.lastFresh).Seconds() > 2*d.cfg.EvaluateIntervalS {
-		d.ResetReadings()
-	}
-	if *stamp <= d.lastSample {
-		return nil
-	}
-	d.lastSample = *stamp
-	d.lastFresh = now
-	event := &Event{ObservedAt: *stamp, Sample: s.Sample, Changes: make(map[string]Change), SustainedS: d.cfg.SustainS}
+	event.Sample["timestamp"] = &event.ObservedAt
 	for key, rule := range d.cfg.Metrics {
-		value := s.Sample[key]
-		if value == nil || !finite(*value) {
+		value, stamp, source := d.reading(s, key)
+		if value == nil {
 			delete(d.metrics, key)
 			continue
 		}
 		state := d.metrics[key]
-		if state == nil {
-			state = &metricState{first: now}
+		// Each source owns its warmup and outage history. One healthy component must
+		// not preserve another component's baseline across a fault or replacement.
+		if state == nil || state.source != source || (!state.lastFresh.IsZero() && now.Sub(state.lastFresh).Seconds() > math.Max(2*d.cfg.EvaluateIntervalS, d.cfg.MaxSampleAgeS)) || stamp < state.lastSample {
+			state = &metricState{first: now, source: source}
 			d.metrics[key] = state
 		}
+		if stamp <= state.lastSample {
+			continue
+		}
+		state.lastSample, state.lastFresh = stamp, now
+
 		if now.Sub(state.first).Seconds() < rule.WarmupS {
 			continue
 		}
 		if state.baseline == nil {
 			v := *value
 			state.baseline = &v
-			state.baselineAt = *stamp
+			state.baselineAt = stamp
 			continue
 		}
 		delta := *value - *state.baseline
@@ -122,7 +162,7 @@ func (d *Detector) Observe(now time.Time, s Snapshot) *Event {
 			continue
 		}
 		if now.Sub(state.since).Seconds() >= d.cfg.SustainS {
-			event.Changes[key] = Change{Previous: *state.baseline, PreviousAt: state.baselineAt, Current: *value, Delta: delta}
+			event.Changes[key] = Change{CurrentAt: stamp, Source: source, Previous: *state.baseline, PreviousAt: state.baselineAt, Current: *value, Delta: delta}
 		}
 	}
 	if len(event.Changes) == 0 || (!d.lastAccepted.IsZero() && now.Sub(d.lastAccepted).Seconds() < d.cfg.CooldownS) || (!d.lastAttempt.IsZero() && now.Sub(d.lastAttempt).Seconds() < d.cfg.RetryIntervalS) {
@@ -141,7 +181,7 @@ func (d *Detector) Attempted(now time.Time, event *Event, accepted bool) {
 		if state := d.metrics[key]; state != nil {
 			v := change.Current
 			state.baseline = &v
-			state.baselineAt = event.ObservedAt
+			state.baselineAt = change.CurrentAt
 			state.since = time.Time{}
 			state.direction = 0
 		}

--- a/system/environment/detector_test.go
+++ b/system/environment/detector_test.go
@@ -150,3 +150,96 @@ func TestDetectorNullMetricDoesNotResetOtherMetrics(t *testing.T) {
 		}
 	}
 }
+
+func componentSample(second, co2Second int, temperature, co2 float64) Snapshot {
+	s := sample(second, temperature)
+	c := Snapshot{State: "ready", Enabled: true, AgeS: number(float64(second - co2Second)), Sample: map[string]*float64{"timestamp": number(float64(1000 + co2Second)), "co2_ppm": number(co2)}}
+	s.Components = map[string]Snapshot{"sen55": sample(second, temperature), "scd41": c}
+	s.Sample["co2_ppm"] = number(co2)
+	s.Sources = map[string]string{"temperature_c": "sen55", "co2_ppm": "scd41"}
+	s.MetricTimestamps = map[string]float64{"temperature_c": float64(1000 + second), "co2_ppm": float64(1000 + co2Second)}
+	return s
+}
+func multiDetector() *Detector {
+	c := testSettings()
+	c.Metrics["temperature_c"] = config.EnvironmentMetricRule{Delta: 2}
+	c.Metrics["co2_ppm"] = config.EnvironmentMetricRule{Delta: 200}
+	return NewDetector(c)
+}
+func TestComponentFailureIsolated(t *testing.T) {
+	for _, failed := range []string{"sen55", "scd41"} {
+		t.Run(failed, func(t *testing.T) {
+			d := multiDetector()
+			d.Observe(epoch, componentSample(0, 0, 20, 500))
+			var e *Event
+			for second := 10; second <= 30; second += 10 {
+				s := componentSample(second, second, 23, 800)
+				c := s.Components[failed]
+				c.Sample["device_status"] = number(1)
+				s.Components[failed] = c
+				e = d.Observe(epoch.Add(time.Duration(second)*time.Second), s)
+			}
+			if e == nil {
+				t.Fatal("healthy component lost change")
+			}
+			good, bad := "temperature_c", "co2_ppm"
+			if failed == "sen55" {
+				good, bad = bad, good
+			}
+			if len(e.Changes) != 1 || e.Changes[good].Current == 0 || e.Sample[bad] != nil {
+				t.Fatalf("event leaks failed component: %+v", e)
+			}
+		})
+	}
+}
+func TestComponentTimestampCannotBorrowOtherSensorFreshness(t *testing.T) {
+	d := multiDetector()
+	d.cfg.MaxSampleAgeS = 60
+	d.Observe(epoch, componentSample(0, 0, 20, 500))
+	d.Observe(epoch.Add(10*time.Second), componentSample(10, 10, 20, 800))
+	for second := 20; second <= 30; second += 10 {
+		mustNoEvent(t, d.Observe(epoch.Add(time.Duration(second)*time.Second), componentSample(second, 10, 20, 800)))
+	}
+	e := d.Observe(epoch.Add(40*time.Second), componentSample(40, 35, 20, 800))
+	if e == nil || e.Changes["co2_ppm"].CurrentAt != 1035 || e.MetricTimestamps["co2_ppm"] != 1035 || e.ObservedAt != 1040 || e.Changes["co2_ppm"].Source != "scd41" {
+		t.Fatalf("wrong provenance: %+v", e)
+	}
+	d.Attempted(epoch.Add(40*time.Second), e, true)
+	if d.metrics["co2_ppm"].baselineAt != 1035 {
+		t.Fatal("baseline borrowed aggregate timestamp")
+	}
+}
+func TestComponentInvalidProvenanceResetsOnlyMetric(t *testing.T) {
+	for _, mutate := range []func(*Snapshot){
+		func(s *Snapshot) { delete(s.Sources, "co2_ppm") },
+		func(s *Snapshot) { s.MetricTimestamps["co2_ppm"]++ },
+		func(s *Snapshot) { s.Sample["co2_ppm"] = number(999) },
+		func(s *Snapshot) { c := s.Components["scd41"]; c.Stale = true; s.Components["scd41"] = c },
+	} {
+		d := multiDetector()
+		d.Observe(epoch, componentSample(0, 0, 20, 500))
+		var e *Event
+		for second := 10; second <= 30; second += 10 {
+			s := componentSample(second, second, 23, 800)
+			mutate(&s)
+			e = d.Observe(epoch.Add(time.Duration(second)*time.Second), s)
+		}
+		mustChange(t, e, 20, 23)
+		if _, ok := e.Changes["co2_ppm"]; ok {
+			t.Fatal("invalid CO2 emitted")
+		}
+	}
+}
+func TestComponentReplacementRestartsBaseline(t *testing.T) {
+	d := multiDetector()
+	d.Observe(epoch, componentSample(0, 0, 20, 500))
+	for second := 10; second <= 30; second += 10 {
+		s := componentSample(second, second, 20, 800)
+		s.Components["replacement"] = s.Components["scd41"]
+		s.Sources["co2_ppm"] = "replacement"
+		mustNoEvent(t, d.Observe(epoch.Add(time.Duration(second)*time.Second), s))
+	}
+	if *d.metrics["co2_ppm"].baseline != 800 {
+		t.Fatal("replacement inherited old baseline")
+	}
+}

--- a/system/server/config/environment_settings.go
+++ b/system/server/config/environment_settings.go
@@ -33,6 +33,7 @@ func DefaultEnvironmentConfig() EnvironmentConfig {
 			"pm4_0_ug_m3": {15, 60}, "pm10_ug_m3": {15, 60},
 			"temperature_c": {2, 60}, "humidity_pct": {10, 60},
 			"voc_index": {50, 3600}, "nox_index": {20, 21600},
+			"co2_ppm": {200, 60},
 		},
 	}
 }

--- a/system/server/config/environment_test.go
+++ b/system/server/config/environment_test.go
@@ -20,7 +20,7 @@ func TestEnvironmentDefaultsAndPartialConfig(t *testing.T) {
 		t.Fatal("settings returned shared map")
 	}
 	var old Config
-	if got := old.EnvironmentSettings(); !got.Enabled || got.SustainS != 60 || len(got.Metrics) != 8 {
+	if got := old.EnvironmentSettings(); !got.Enabled || got.SustainS != 60 || len(got.Metrics) != 9 {
 		t.Fatalf("old config defaults: %+v", got)
 	}
 	if Default().Environment == nil {
@@ -33,7 +33,7 @@ func TestEnvironmentRejectsInvalidConfig(t *testing.T) {
 		`{"evaluate_interval_s":0}`, `{"sustain_s":1}`, `{"retry_interval_s":1}`,
 		`{"cooldown_s":-1}`, `{"max_sample_age_s":0}`, `{"enabled":null}`,
 		`{"metrics":{}}`, `{"metrics":null}`, `{"unknown":1}`,
-		`{"metrics":{"co2_ppm":{"delta":10}}}`, `{"metrics":{"voc_index":null}}`,
+		`{"metrics":{"co_ppm":{"delta":10}}}`, `{"metrics":{"voc_index":null}}`,
 		`{"metrics":{"voc_index":{"delta":0}}}`, `{"metrics":{"voc_index":{"warmup_s":null}}}`,
 		`{"metrics":{"voc_index":{"warmup_s":-1}}}`, `{"metrics":{"voc_index":{"typo":2}}}`,
 	} {
@@ -48,5 +48,27 @@ func TestEnvironmentRejectsInvalidConfig(t *testing.T) {
 	c.EvaluateIntervalS = math.NaN()
 	if c.Validate() == nil {
 		t.Fatal("NaN accepted")
+	}
+}
+
+func TestEnvironmentCO2DefaultsAndExplicitSubset(t *testing.T) {
+	var c EnvironmentConfig
+	if err := json.Unmarshal([]byte(`{}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.Metrics["co2_ppm"] != (EnvironmentMetricRule{Delta: 200, WarmupS: 60}) {
+		t.Fatal(c.Metrics)
+	}
+	if err := json.Unmarshal([]byte(`{"metrics":{"temperature_c":{"delta":3}}}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := c.Metrics["co2_ppm"]; ok {
+		t.Fatal("explicit subset unexpectedly monitors CO2")
+	}
+	if err := json.Unmarshal([]byte(`{"metrics":{"co2_ppm":{"delta":300}}}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.Metrics["co2_ppm"].WarmupS != 60 {
+		t.Fatal(c.Metrics)
 	}
 }

--- a/system/web/src/pages/monitor/sensing/EnvironmentCard.tsx
+++ b/system/web/src/pages/monitor/sensing/EnvironmentCard.tsx
@@ -1,12 +1,14 @@
 import { S } from "../styles";
 import type { Measurement } from "./environmentApi";
 import { useEnvironment } from "./useEnvironment";
+import { EnvironmentDiagnostics } from "./EnvironmentDiagnostics";
 
 const measurements: [Measurement, string, string][] = [
   ["temperature_c", "Temperature", "°C"], ["humidity_pct", "Humidity", "%RH"],
   ["pm1_0_ug_m3", "PM1", "µg/m³"], ["pm2_5_ug_m3", "PM2.5", "µg/m³"],
   ["pm4_0_ug_m3", "PM4", "µg/m³"], ["pm10_ug_m3", "PM10", "µg/m³"],
   ["voc_index", "VOC", "index"], ["nox_index", "NOx", "index"],
+  ["co2_ppm", "CO₂", "ppm"],
 ];
 const stateLabels = { disabled: "Disabled", starting: "Connecting", ready: "Receiving data", error: "Sensor error", stopped: "Stopped" };
 
@@ -14,27 +16,38 @@ export function EnvironmentCard() {
   const { data, error } = useEnvironment();
 
   const stale = !!error || data?.stale !== false;
+  const componentIssues = Object.entries(data?.components ?? {}).filter(([, status]) => status.enabled !== false && status.state !== "disabled" && (status.stale || status.last_error));
   const label = error ? "Unavailable" : !data ? "Loading…" : data.stale && data.state === "ready" ? "Stale data" : stateLabels[data.state];
   return (
     <section style={S.card} aria-label="Environmental sensing">
       <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", marginBottom: 18 }}>
         <div>
-          <h2 style={{ margin: 0, fontSize: 16 }}>Environment · SEN55</h2>
+          <h2 style={{ margin: 0, fontSize: 16 }}>Environment</h2>
           <div style={{ color: "var(--lm-text-muted)", fontSize: 12, marginTop: 5 }}>Air quality, temperature and humidity</div>
         </div>
         <span role="status" style={{ color: stale ? "var(--lm-amber)" : "var(--lm-green)" }}>{label}</span>
       </div>
       {(error || data?.last_error) && <p role="alert" style={{ color: "var(--lm-amber)" }}>{error || data?.last_error}</p>}
-      {data?.state === "disabled" && <p style={{ color: "var(--lm-text-muted)" }}>This sensor is not enabled on this device.</p>}
+      {!error && componentIssues.length > 0 && <p role="status" style={{ color: "var(--lm-amber)" }}>
+        {componentIssues.map(([name, status]) => `${name.toUpperCase()}: ${status.last_error || (status.state === "ready" ? "Stale data" : stateLabels[status.state])}`).join(" · ")}
+      </p>}
+      {data?.state === "disabled" && <p style={{ color: "var(--lm-text-muted)" }}>Environment sensors are not enabled on this device.</p>}
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 18 }}>
         {measurements.map(([key, title, unit]) => {
+          if (key === "co2_ppm" && !data?.components?.scd41 && !(key in (data?.sample ?? {}))) return null;
+          if (data?.components && key !== "co2_ppm" && !data.components.sen55 && !(key in (data.sample ?? {}))) return null;
           const value = data?.sample?.[key];
+          const source = data?.sources?.[key];
+          const sourceStatus = source ? data?.components?.[source] : undefined;
+          const unavailable = stale || sourceStatus?.stale === true;
+          const timestamp = data?.metric_timestamps?.[key];
           return <div key={key}>
             <div style={{ color: "var(--lm-text-muted)", fontSize: 12 }}>{title}</div>
-            <div style={{ fontSize: 24, marginTop: 4, color: stale ? "var(--lm-text-muted)" : "var(--lm-text)" }}>
-              {!stale && value != null && Number.isFinite(value) ? value.toLocaleString(undefined, { maximumFractionDigits: 2 }) : "—"}
+            <div style={{ fontSize: 24, marginTop: 4, color: unavailable ? "var(--lm-text-muted)" : "var(--lm-text)" }}>
+              {!unavailable && value != null && Number.isFinite(value) ? value.toLocaleString(undefined, { maximumFractionDigits: 2 }) : "—"}
               <span style={{ fontSize: 12, marginLeft: 6 }}>{unit}</span>
             </div>
+            {source && <div style={{ color: "var(--lm-text-muted)", fontSize: 11, marginTop: 4 }} title={timestamp != null ? new Date(timestamp * 1000).toLocaleString() : undefined}>{source.toUpperCase()}{unavailable ? " · No fresh data" : ""}</div>}
           </div>;
         })}
       </div>
@@ -43,17 +56,7 @@ export function EnvironmentCard() {
         {stale && data?.sample ? " · No fresh data" : ""}
         {" · VOC and NOx are indexes, not ppm."}
       </p>
-      <details style={{ color: "var(--lm-text-muted)", fontSize: 12 }}>
-        <summary style={{ cursor: "pointer" }}>Technical details</summary>
-        <dl style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-          <dt>I²C bus</dt><dd>{data?.bus ?? "—"}</dd>
-          <dt>Device status register</dt><dd>{data?.sample ? `0x${data.sample.device_status.toString(16).padStart(8, "0")}` : "—"}</dd>
-          <dt>Poll interval</dt><dd>{data?.timing ? `${data.timing.poll_interval_s} s` : "—"}</dd>
-          <dt>Retry interval</dt><dd>{data?.timing ? `${data.timing.retry_interval_s} s` : "—"}</dd>
-          <dt>Stale after</dt><dd>{data?.timing ? `${data.timing.stale_after_s} s` : "—"}</dd>
-          <dt>No-data timeout</dt><dd>{data?.timing ? `${data.timing.no_data_timeout_s} s` : "—"}</dd>
-        </dl>
-      </details>
+      <EnvironmentDiagnostics data={data} />
     </section>
   );
 }

--- a/system/web/src/pages/monitor/sensing/EnvironmentDiagnostics.tsx
+++ b/system/web/src/pages/monitor/sensing/EnvironmentDiagnostics.tsx
@@ -1,0 +1,28 @@
+import type { EnvironmentComponentStatus, EnvironmentStatus } from "./environmentApi";
+
+function ComponentDetails({ name, status }: { name: string; status: EnvironmentComponentStatus }) {
+  return <div>
+    <h3 style={{ fontSize: 13 }}>{name} · {status.state}{status.stale && status.state === "ready" ? " · stale" : ""}</h3>
+    {status.last_error && <p style={{ color: "var(--lm-amber)" }}>{status.last_error}</p>}
+    <dl style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+      <dt>I²C bus</dt><dd>{status.bus ?? "—"}</dd>
+      {status.sample?.device_status != null && <>
+        <dt>Device status register</dt><dd>{`0x${status.sample.device_status.toString(16).padStart(8, "0")}`}</dd>
+      </>}
+      <dt>Last measurement</dt><dd>{status.sample ? new Date(status.sample.timestamp * 1000).toLocaleString() : "—"}</dd>
+      <dt>Poll interval</dt><dd>{status.timing ? `${status.timing.poll_interval_s} s` : "—"}</dd>
+      <dt>Retry interval</dt><dd>{status.timing ? `${status.timing.retry_interval_s} s` : "—"}</dd>
+      <dt>Stale after</dt><dd>{status.timing ? `${status.timing.stale_after_s} s` : "—"}</dd>
+      <dt>No-data timeout</dt><dd>{status.timing ? `${status.timing.no_data_timeout_s} s` : "—"}</dd>
+    </dl>
+  </div>;
+}
+
+export function EnvironmentDiagnostics({ data }: { data: EnvironmentStatus | null }) {
+  return <details style={{ color: "var(--lm-text-muted)", fontSize: 12 }}>
+    <summary style={{ cursor: "pointer" }}>Sensor details</summary>
+    {data && (data.components
+      ? Object.entries(data.components).map(([name, status]) => <ComponentDetails key={name} name={name.toUpperCase()} status={status} />)
+      : <ComponentDetails name="SEN55" status={data} />)}
+  </details>;
+}

--- a/system/web/src/pages/monitor/sensing/environmentApi.ts
+++ b/system/web/src/pages/monitor/sensing/environmentApi.ts
@@ -1,14 +1,20 @@
 import { HW } from "../types";
 
-export type Measurement = "temperature_c" | "humidity_pct" | "pm1_0_ug_m3" | "pm2_5_ug_m3" | "pm4_0_ug_m3" | "pm10_ug_m3" | "voc_index" | "nox_index";
-export interface EnvironmentStatus {
+export type Measurement = "temperature_c" | "humidity_pct" | "pm1_0_ug_m3" | "pm2_5_ug_m3" | "pm4_0_ug_m3" | "pm10_ug_m3" | "voc_index" | "nox_index" | "co2_ppm";
+export interface EnvironmentComponentStatus {
   state: "disabled" | "starting" | "ready" | "error" | "stopped";
-  bus: number | null;
+  enabled?: boolean;
+  bus?: number | null;
   last_error: string | null;
   stale: boolean;
   age_s: number | null;
   timing?: { poll_interval_s: number; retry_interval_s: number; stale_after_s: number; no_data_timeout_s: number };
-  sample: ({ timestamp: number; device_status: number } & Record<Measurement, number | null>) | null;
+  sample: ({ timestamp: number; device_status?: number } & Partial<Record<Measurement, number | null>>) | null;
+}
+export interface EnvironmentStatus extends EnvironmentComponentStatus {
+  components?: Record<string, EnvironmentComponentStatus>;
+  sources?: Partial<Record<Measurement, string>>;
+  metric_timestamps?: Partial<Record<Measurement, number>>;
 }
 
 const states = new Set<EnvironmentStatus["state"]>(["disabled", "starting", "ready", "error", "stopped"]);


### PR DESCRIPTION
Add SCD41 as an optional CO2-only component of the existing environment capability. A device can select SEN55, SCD41 or both in environment.json; each component retains its own wiring, worker and diagnostics. SCD41 temperature/humidity values are not exposed.

- Implement the SCD41 periodic I2C protocol with CRC validation, configurable acquisition timing and optional non-persistent ASC setting. Lamp ships both sensors disabled; unconfirmed SCD41 wiring stays null.
- Combine fresh measurements into the existing web/MQTT/status interfaces with per-metric source and timestamps. A faulty or stale sensor does not suppress healthy data from another component.
- Extend OS sustained-change detection and environment/wellbeing skills for measured CO2. Freshness, warm-up and baseline timestamps are tracked per source; defaults add a 200 ppm change threshold and 60-second warm-up. Explicit metric subsets remain unchanged.
- Update the Device Sensing card and per-sensor diagnostics. Log every sample and every no-data poll at INFO with stable [sen55]/[scd41] keys, alongside startup, retry and shutdown logs.
- Update English/Vietnamese docs and the capability contract. The environment capability remains commented out; wakeup greeting integration is deferred.

Validation:
- 137 HAL tests passed: environment, multi-component aggregation/logs, SCD41 protocol/config, and device declarations.
- HAL import/undefined-name lint passed (373 files).
- Go tests passed for environment, config, HAL client, MQTT device handler, server and skills; environment/config race tests passed.
- Linux ARM64 os-server build passed.
- From system/web: npm run lint and npm run build passed; Vite reports its existing large-bundle warning.
- SSR checks covered legacy SEN55, SCD41-only, partial sensor failure and stale data. Skill validation and diff whitespace checks passed.

No real SCD41/SEN55 wiring or on-device measurements were tested, and nothing was deployed.
