### PR TITLE
Add environment startup reports and confirm Lamp SEN55 bus

### DIFF
--- a/docs/os-server.md
+++ b/docs/os-server.md
@@ -62,6 +62,17 @@ status reads and HAL acquisition remain available.
 Capability, sleep and conversation-floor gates apply; busy queues coalesce to
 the latest environment event with a 60-second expiry and recheck capability,
 sleep and policy enabled at replay. Queue acceptance is best-effort, not guaranteed notification delivery.
+`environment.initial_report` defaults to `true`: greeting uses only cached,
+fresh readings that passed warm-up, under `[environment:initial]`, and never
+waits for HAL. Otherwise the first eligible snapshot is sent once after greeting
+completion through `environment.update` (`reason: "initial"`, `changes: {}`).
+Only eligible metrics are included; later warming metrics do not reannounce.
+Successful greeting context or accepted/queued delivery consumes this initial
+report for the OS process; retries use the configured retry interval. Reconnects
+and config edits do not rearm it. Set `initial_report: false` to disable both
+startup paths while retaining change detection. HAL's optional per-component
+`continuous_data_s` allows existing acquisition continuity to count toward
+warm-up after an OS-only restart; invalid/stale components remain excluded.
 The `environment` skill interprets measurements and consults `wellbeing` for
 proportionate advice. Hardware acquisition and OS change policy are separate;
 this feature does not enable Lamp's commented capability or disabled SEN55/SCD41.

--- a/docs/vi/os-server_vi.md
+++ b/docs/vi/os-server_vi.md
@@ -61,7 +61,19 @@ tự động (`dropped_disabled`); vẫn đọc được status chẩn đoán v�
 sleep và conversation floor; queue lúc bận chỉ giữ event môi trường mới nhất,
 hết hạn sau 60 giây, kiểm tra lại capability, sleep và policy enabled khi phát
 lại. Nhận vào queue
-là best-effort, không bảo đảm giao thông báo. Skill `environment` diễn giải
+là best-effort, không bảo đảm giao thông báo.
+`environment.initial_report` mặc định `true`: lời chào chỉ dùng số đo đã cache,
+còn mới và đủ warm-up dưới `[environment:initial]`, không chờ HAL. Nếu chưa có,
+snapshot đủ điều kiện đầu tiên được gửi một lần sau khi lời chào hoàn tất qua
+`environment.update` (`reason: "initial"`, `changes: {}`). Chỉ gồm chỉ số đủ
+điều kiện; chỉ số warm-up muộn không tạo thông báo ban đầu khác. Lời chào thành
+công có context hoặc dispatch được nhận/xếp queue tiêu thụ thông báo cho tiến
+trình OS; retry dùng chu kỳ cấu hình. Kết nối lại hay sửa config không tạo lại
+thông báo đã tiêu thụ. `initial_report: false` tắt cả hai đường khởi động nhưng
+giữ phát hiện thay đổi. Trường `continuous_data_s` tùy chọn của component HAL
+cho phép tính thời gian thu nhận liên tục sẵn có vào warm-up khi chỉ OS restart;
+vẫn loại component không hợp lệ/stale.
+Skill `environment` diễn giải
 số đo và tham khảo `wellbeing` để gợi ý phù hợp. Thu nhận phần cứng tách biệt
 chính sách thay đổi ở OS; tính năng không bật capability đang comment hay SEN55/SCD41
 đang tắt của Lamp. Xem [cảm biến môi trường Lamp](../../robots/lamp/docs/vi/environment-sensing_vi.md#chính-sách-thay-đổi-của-os-và-api-cho-agent)

--- a/hal/drivers/environment/service.py
+++ b/hal/drivers/environment/service.py
@@ -25,10 +25,22 @@ class EnvironmentService:
         self._error = None
         self._sample = None
         self._sample_time = None
+        self._first_sample_time = None
 
     def _set_state(self, state, error=None):
         with self._lock:
             self._state, self._error = state, error
+            if state != "ready":
+                self._first_sample_time = None
+
+    def _store_sample(self, sample, sampled_at):
+        with self._lock:
+            if (self._first_sample_time is None or self._sample_time is None
+                    or sampled_at - self._sample_time > self.timing.stale_after_s):
+                self._first_sample_time = sampled_at
+            self._sample = sample
+            self._sample_time = sampled_at
+            self._state, self._error = "ready", None
 
     def start(self):
         if self._thread is not None:
@@ -64,10 +76,7 @@ class EnvironmentService:
                         raise OSError(f"{self.name}: no new data for {self.timing.no_data_timeout_s:g} seconds")
                     if sample is not None:
                         last_data = time.monotonic()
-                        with self._lock:
-                            self._sample = sample
-                            self._sample_time = time.monotonic()
-                            self._state, self._error = "ready", None
+                        self._store_sample(sample, last_data)
                         if not received:
                             logger.info("[%s] receiving data: fields=%s", self.name, ",".join(sample))
                             received = True
@@ -100,11 +109,17 @@ class EnvironmentService:
     def snapshot(self):
         with self._lock:
             age = None if self._sample_time is None else time.monotonic() - self._sample_time
+            stale = age is None or age > self.timing.stale_after_s or self._state != "ready"
+            # Count successful acquisition time, never time spent waiting for data.
+            continuous_data = None
+            if self.enabled and not stale and self._first_sample_time is not None:
+                continuous_data = self._sample_time - self._first_sample_time
             return {
                 "state": self._state, "enabled": self.enabled, "bus": self.bus,
                 "last_error": self._error,
                 "timing": asdict(self.timing),
                 "sample": None if self._sample is None else dict(self._sample),
                 "age_s": age,
-                "stale": age is None or age > self.timing.stale_after_s or self._state != "ready",
+                "stale": stale,
+                "continuous_data_s": continuous_data,
             }

--- a/hal/test/test_environment_readiness.py
+++ b/hal/test/test_environment_readiness.py
@@ -1,0 +1,85 @@
+"""Acquisition continuity for environment context across OS restarts."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from hal.drivers.environment.service import EnvironmentService
+
+
+def snapshot_at(service, now):
+    with patch("hal.drivers.environment.service.time.monotonic", return_value=now):
+        return service.snapshot()
+
+
+def test_continuity_advances_only_with_samples():
+    service = EnvironmentService(True, 1)
+    assert service.snapshot()["continuous_data_s"] is None
+    service._store_sample({"co2_ppm": 600}, 100)
+    assert snapshot_at(service, 100)["continuous_data_s"] == 0
+    service._store_sample({"co2_ppm": 601}, 104)
+    assert snapshot_at(service, 104)["continuous_data_s"] == 4
+    # Reading the cache or waiting for the next sample cannot prove warm-up.
+    assert snapshot_at(service, 108)["continuous_data_s"] == 4
+    assert snapshot_at(service, 110)["continuous_data_s"] is None
+    service._store_sample({"co2_ppm": 602}, 110)
+    assert snapshot_at(service, 110)["continuous_data_s"] == 0
+
+
+@pytest.mark.parametrize("state", ["starting", "error", "stopped", "disabled"])
+def test_state_transition_resets_continuity(state):
+    service = EnvironmentService(True, 1)
+    service._store_sample({"co2_ppm": 600}, 100)
+    service._store_sample({"co2_ppm": 601}, 104)
+    service._set_state(state)
+    assert snapshot_at(service, 104)["continuous_data_s"] is None
+    service._store_sample({"co2_ppm": 602}, 105)
+    assert snapshot_at(service, 105)["continuous_data_s"] == 0
+
+
+def test_disabled_and_legacy_cache_have_no_readiness():
+    service = EnvironmentService(False, 1)
+    service._store_sample({"co2_ppm": 600}, 100)
+    assert snapshot_at(service, 100)["continuous_data_s"] is None
+    service.enabled = True
+    service._first_sample_time = None
+    assert snapshot_at(service, 100)["continuous_data_s"] is None
+
+
+def test_worker_retry_and_not_ready_reads_do_not_preserve_continuity():
+    clock = [100.0]
+    service = EnvironmentService(True, 1)
+    driver = Mock()
+    service._factory = lambda _: driver
+    outcomes = iter([
+        (100, {"co2_ppm": 600}),
+        (104, {"co2_ppm": 601}),
+        (105, None),
+        (106, OSError("read failed")),
+        (107, {"co2_ppm": 602}),
+    ])
+    observed = []
+
+    def read():
+        clock[0], result = next(outcomes)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def wait(_):
+        observed.append(service.snapshot())
+        if driver.read.call_count == 5:
+            service._stop.is_set.return_value = True
+            return True
+        return False
+
+    driver.read.side_effect = read
+    service._stop = Mock()
+    service._stop.is_set.return_value = False
+    service._stop.wait.side_effect = wait
+    with patch("hal.drivers.environment.service.time.monotonic", side_effect=lambda: clock[0]):
+        service._run()
+    assert [s["continuous_data_s"] for s in observed] == [None, 0, 4, 4, None, None, 0, 0]
+    assert driver.start.call_count == 2
+    assert driver.close.call_count == 2
+    assert service.snapshot()["continuous_data_s"] is None

--- a/robots/lamp/docs/environment-sensing.md
+++ b/robots/lamp/docs/environment-sensing.md
@@ -260,6 +260,7 @@ This is separate from HAL timing in `sen55.json` and `scd41.json`. Defaults are:
 {
   "environment": {
     "enabled": true,
+    "initial_report": true,
     "evaluate_interval_s": 10,
     "sustain_s": 60,
     "cooldown_s": 900,
@@ -300,15 +301,40 @@ composite snapshots, `sources`, `components`, and `metric_timestamps` prevent
 a healthy sensor from making another sensor's old values appear current. A
 faulty SEN55 resets its own metrics without suppressing healthy SCD41 CO₂.
 Legacy single-sensor snapshots still use the top-level timestamp/status.
-After continuous valid readings
-for each metric's warm-up, the first value establishes a silent baseline.
+After continuous valid readings for each metric's warm-up, the first value
+establishes its change-detection baseline. Each HAL component optionally reports
+`continuous_data_s`: elapsed successful acquisition time from its first to its
+latest sample in the uninterrupted acquisition period. It is null while invalid,
+stale or errored and resets after interrupted acquisition. OS can use this
+continuity plus locally observed valid duration to satisfy warm-up after an
+OS-only restart; legacy HAL without it uses local observation. Freshness and
+per-metric validity still apply; component uptime alone is not usable data.
 Changes must meet `delta` in the same direction for `sustain_s`; falling below
 that difference or reversing direction resets the pending duration. Null
 metrics reset their own warm-up/baseline; an unavailable snapshot or read failure
 resets readings for all metrics. Large gaps also reset continuity. Warm-up is an
 OS gating period, not a certificate of sensor calibration.
 
-A qualifying event contains `[environment:update]` followed by JSON with
+`environment.initial_report` defaults to `true`. The system greeting never
+waits for a sensor or fetches HAL: it may attach a fresh, warmed-up snapshot
+already cached by the OS worker as `[environment:initial]` JSON. The agent adds
+at most one factual sentence with one or two readings to the normal greeting.
+Cold boot normally greets without environmental data. After greeting completion,
+OS sends the first eligible snapshot once through `environment.update`, with
+`reason: "initial"` and `changes: {}`, even if no significant change occurred.
+Only eligible metrics are included; metrics still warming up do not each trigger
+another initial report. A successful greeting with context consumes the report;
+otherwise it remains pending. Rejected dispatch retries at `retry_interval_s`;
+accepted or queued dispatch consumes it and starts the shared cooldown. Queued
+acceptance is best-effort, so later expiry does not generate another initial
+report. Capability, enabled policy, sleep, busy and conversation-floor rules
+still apply to the separate event. This state lasts for the OS process; sensor
+reconnections and configuration edits do not rearm a consumed report. Setting
+`initial_report: false` disables both greeting inclusion and the separate
+initial update, preserving sustained-change detection. No initial snapshot
+establishes a trend, health diagnosis, or assurance of safe air.
+
+A qualifying change event contains `[environment:update]` followed by JSON with
 `observed_at` (Unix seconds), `sample`, `changes` keyed by metric with
 `previous`, `previous_at` (baseline Unix seconds), `current`, `current_at`
 (current metric Unix seconds), `source`, signed `delta`, and `sustained_s`.
@@ -353,6 +379,10 @@ not require camera observations, identity, activity logs or hydration counters.
 
 - **Ask about the room:** read status once, report useful measurements; missing
   or stale data is unknown, not zero pollution or proof of safe air.
+- **Startup:** greet immediately; optionally use cached eligible readings in one
+  short sentence. If unavailable, the first eligible snapshot can produce a
+  separate observation after the greeting, without greeting again or fetching
+  data for this report. Stale initial data is omitted.
 - **Sustained change:** explain supported changes and offer at most one useful
   action when appropriate. Respect quiet/sleep preferences; output `NO_REPLY`
   when no useful notification is warranted.

--- a/robots/lamp/docs/environment-sensing.md
+++ b/robots/lamp/docs/environment-sensing.md
@@ -38,9 +38,10 @@ not wire colors. A compatible cable plug is JST GHR-06V-S.
 Hardware-team wiring note (reported by the owner): the **OrangePi host header**
 uses physical **pin 3 for SDA** and **pin 5 for SCL**. These are host header
 positions, not SEN55 connector pin numbers: connect OrangePi pin 3 to SEN55
-pin 3 (SDA), and OrangePi pin 5 to SEN55 pin 4 (SCL). The Linux `/dev/i2c-N`
-bus number and pin-mux configuration still require confirmation; this note
-has not been verified on the device and does not enable acquisition.
+pin 3 (SDA), and OrangePi pin 5 to SEN55 pin 4 (SCL). On the inspected OrangePi 4 Pro, `gpio readall` identifies pin 3 as
+SDA.0 (PB3) and pin 5 as SCL.0 (PB2). The live device tree maps these pins
+to `/dev/i2c-0`, with the `i2c0` overlay enabled. `sen55.json` therefore
+records `bus: 0`; acquisition remains disabled.
 
 `sen55.json` records these physical host header positions as `sda_pin: 3` and
 `scl_pin: 5`. They are wiring metadata; the driver uses `bus` and does not
@@ -53,8 +54,12 @@ pin multiplexing, available bus, and power budget before wiring. HAL does
 not select board header pins or configure bus speed. Keep the air inlet and
 outlet clear and avoid heat from the host when mounting.
 
-Physical wiring, board I2C configuration, and readings on a real SEN55 have
-not yet been verified in this integration.
+Device inspection on 2026-09-11 confirmed the host bus mapping, but the
+SEN55 product-name command at `0x69` received no address ACK (the Sunxi
+driver returned `EINVAL`). The live bus clock was 400 kHz, above the SEN55
+limit. No sensor identity or readings have been verified. Configure the bus
+for at most 100 kHz and check power, common ground, SEL and wiring before
+enabling acquisition. This inspection did not change device configuration.
 
 ## Enable in HAL
 
@@ -75,7 +80,7 @@ selected component has an independent worker and configuration.
 
 SEN55 configuration belongs to `robots/<device>/sen55.json`, using a
 `boards` map like `mpr121.json`. The target board is OrangePi (`orangepi_sun60`); Lamp ships its entry disabled
-(`{"enabled": false}`), without an assumed bus. A missing file
+(`{"enabled": false}`), with the verified host-header bus `0`. A missing file
 or selected-board entry disables the sensor. Disabled entries may omit `bus` or set it to `null` while the bus is unknown.
 Enabling acquisition requires a nonnegative integer `bus`.
 Invalid configuration, including unknown fields, is rejected at startup.
@@ -95,7 +100,8 @@ uses placeholders and is not directly loadable JSON:
 Replace the board ID with the detected board and the bus placeholder with its
 actual nonnegative integer Linux bus number. There is no default bus. Enable
 the kernel I2C interface and configure pin multiplexing and bus speed for that
-board; OrangePi is the selected board, but the physical wiring and bus still need confirmation.
+board; the inspected OrangePi 4 Pro uses bus `0`, but sensor communication
+and the required bus clock still need verification.
 HAL accesses `/dev/i2c-N` through Python's standard library; the process needs
 permission to open that device. No additional Python I2C package is needed.
 Simulation never accesses the hardware, even with an enabled entry.

--- a/robots/lamp/docs/vi/environment-sensing_vi.md
+++ b/robots/lamp/docs/vi/environment-sensing_vi.md
@@ -250,6 +250,7 @@ Cấu hình này tách biệt thời gian HAL trong `sen55.json` và `scd41.json
 {
   "environment": {
     "enabled": true,
+    "initial_report": true,
     "evaluate_interval_s": 10,
     "sustain_s": 60,
     "cooldown_s": 900,
@@ -288,15 +289,38 @@ Cả cờ `stale` của HAL lẫn tuổi mẫu tối đa OS áp dụng cho từn
 Snapshot tổng hợp dùng `sources`, `components`, `metric_timestamps` để sensor
 khỏe không khiến dữ liệu cũ của sensor khác có vẻ mới. SEN55 lỗi chỉ reset
 chỉ số của nó, không chặn CO₂ SCD41 còn tốt. Snapshot một sensor kiểu cũ vẫn
-dùng timestamp/status cấp cao nhất. Sau khi
-có số đo hợp lệ liên tục hết warm-up của từng chỉ số, giá trị đầu tiên tạo
-baseline im lặng. Chênh lệch phải đạt `delta` cùng chiều trong `sustain_s`;
+dùng timestamp/status cấp cao nhất. Sau khi có số đo hợp lệ liên tục hết warm-up
+của từng chỉ số, giá trị đầu tiên tạo baseline phát hiện thay đổi. Mỗi component
+HAL có thể trả `continuous_data_s`: thời gian từ mẫu thành công đầu tiên tới
+mẫu thành công mới nhất trong đợt thu nhận liên tục. Giá trị là null khi không
+hợp lệ, stale hoặc lỗi, và reset khi thu nhận bị gián đoạn. OS dùng thông tin
+liên tục này cùng thời gian quan sát hợp lệ local để đáp ứng warm-up khi chỉ
+OS restart; HAL cũ thiếu trường này dùng quan sát local. Vẫn kiểm tra độ mới và
+tính hợp lệ từng chỉ số; chỉ biết component đã chạy lâu là chưa đủ. Chênh lệch phải đạt `delta` cùng chiều trong `sustain_s`;
 giảm dưới mức chênh lệch hoặc đảo chiều sẽ reset thời gian đang chờ.
 Chỉ số null reset warm-up/baseline riêng; snapshot không khả dụng hay lỗi đọc
 reset số đo của mọi chỉ số. Khoảng gián đoạn lớn cũng reset tính liên tục.
 Warm-up là thời gian chờ của OS, không chứng nhận cảm biến đã hiệu chuẩn.
 
-Event đủ điều kiện gồm `[environment:update]` rồi JSON với `observed_at`
+`environment.initial_report` mặc định `true`. Lời chào hệ thống không chờ sensor
+hay gọi HAL: chỉ có thể đính kèm snapshot còn mới, đủ warm-up đã cache trong
+worker OS bằng JSON `[environment:initial]`. Agent thêm tối đa một câu thực tế
+với một hoặc hai số đo vào lời chào bình thường. Cold boot thường chào khi chưa
+có dữ liệu môi trường. Sau khi lời chào hoàn tất, OS gửi snapshot đủ điều kiện
+đầu tiên một lần qua `environment.update`, với `reason: "initial"` và
+`changes: {}`, kể cả chưa có thay đổi đáng kể. Chỉ gửi chỉ số đủ điều kiện;
+chỉ số còn warm-up không tạo thêm thông báo ban đầu riêng khi sẵn sàng muộn.
+Lời chào thành công có kèm context sẽ tiêu thụ thông báo này; nếu không, nó
+vẫn chờ. Dispatch bị từ chối thử lại theo `retry_interval_s`; dispatch được
+nhận hoặc xếp queue tiêu thụ thông báo và bắt đầu cooldown chung. Queue là
+best-effort, nên hết hạn về sau không tạo lại thông báo ban đầu. Event riêng
+vẫn tuân theo capability, policy enabled, sleep, busy và conversation floor.
+Trạng thái tồn tại trong tiến trình OS; sensor kết nối lại hoặc sửa config
+không tạo lại thông báo đã tiêu thụ. Đặt `initial_report: false` tắt cả dữ liệu
+kèm lời chào lẫn update ban đầu, vẫn giữ phát hiện thay đổi kéo dài. Snapshot
+ban đầu không chứng minh xu hướng, chẩn đoán sức khỏe hay không khí an toàn.
+
+Event thay đổi đủ điều kiện gồm `[environment:update]` rồi JSON với `observed_at`
 (Unix giây), `sample`, `changes` theo tên chỉ số chứa `previous`, `current`,
 `previous_at` (Unix giây của baseline), `current_at` (Unix giây của số đo hiện
 tại), `source`, `delta` có dấu, và `sustained_s`. Event tổng hợp còn chứa
@@ -341,6 +365,9 @@ cần quan sát camera, danh tính, log hoạt động hay bộ đếm uống n�
 
 - **Hỏi về phòng:** đọc status một lần, báo số đo hữu ích; thiếu dữ liệu hoặc
   dữ liệu cũ là chưa biết, không phải không ô nhiễm hay bằng chứng an toàn.
+- **Khởi động:** chào ngay; có thể thêm một câu từ số đo đã cache đủ điều kiện.
+  Nếu chưa có, snapshot đầu tiên đủ điều kiện có thể tạo update riêng sau lời
+  chào, không chào lần nữa hay gọi API cho bản tin này. Bỏ số đo ban đầu đã cũ.
 - **Thay đổi kéo dài:** giải thích thay đổi có căn cứ, gợi ý tối đa một hành
   động hữu ích khi phù hợp. Tôn trọng yêu cầu yên tĩnh/ngủ; trả `NO_REPLY`
   nếu không có thông báo hữu ích.

--- a/robots/lamp/docs/vi/environment-sensing_vi.md
+++ b/robots/lamp/docs/vi/environment-sensing_vi.md
@@ -37,9 +37,10 @@ không dựa vào màu dây. Đầu cáp tương thích là JST GHR-06V-S.
 Ghi nhận từ bên hardware do chủ device cung cấp: **header phía OrangePi** dùng
 **chân vật lý 3 là SDA**, **chân vật lý 5 là SCL**. Đây là vị trí chân header
 host, không phải số chân connector SEN55: nối OrangePi pin 3 với SEN55 pin 3
-(SDA), OrangePi pin 5 với SEN55 pin 4 (SCL). Số bus Linux `/dev/i2c-N` và cấu
-hình pin-mux vẫn cần xác nhận; chưa kiểm chứng trên device và ghi chú này
-không bật thu nhận dữ liệu.
+(SDA), OrangePi pin 5 với SEN55 pin 4 (SCL). Trên OrangePi 4 Pro đã kiểm tra,
+`gpio readall` xác định chân 3 là SDA.0 (PB3), chân 5 là SCL.0 (PB2).
+Device tree đang chạy ánh xạ các chân này tới `/dev/i2c-0`, overlay `i2c0`
+đã bật. Vì vậy `sen55.json` ghi `bus: 0`; thu nhận dữ liệu vẫn tắt.
 
 `sen55.json` ghi vị trí chân vật lý phía host bằng `sda_pin: 3` và `scl_pin: 5`.
 Đây là metadata dây nối; driver dùng `bus`, không tự cấu hình pin-mux GPIO
@@ -52,8 +53,12 @@ pin multiplexing, bus khả dụng và khả năng cấp nguồn trước khi đ
 HAL không chọn chân header hay cấu hình tốc độ bus. Khi lắp, giữ thông
 thoáng cửa hút/xả khí và tránh nhiệt từ host.
 
-Tích hợp này chưa được kiểm chứng dây nối, cấu hình I2C trên board hay
-số đo với SEN55 thật.
+Kiểm tra device ngày 2026-09-11 đã xác nhận mapping bus phía host, nhưng
+lệnh đọc tên SEN55 tại `0x69` không nhận ACK địa chỉ (driver Sunxi trả
+`EINVAL`). Clock bus thực tế là 400 kHz, vượt giới hạn SEN55. Chưa xác nhận
+được danh tính hay số đo sensor. Cần cấu hình bus tối đa 100 kHz và kiểm tra
+nguồn, GND chung, SEL, dây nối trước khi bật thu nhận. Lần kiểm tra này
+không thay đổi cấu hình trên device.
 
 ## Bật trong HAL
 
@@ -74,7 +79,7 @@ cấu hình riêng.
 
 Cấu hình SEN55 thuộc device tại `robots/<device>/sen55.json`, dùng map `boards`
 như `mpr121.json`. Board mục tiêu là OrangePi (`orangepi_sun60`); Lamp có entry tắt
-(`{"enabled": false}`) cho board này và chưa giả định bus. Thiếu file hoặc
+(`{"enabled": false}`) cho board này với bus header đã xác nhận là `0`. Thiếu file hoặc
 entry của board đang chọn thì cảm biến tắt. Entry tắt có thể bỏ `bus` hoặc để `null` khi chưa biết bus.
 Khi bật, `bus` phải là số nguyên không âm.
 Cấu hình sai, kể cả trường không được hỗ trợ, bị từ chối khi khởi động.
@@ -94,7 +99,8 @@ chưa phải JSON có thể nạp trực tiếp:
 Thay board ID bằng board được nhận diện và placeholder bus bằng số bus Linux
 thực tế, là số nguyên không âm. Không có bus mặc định. Bật interface I2C của
 kernel, cấu hình pin multiplexing và tốc độ bus theo board đó; tích hợp này
-đã chọn OrangePi nhưng vẫn cần xác nhận dây nối và bus thực tế. HAL truy cập `/dev/i2c-N` bằng thư viện
+đã xác nhận OrangePi 4 Pro dùng bus `0` nhưng vẫn cần kiểm chứng giao tiếp
+sensor và clock bus phù hợp. HAL truy cập `/dev/i2c-N` bằng thư viện
 chuẩn Python; process cần quyền mở thiết bị này. Không cần thêm package I2C
 Python. Chế độ mô phỏng không bao giờ truy cập phần cứng, kể cả entry đã bật.
 

--- a/robots/lamp/sen55.json
+++ b/robots/lamp/sen55.json
@@ -2,7 +2,7 @@
   "boards": {
     "orangepi_sun60": {
       "enabled": false,
-      "bus": null,
+      "bus": 0,
       "sda_pin": 3,
       "scl_pin": 5,
       "poll_interval_s": 1.0,

--- a/skills/environment/SKILL.md
+++ b/skills/environment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: environment
-description: Interpret environmental sensor readings and sustained changes for room comfort and air quality. Use for [environment:update] events, questions about room temperature, humidity, measured CO2 or air quality, and checking changes after ventilation or air cleaning. Requires the environment capability. Link to wellbeing for considerate proactive advice; do not diagnose health conditions or infer CO2 or oxygen from other measurements.
+description: Interpret environmental sensor readings and sustained changes for room comfort and air quality. Use for [environment:initial] greeting context, [environment:update] events, questions about room temperature, humidity, measured CO2 or air quality, and checking changes after ventilation or air cleaning. Requires the environment capability. Link to wellbeing for considerate proactive advice; do not diagnose health conditions or infer CO2 or oxygen from other measurements.
 ---
 
 # Environment
@@ -48,13 +48,20 @@ average. `sustained_s` describes consecutive qualifying readings, not a health
 exposure assessment. Missing context does not
 justify invented thresholds, durations, health classifications or user activity.
 
+An initial report has `reason: "initial"`, `changes: {}`, and only the metrics
+that have passed OS freshness and warm-up checks. It is either embedded in the
+startup greeting under `[environment:initial]`, or sent after the greeting as
+`[environment:update]`. It is a first observation, not a significant-change
+alert: empty `changes` is expected. Other metrics may still be warming up.
+
 ## Choose the response
 
 1. **Direct room-status question:** report the most relevant available measurements and an evidenced trend, usually in one or two sentences. Give numbers when useful or requested. A single snapshot cannot establish a trend or that the whole room is safe.
-2. **Automatic `[environment:update]`:** use the supplied change facts. A significant change means OS's configurable change policy fired; it is not automatically a harmful level. Consider whether the change merits action using the environmental-care section of `skills/wellbeing/SKILL.md`. If there is no useful new advice, output exactly `NO_REPLY`.
-3. **After an action:** compare a fresh value with an actual earlier, timestamped value in the event or conversation. State the observed direction without claiming causation: “Particles are lower than before.” If there is no comparison point, say that a change cannot yet be established. A later significant-change event may support an update, but no event is a guarantee of scheduled follow-up.
+2. **Initial report (`reason: "initial"`):** use the supplied snapshot to add at most one short factual sentence with one or two useful readings. In `[environment:initial]` greeting context, preserve the normal greeting and do not create another turn or fetch/wait for sensor data. Without usable greeting context, just greet normally. For a separate initial update, skip a second greeting; a simple observation can be useful even without a change or advice. If delayed data is no longer current, omit it rather than refresh or poll for this startup report. Respect quiet/sleep preferences with `NO_REPLY` for a separate update; in a greeting omit only the environmental sentence. Do not claim improvement, a trend, safety, or health effects from this first snapshot. OS owns one-time delivery and retries; do not schedule another report for missing or warming metrics.
+3. **Automatic changed `[environment:update]`:** use the supplied change facts. A significant change means OS's configurable change policy fired; it is not automatically a harmful level. Consider whether the change merits action using the environmental-care section of `skills/wellbeing/SKILL.md`. If there is no useful new advice, output exactly `NO_REPLY`.
+4. **After an action:** compare a fresh value with an actual earlier, timestamped value in the event or conversation. State the observed direction without claiming causation: “Particles are lower than before.” If there is no comparison point, say that a change cannot yet be established. A later significant-change event may support an update, but no event is a guarantee of scheduled follow-up.
 
-Do not route environmental updates to sensing's camera/presence reaction matrix or guard alerts, even while guard mode is active. No mandatory emotion, servo, light, camera or speech action. Never greet a person or infer presence from environmental data. Process only this event; it does not authorize resuming an unrelated task.
+Do not route environmental updates to sensing's camera/presence reaction matrix or guard alerts, even while guard mode is active. No mandatory emotion, servo, light, camera or speech action. An environmental event alone never establishes a person’s presence or authorizes a greeting; startup context only supplements an already requested system greeting. Process only this event; it does not authorize resuming an unrelated task.
 
 ## Useful, proportionate advice
 
@@ -78,6 +85,10 @@ When speaking proactively, offer one useful observation and at most one action i
 | Input | Response direction |
 |---|---|
 | “How is the room?”; temperature valid, VOC null | Report temperature and other valid readings; VOC is unavailable. Do not turn null into zero. |
+| Cold boot; greeting has no environmental context | Greet normally without waiting, checking the API, or claiming missing readings are zero. |
+| Warm HAL; greeting includes initial temperature and CO₂ | Add at most one factual sentence using supplied fresh readings; no second notification. |
+| First update has `reason: "initial"`, `changes: {}`, temperature only | Briefly report temperature when appropriate; do not require a delta or wait for VOC/NOx. |
+| Delayed initial update; readings are stale or unavailable | Omit the environmental report (`NO_REPLY` for a separate update); do not fetch or promise a retry. |
 | “Why am I tired?” | Do not attribute fatigue to the sensor readings. If a room check is requested, describe only supported environmental facts. |
 | CO₂ component stale; PM fresh | Report PM if useful; CO₂ is unavailable. Do not reuse the aggregate timestamp to call CO₂ current. |
 | CO₂ rises after a particle purifier starts | Explain that particle filtration does not address CO₂; consider ventilation conditionally, without assuming occupancy or health effects. |

--- a/skills/wellbeing/SKILL.md
+++ b/skills/wellbeing/SKILL.md
@@ -7,7 +7,7 @@ description: "Proactive coaching across hydration, breaks, meals, posture and en
 
 ## Environmental care
 
-For room air quality, measured CO₂, temperature, humidity, `[environment:update]` events, or a
+For room air quality, measured CO₂, temperature, humidity, `[environment:initial]` greeting context, `[environment:update]` events, or a
 comparison after ventilation/air cleaning, use `skills/environment/SKILL.md` for
 measurements and interpretation. When already consulting this section from
 that skill, apply these care rules and finish there; do not recursively reload
@@ -24,6 +24,14 @@ cooldowns; an emitted event still permits `NO_REPLY` when there is no useful new
 advice. Do not bypass these gates with your own timers or repeated tool calls.
 A direct user question should receive an answer even when a proactive reminder
 would be inappropriate.
+
+An initial report (`reason: "initial"`) can offer one brief factual observation
+without a change or advice. During a startup greeting, add at most one sentence
+with one or two supplied readings; preserve the greeting when readings are
+absent. For the separate post-greeting update, do not greet again. Never wait
+for sensors, fetch data for the greeting, or arrange duplicate follow-ups.
+Quiet/sleep preferences still take precedence. A first snapshot says nothing
+about improvement, health, or whether the room is safe.
 
 Offer at most one practical suggestion, with room for user choice. A meaningful
 improvement can merit a short acknowledgment when it follows an actual user

--- a/system/environment/detector.go
+++ b/system/environment/detector.go
@@ -10,9 +10,13 @@ import (
 )
 
 type Snapshot struct {
+	Timing struct {
+		StaleAfterS float64 `json:"stale_after_s"`
+	} `json:"timing,omitempty"`
 	State            string              `json:"state"`
 	Enabled          bool                `json:"enabled"`
 	Stale            bool                `json:"stale"`
+	ContinuousDataS  *float64            `json:"continuous_data_s,omitempty"`
 	AgeS             *float64            `json:"age_s"`
 	Sample           map[string]*float64 `json:"sample"`
 	Components       map[string]Snapshot `json:"components,omitempty"`
@@ -30,6 +34,7 @@ type Change struct {
 }
 
 type Event struct {
+	Reason           string              `json:"reason,omitempty"`
 	ObservedAt       float64             `json:"observed_at"`
 	Sample           map[string]*float64 `json:"sample"`
 	Changes          map[string]Change   `json:"changes"`
@@ -52,6 +57,8 @@ type metricState struct {
 	baselineAt float64
 	since      time.Time
 	direction  int
+	ready      bool
+	continuous *float64
 }
 
 // Detector is owned by one polling goroutine. Baselines change only after the
@@ -126,10 +133,18 @@ func (d *Detector) Observe(now time.Time, s Snapshot) *Event {
 			delete(d.metrics, key)
 			continue
 		}
+		owner := s
+		if s.Components != nil {
+			owner = s.Components[source]
+		}
+		continuous := owner.ContinuousDataS
+		if continuous != nil && (!finite(*continuous) || *continuous < 0) {
+			continuous = nil
+		}
 		state := d.metrics[key]
 		// Each source owns its warmup and outage history. One healthy component must
 		// not preserve another component's baseline across a fault or replacement.
-		if state == nil || state.source != source || (!state.lastFresh.IsZero() && now.Sub(state.lastFresh).Seconds() > math.Max(2*d.cfg.EvaluateIntervalS, d.cfg.MaxSampleAgeS)) || stamp < state.lastSample {
+		if state == nil || state.source != source || (continuous != nil && state.continuous != nil && *continuous < *state.continuous) || (!state.lastFresh.IsZero() && now.Sub(state.lastFresh).Seconds() > math.Max(2*d.cfg.EvaluateIntervalS, d.cfg.MaxSampleAgeS)) || stamp < state.lastSample {
 			state = &metricState{first: now, source: source}
 			d.metrics[key] = state
 		}
@@ -137,8 +152,17 @@ func (d *Detector) Observe(now time.Time, s Snapshot) *Event {
 			continue
 		}
 		state.lastSample, state.lastFresh = stamp, now
+		if continuous != nil {
+			v := *continuous
+			state.continuous = &v
+		}
 
-		if now.Sub(state.first).Seconds() < rule.WarmupS {
+		duration := now.Sub(state.first).Seconds()
+		if continuous != nil {
+			duration = math.Max(duration, *continuous)
+		}
+		state.ready = duration >= rule.WarmupS
+		if !state.ready {
 			continue
 		}
 		if state.baseline == nil {
@@ -177,6 +201,18 @@ func (d *Detector) Attempted(now time.Time, event *Event, accepted bool) {
 		return
 	}
 	d.lastAccepted = now
+	if event.Reason == "initial" {
+		for key, value := range event.Sample {
+			state := d.metrics[key]
+			if state == nil || value == nil || state.source != event.Sources[key] || state.baselineAt > event.MetricTimestamps[key] {
+				continue
+			}
+			v := *value
+			state.baseline, state.baselineAt = &v, event.MetricTimestamps[key]
+			state.since, state.direction = time.Time{}, 0
+		}
+		return
+	}
 	for key, change := range event.Changes {
 		if state := d.metrics[key]; state != nil {
 			v := change.Current

--- a/system/environment/service.go
+++ b/system/environment/service.go
@@ -15,13 +15,14 @@ import (
 )
 
 type Service struct {
+	Startup   *StartupCoordinator
 	Settings  func() config.EnvironmentConfig
 	Available func() bool
 	Read      func(context.Context) (json.RawMessage, error)
 	Send      func(context.Context, Event) (bool, error)
 }
 
-// Run polls locally; no cloud call is made until a sustained change qualifies.
+// Run polls locally and dispatches an optional startup snapshot or sustained changes.
 // Settings are re-read on each tick, independently of the shared config channel.
 func (s Service) Run(ctx context.Context) {
 	var detector *Detector
@@ -38,12 +39,20 @@ func (s Service) Run(ctx context.Context) {
 		if err := settings.Validate(); err != nil {
 			slog.Warn("invalid environment config", "component", "environment", "error", err)
 			detector = nil
+			if s.Startup != nil {
+				s.Startup.update(false, nil, nil)
+			}
 			timer.Reset(10 * time.Second)
 			continue
 		}
 		if detector == nil || !reflect.DeepEqual(current, settings) {
 			current = settings.Clone()
 			detector = NewDetector(current)
+		}
+		if s.Startup != nil {
+			if acknowledged := s.Startup.takeAcknowledged(); acknowledged != nil {
+				detector.Attempted(time.Now(), acknowledged, true)
+			}
 		}
 		if settings.Enabled && s.Available() {
 			body, err := s.Read(ctx)
@@ -53,16 +62,36 @@ func (s Service) Run(ctx context.Context) {
 			}
 			if err != nil {
 				detector.ResetReadings()
+				if s.Startup != nil {
+					s.Startup.update(settings.InitialReport, nil, nil)
+				}
 				slog.Debug("environment sample unavailable", "component", "environment", "error", err)
-			} else if event := detector.Observe(time.Now(), snapshot); event != nil {
-				accepted, err := s.Send(ctx, *event)
-				detector.Attempted(time.Now(), event, accepted)
-				if err != nil {
-					slog.Warn("environment dispatch failed", "component", "environment", "error", err)
+			} else {
+				now := time.Now()
+				event := detector.Observe(now, snapshot)
+				if s.Startup != nil {
+					initial, expires := detector.startupSnapshot(now, snapshot)
+					s.Startup.update(settings.InitialReport, initial, expires)
+					if pending, next := s.Startup.initial(now, settings.RetryIntervalS); pending {
+						event = next
+					}
+				}
+				if event != nil {
+					accepted, err := s.Send(ctx, *event)
+					detector.Attempted(time.Now(), event, accepted)
+					if accepted && event.Reason == "initial" && s.Startup != nil {
+						s.Startup.acceptedInitial()
+					}
+					if err != nil {
+						slog.Warn("environment dispatch failed", "component", "environment", "error", err)
+					}
 				}
 			}
 		} else {
 			detector.ResetReadings()
+			if s.Startup != nil {
+				s.Startup.update(false, nil, nil)
+			}
 		}
 		timer.Reset(time.Duration(settings.EvaluateIntervalS * float64(time.Second)))
 	}

--- a/system/environment/service_test.go
+++ b/system/environment/service_test.go
@@ -164,3 +164,42 @@ func TestServiceReadErrorResetsBaselineBeforeRecovery(t *testing.T) {
 		t.Fatal("worker did not stop")
 	}
 }
+
+func TestServiceStartupReportRetriesThenDoesNotReplayOnReconnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := testSettings()
+	cfg.EvaluateIntervalS = 1
+	cfg.RetryIntervalS = 1
+	startup := NewStartupCoordinator()
+	startup.FinishGreeting(true)
+	reads, sends := 0, 0
+	done := make(chan struct{})
+	service := Service{Startup: startup, Settings: func() config.EnvironmentConfig { return cfg }, Available: func() bool { return true }, Read: func(context.Context) (json.RawMessage, error) {
+		reads++
+		if reads == 3 {
+			return nil, errors.New("reconnect")
+		}
+		if reads == 5 {
+			cancel()
+		}
+		s := sample(reads, 24)
+		s.ContinuousDataS = number(100)
+		return json.Marshal(s)
+	}, Send: func(_ context.Context, event Event) (bool, error) {
+		sends++
+		if event.Reason != "initial" || len(event.Changes) != 0 {
+			t.Error("initial report must not assert a trend")
+		}
+		return sends == 2, nil
+	}}
+	go func() { service.Run(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(7 * time.Second):
+		t.Fatal("worker did not finish")
+	}
+	if sends != 2 {
+		t.Fatalf("want dropped attempt + accepted retry, got %d", sends)
+	}
+}

--- a/system/environment/startup.go
+++ b/system/environment/startup.go
@@ -1,0 +1,179 @@
+package environment
+
+import (
+	"sync"
+	"time"
+)
+
+// StartupCoordinator coordinates the greeting and polling worker without making
+// the greeting wait for HAL. A successful greeting or accepted initial event
+// consumes the single startup report for this OS process.
+type StartupCoordinator struct {
+	mu           sync.Mutex
+	enabled      bool
+	resolved     bool
+	consumed     bool
+	reserved     *Event
+	cached       *Event
+	expires      map[string]time.Time
+	acknowledged *Event
+	lastAttempt  time.Time
+}
+
+func NewStartupCoordinator() *StartupCoordinator { return &StartupCoordinator{} }
+
+// ReserveGreeting returns only cached, stabilized readings that are fresh now.
+// FinishGreeting must be called even when this returns nil or greeting is skipped.
+func (c *StartupCoordinator) ReserveGreeting(now time.Time) *Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.enabled || c.resolved || c.consumed || c.reserved != nil {
+		return nil
+	}
+	c.reserved = c.fresh(now)
+	return cloneEvent(c.reserved)
+}
+
+// FinishGreeting releases the worker. Success consumes only readings actually
+// reserved for this greeting; a plain greeting leaves the initial report pending.
+func (c *StartupCoordinator) FinishGreeting(success bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.resolved {
+		return
+	}
+	c.resolved = true
+	if success && c.reserved != nil {
+		c.consumed = true
+		c.acknowledged = c.reserved
+	}
+	c.reserved = nil
+}
+
+func cloneEvent(e *Event) *Event {
+	if e == nil {
+		return nil
+	}
+	copy := *e
+	copy.Sample = make(map[string]*float64)
+	copy.Sources = make(map[string]string)
+	copy.MetricTimestamps = make(map[string]float64)
+	copy.Changes = make(map[string]Change)
+	for k, v := range e.Sample {
+		if v != nil {
+			n := *v
+			copy.Sample[k] = &n
+		}
+	}
+	for k, v := range e.Sources {
+		copy.Sources[k] = v
+	}
+	for k, v := range e.MetricTimestamps {
+		copy.MetricTimestamps[k] = v
+	}
+	for k, v := range e.Changes {
+		copy.Changes[k] = v
+	}
+	return &copy
+}
+
+// fresh is called under mu and expires each metric independently.
+func (c *StartupCoordinator) fresh(now time.Time) *Event {
+	event := cloneEvent(c.cached)
+	if event == nil {
+		return nil
+	}
+	event.ObservedAt = 0
+	for key := range event.MetricTimestamps {
+		if now.After(c.expires[key]) {
+			delete(event.Sample, key)
+			delete(event.Sources, key)
+			delete(event.MetricTimestamps, key)
+		} else if stamp := event.MetricTimestamps[key]; stamp > event.ObservedAt {
+			event.ObservedAt = stamp
+		}
+	}
+	if len(event.MetricTimestamps) == 0 {
+		return nil
+	}
+	event.Sample["timestamp"] = &event.ObservedAt
+	return event
+}
+
+func (c *StartupCoordinator) update(enabled bool, event *Event, expires map[string]time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.enabled = enabled
+	c.cached, c.expires = event, expires
+}
+
+func (c *StartupCoordinator) takeAcknowledged() *Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	event := c.acknowledged
+	c.acknowledged = nil
+	return event
+}
+
+// initial returns whether normal changes must wait, and an initial event when
+// greeting has finished, readings are ready, and the retry interval permits it.
+func (c *StartupCoordinator) initial(now time.Time, retryS float64) (bool, *Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.acknowledged != nil {
+		return true, nil
+	}
+	if !c.enabled || c.consumed {
+		return false, nil
+	}
+	if !c.resolved || (!c.lastAttempt.IsZero() && now.Sub(c.lastAttempt).Seconds() < retryS) {
+		return true, nil
+	}
+	event := c.fresh(now)
+	if event != nil {
+		c.lastAttempt = now
+	}
+	return true, event
+}
+
+func (c *StartupCoordinator) acceptedInitial() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.consumed = true
+}
+
+// startupSnapshot excludes warming and unknown metrics, retaining only readings
+// whose configured warmup has completed. It is never used as a trend assertion.
+func (d *Detector) startupSnapshot(now time.Time, s Snapshot) (*Event, map[string]time.Time) {
+	event := &Event{Reason: "initial", Sample: make(map[string]*float64), Changes: make(map[string]Change), Sources: make(map[string]string), MetricTimestamps: make(map[string]float64)}
+	expires := make(map[string]time.Time)
+	for key, state := range d.metrics {
+		value, stamp, source := d.reading(s, key)
+		if !state.ready || value == nil || source != state.source {
+			continue
+		}
+		owner := s
+		if s.Components != nil {
+			owner = s.Components[source]
+		}
+		v := *value
+		event.Sample[key] = &v
+		event.MetricTimestamps[key] = stamp
+		if source != "" {
+			event.Sources[key] = source
+		}
+		maxAge := d.cfg.MaxSampleAgeS
+		if ttl := owner.Timing.StaleAfterS; finite(ttl) && ttl > 0 && ttl < maxAge {
+			maxAge = ttl
+		}
+		expires[key] = now.Add(time.Duration((maxAge - *owner.AgeS) * float64(time.Second)))
+		if stamp > event.ObservedAt {
+			event.ObservedAt = stamp
+		}
+	}
+	if len(event.MetricTimestamps) == 0 {
+		return nil, nil
+	}
+	event.Sample["timestamp"] = &event.ObservedAt
+	return event, expires
+}

--- a/system/environment/startup_test.go
+++ b/system/environment/startup_test.go
@@ -1,0 +1,230 @@
+package environment
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"go.autonomous.ai/os/system/server/config"
+)
+
+func readyStartup(t *testing.T) (*StartupCoordinator, *Detector, *Event) {
+	t.Helper()
+	d := NewDetector(testSettings())
+	s := sample(0, 24)
+	s.ContinuousDataS = number(100)
+	d.Observe(epoch, s)
+	event, expires := d.startupSnapshot(epoch, s)
+	if event == nil {
+		t.Fatal("warm HAL snapshot missing")
+	}
+	c := NewStartupCoordinator()
+	c.update(true, event, expires)
+	return c, d, event
+}
+
+func TestStartupGreetingReservesWithoutDuplicate(t *testing.T) {
+	c, d, _ := readyStartup(t)
+	greeting := c.ReserveGreeting(epoch)
+	if greeting == nil || greeting.Reason != "initial" || len(greeting.Changes) != 0 {
+		t.Fatal("missing non-trend greeting snapshot")
+	}
+	// Callers cannot mutate the worker-owned reservation.
+	*greeting.Sample["temperature_c"] = 99
+	if pending, event := c.initial(epoch, 10); !pending || event != nil {
+		t.Fatal("sent during greeting")
+	}
+	c.FinishGreeting(true)
+	acknowledged := c.takeAcknowledged()
+	if acknowledged == nil || *acknowledged.Sample["temperature_c"] != 24 {
+		t.Fatal("reservation mutated")
+	}
+	d.Attempted(epoch, acknowledged, true)
+	if d.metrics["temperature_c"].baselineAt != 1000 || d.lastAccepted != epoch {
+		t.Fatal("greeting did not advance baseline/cooldown")
+	}
+	if pending, event := c.initial(epoch, 10); pending || event != nil {
+		t.Fatal("duplicate initial report")
+	}
+	c.update(true, nil, nil)
+	_, _, event := readyStartup(t)
+	c.update(true, event, map[string]time.Time{"temperature_c": epoch.Add(time.Hour)})
+	if pending, _ := c.initial(epoch.Add(time.Minute), 10); pending {
+		t.Fatal("reconnect/config refresh replayed initial")
+	}
+}
+
+func TestStartupColdBootAndDroppedRetry(t *testing.T) {
+	c := NewStartupCoordinator()
+	if c.ReserveGreeting(epoch) != nil {
+		t.Fatal("cold greeting had data")
+	}
+	c.FinishGreeting(true)
+	_, _, event := readyStartup(t)
+	expires := map[string]time.Time{"temperature_c": epoch.Add(time.Hour)}
+	c.update(true, event, expires)
+	if pending, e := c.initial(epoch, 10); !pending || e == nil {
+		t.Fatal("no initial report after plain greeting")
+	}
+	if _, e := c.initial(epoch.Add(9*time.Second), 10); e != nil {
+		t.Fatal("dropped report retried too soon")
+	}
+	if _, e := c.initial(epoch.Add(10*time.Second), 10); e == nil {
+		t.Fatal("dropped report not retried")
+	}
+	c.acceptedInitial()
+	if pending, _ := c.initial(epoch.Add(time.Minute), 10); pending {
+		t.Fatal("accepted queued/live report replayed")
+	}
+}
+
+func TestStartupFailedGreetingAndPerMetricExpiry(t *testing.T) {
+	c, _, event := readyStartup(t)
+	event.Sample["co2_ppm"] = number(800)
+	event.MetricTimestamps["co2_ppm"] = 1000
+	c.update(true, event, map[string]time.Time{"temperature_c": epoch.Add(time.Second), "co2_ppm": epoch.Add(5 * time.Second)})
+	greeting := c.ReserveGreeting(epoch.Add(2 * time.Second))
+	if greeting == nil || greeting.Sample["temperature_c"] != nil || greeting.Sample["co2_ppm"] == nil {
+		t.Fatal("per-metric expiry not applied")
+	}
+	c.FinishGreeting(false)
+	if _, e := c.initial(epoch.Add(3*time.Second), 10); e == nil {
+		t.Fatal("failed greeting consumed report")
+	}
+	c2, _, _ := readyStartup(t)
+	if c2.ReserveGreeting(epoch.Add(time.Hour)) != nil {
+		t.Fatal("stale cache included")
+	}
+	c2.update(false, event, nil)
+	if c2.ReserveGreeting(epoch) != nil {
+		t.Fatal("disabled initial report included")
+	}
+}
+
+func TestStartupWarmupMetadataAndLegacy(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		evidence *float64
+		ready    bool
+	}{
+		{"warm HAL", number(20), true}, {"cold HAL", number(0), false}, {"legacy", nil, false},
+		{"negative", number(-1), false}, {"nan", number(math.NaN()), false}, {"infinite", number(math.Inf(1)), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewDetector(testSettings())
+			s := sample(0, 24)
+			s.ContinuousDataS = tc.evidence
+			d.Observe(epoch, s)
+			event, _ := d.startupSnapshot(epoch, s)
+			if (event != nil) != tc.ready {
+				t.Fatalf("ready=%v", event != nil)
+			}
+			if !tc.ready {
+				for sec := 10; sec <= 20; sec += 10 {
+					s = sample(sec, 24)
+					d.Observe(epoch.Add(time.Duration(sec)*time.Second), s)
+				}
+				event, _ = d.startupSnapshot(epoch.Add(20*time.Second), s)
+				if event == nil {
+					t.Fatal("local warmup evidence ignored")
+				}
+			}
+		})
+	}
+}
+
+func TestStartupExcludesWarmingGasAndNoLaterInitial(t *testing.T) {
+	cfg := testSettings()
+	cfg.Metrics["voc_index"] = config.EnvironmentMetricRule{Delta: 50, WarmupS: 3600}
+	d := NewDetector(cfg)
+	s := sample(0, 24)
+	s.ContinuousDataS = number(30)
+	s.Sample["voc_index"] = number(120)
+	d.Observe(epoch, s)
+	event, expires := d.startupSnapshot(epoch, s)
+	if event == nil || event.Sample["voc_index"] != nil {
+		t.Fatal("warming gas included")
+	}
+	c := NewStartupCoordinator()
+	c.update(true, event, expires)
+	c.FinishGreeting(false)
+	if _, e := c.initial(epoch, 10); e == nil {
+		t.Fatal("ready temperature blocked by gas warmup")
+	}
+	c.acceptedInitial()
+	s = sample(3600, 24)
+	s.ContinuousDataS = number(3600)
+	s.Sample["voc_index"] = number(120)
+	d.Observe(epoch.Add(time.Hour), s)
+	event, expires = d.startupSnapshot(epoch.Add(time.Hour), s)
+	c.update(true, event, expires)
+	if pending, _ := c.initial(epoch.Add(time.Hour), 10); pending {
+		t.Fatal("later gas replayed initial report")
+	}
+}
+
+func TestStartupConcurrentGreetingAndPolling(t *testing.T) {
+	c, _, event := readyStartup(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				c.update(true, event, map[string]time.Time{"temperature_c": epoch.Add(time.Hour)})
+				c.ReserveGreeting(epoch)
+				c.initial(epoch, 10)
+			}
+		}()
+	}
+	c.FinishGreeting(true)
+	wg.Wait()
+}
+
+func TestStartupContinuousEvidenceResetRestartsWarmup(t *testing.T) {
+	d := NewDetector(testSettings())
+	s := sample(0, 24)
+	s.ContinuousDataS = number(100)
+	d.Observe(epoch, s)
+	s = sample(10, 24)
+	s.ContinuousDataS = number(0)
+	d.Observe(epoch.Add(10*time.Second), s)
+	if event, _ := d.startupSnapshot(epoch.Add(10*time.Second), s); event != nil {
+		t.Fatal("HAL reconnect reused previous warmup")
+	}
+}
+
+func TestStartupCacheRespectsHALStaleDeadline(t *testing.T) {
+	d := NewDetector(testSettings())
+	s := sample(0, 24)
+	s.ContinuousDataS = number(100)
+	s.AgeS = number(2)
+	s.Timing.StaleAfterS = 5
+	d.Observe(epoch, s)
+	event, expires := d.startupSnapshot(epoch, s)
+	c := NewStartupCoordinator()
+	c.update(true, event, expires)
+	if c.ReserveGreeting(epoch.Add(4*time.Second)) != nil {
+		t.Fatal("cache outlived HAL freshness deadline")
+	}
+}
+
+func TestStartupWarmupEvidenceBelongsToProducingComponent(t *testing.T) {
+	cfg := testSettings()
+	cfg.Metrics["co2_ppm"] = config.EnvironmentMetricRule{Delta: 200, WarmupS: 20}
+	d := NewDetector(cfg)
+	s := componentSample(0, 0, 24, 800)
+	s.ContinuousDataS = number(10000)
+	sen := s.Components["sen55"]
+	sen.ContinuousDataS = number(100)
+	s.Components["sen55"] = sen
+	co2 := s.Components["scd41"]
+	co2.ContinuousDataS = number(0)
+	s.Components["scd41"] = co2
+	d.Observe(epoch, s)
+	event, _ := d.startupSnapshot(epoch, s)
+	if event == nil || event.Sample["temperature_c"] == nil || event.Sample["co2_ppm"] != nil {
+		t.Fatal("one component's uptime warmed another")
+	}
+}

--- a/system/server/config/environment_settings.go
+++ b/system/server/config/environment_settings.go
@@ -16,6 +16,7 @@ type EnvironmentMetricRule struct {
 // EnvironmentConfig controls OS interpretation separately from HAL acquisition.
 type EnvironmentConfig struct {
 	Enabled           bool                             `json:"enabled"`
+	InitialReport     bool                             `json:"initial_report"`
 	EvaluateIntervalS float64                          `json:"evaluate_interval_s"`
 	SustainS          float64                          `json:"sustain_s"`
 	CooldownS         float64                          `json:"cooldown_s"`
@@ -26,7 +27,7 @@ type EnvironmentConfig struct {
 
 func DefaultEnvironmentConfig() EnvironmentConfig {
 	return EnvironmentConfig{
-		Enabled: true, EvaluateIntervalS: 10, SustainS: 60, CooldownS: 900,
+		Enabled: true, InitialReport: true, EvaluateIntervalS: 10, SustainS: 60, CooldownS: 900,
 		RetryIntervalS: 60, MaxSampleAgeS: 10,
 		Metrics: map[string]EnvironmentMetricRule{
 			"pm1_0_ug_m3": {10, 60}, "pm2_5_ug_m3": {10, 60},

--- a/system/server/config/environment_test.go
+++ b/system/server/config/environment_test.go
@@ -20,7 +20,7 @@ func TestEnvironmentDefaultsAndPartialConfig(t *testing.T) {
 		t.Fatal("settings returned shared map")
 	}
 	var old Config
-	if got := old.EnvironmentSettings(); !got.Enabled || got.SustainS != 60 || len(got.Metrics) != 9 {
+	if got := old.EnvironmentSettings(); !got.Enabled || !got.InitialReport || got.SustainS != 60 || len(got.Metrics) != 9 {
 		t.Fatalf("old config defaults: %+v", got)
 	}
 	if Default().Environment == nil {
@@ -31,7 +31,7 @@ func TestEnvironmentDefaultsAndPartialConfig(t *testing.T) {
 func TestEnvironmentRejectsInvalidConfig(t *testing.T) {
 	for _, body := range []string{
 		`{"evaluate_interval_s":0}`, `{"sustain_s":1}`, `{"retry_interval_s":1}`,
-		`{"cooldown_s":-1}`, `{"max_sample_age_s":0}`, `{"enabled":null}`,
+		`{"cooldown_s":-1}`, `{"max_sample_age_s":0}`, `{"enabled":null}`, `{"initial_report":null}`, `{"initial_report":"false"}`,
 		`{"metrics":{}}`, `{"metrics":null}`, `{"unknown":1}`,
 		`{"metrics":{"co_ppm":{"delta":10}}}`, `{"metrics":{"voc_index":null}}`,
 		`{"metrics":{"voc_index":{"delta":0}}}`, `{"metrics":{"voc_index":{"warmup_s":null}}}`,
@@ -70,5 +70,15 @@ func TestEnvironmentCO2DefaultsAndExplicitSubset(t *testing.T) {
 	}
 	if c.Metrics["co2_ppm"].WarmupS != 60 {
 		t.Fatal(c.Metrics)
+	}
+}
+
+func TestEnvironmentInitialReportCanBeDisabledIndependently(t *testing.T) {
+	var c EnvironmentConfig
+	if err := json.Unmarshal([]byte(`{"initial_report":false}`), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.InitialReport || !c.Enabled || len(c.Metrics) != 9 {
+		t.Fatalf("initial report toggle changed sensing policy: %+v", c)
 	}
 }

--- a/system/server/config_watch.go
+++ b/system/server/config_watch.go
@@ -334,10 +334,18 @@ func (s *Server) handleSetUpCompleteChange(setupCompleted bool) {
 				slog.Info("INBOUND from system → agent (startup greeting)",
 					"component", "server", "backend", s.agentGateway.Name(),
 					"source", "wake_greeting")
-				if _, err := s.agentGateway.SendSystemChatMessage(wakeGreetingPrompt(s.agentGateway.Name(), deviceType, device.Capabilities(deviceType))); err != nil {
+				settings := s.config.EnvironmentSettings()
+				if err := sendWakeGreetingWithEnvironment(
+					wakeGreetingPrompt(s.agentGateway.Name(), deviceType, device.Capabilities(deviceType)),
+					s.environmentStartup, settings.Enabled && settings.InitialReport && s.environmentAvailable(),
+					s.agentGateway.SendSystemChatMessage,
+				); err != nil {
 					slog.Warn("startup greeting failed", "component", "server", "backend", s.agentGateway.Name(), "error", err)
 				}
 			} else {
+				if s.environmentStartup != nil {
+					s.environmentStartup.FinishGreeting(false)
+				}
 				slog.Warn("startup greeting skipped: agent gateway never reached stable readiness", "component", "server", "backend", s.agentGateway.Name())
 			}
 

--- a/system/server/environment_greeting.go
+++ b/system/server/environment_greeting.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"log/slog"
+	"time"
+
+	"go.autonomous.ai/os/system/environment"
+	"go.autonomous.ai/os/system/lib/i18n"
+)
+
+// sendWakeGreetingWithEnvironment uses only the worker's cache. Missing or
+// warming hardware never delays the existing greeting or adds a HAL request.
+func sendWakeGreetingWithEnvironment(prompt string, startup *environment.StartupCoordinator, allowed bool, send func(string) (string, error)) error {
+	var snapshot *environment.Event
+	if startup != nil && allowed {
+		snapshot = startup.ReserveGreeting(time.Now())
+	}
+	if snapshot != nil {
+		prompt += "\n[environment:initial] " + snapshot.Message() + "\n" + environmentGreetingGuidance()
+	}
+	slog.Info("startup environment context", "component", "environment", "attached", snapshot != nil)
+	_, err := send(prompt)
+	if startup != nil {
+		startup.FinishGreeting(err == nil)
+	}
+	return err
+}
+
+func environmentGreetingGuidance() string {
+	switch i18n.Lang() {
+	case i18n.LangVI:
+		return "Dữ liệu môi trường kèm theo đã đủ điều kiện sử dụng. Theo skill environment, có thể thêm tối đa một câu ngắn về 1–2 số đo hữu ích vào lời chào. Không suy ra xu hướng hay mức an toàn từ một mẫu, không đọc toàn bộ bảng và không gọi thêm công cụ để chờ sensor."
+	case i18n.LangZhCN:
+		return "附带的环境数据已通过就绪检查。按照 environment 技能，可在问候中增加一句简短的话，提及一两个有用读数。不要从单次读数推断趋势或安全性，不要逐项播报，也不要调用工具等待传感器。"
+	case i18n.LangZhTW:
+		return "附帶的環境資料已通過就緒檢查。按照 environment 技能，可在問候中增加一句簡短的話，提及一兩個有用讀數。不要從單次讀數推斷趨勢或安全性，不要逐項播報，也不要呼叫工具等待感測器。"
+	default:
+		return "The attached environment snapshot passed readiness checks. Follow the environment skill and optionally add at most one brief sentence with one or two useful readings to the greeting. Do not infer trends or safety from one snapshot, read every value aloud, or call tools to wait for sensors."
+	}
+}

--- a/system/server/environment_greeting_test.go
+++ b/system/server/environment_greeting_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"go.autonomous.ai/os/system/environment"
+)
+
+func TestWakeGreetingWithoutEnvironmentDoesNotWait(t *testing.T) {
+	for _, allowed := range []bool{true, false} {
+		startup := environment.NewStartupCoordinator()
+		calls := 0
+		err := sendWakeGreetingWithEnvironment("wake now", startup, allowed, func(prompt string) (string, error) {
+			calls++
+			if prompt != "wake now" {
+				t.Fatalf("cold greeting changed: %q", prompt)
+			}
+			return "run-1", nil
+		})
+		if err != nil || calls != 1 {
+			t.Fatalf("greeting calls=%d error=%v", calls, err)
+		}
+	}
+}
+
+func TestWakeGreetingPropagatesGatewayFailure(t *testing.T) {
+	want := errors.New("gateway unavailable")
+	err := sendWakeGreetingWithEnvironment("wake", environment.NewStartupCoordinator(), true, func(string) (string, error) {
+		return "", want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}

--- a/system/server/server.go
+++ b/system/server/server.go
@@ -59,6 +59,8 @@ type Server struct {
 	engine          *gin.Engine
 	config          *config.Config
 
+	environmentStartup *environment.StartupCoordinator
+
 	// handlers
 	healthHandler     _healthHttpDeliver.HealthHandler
 	networkHandler    _networkHttpDeliver.NetworkHandler
@@ -163,6 +165,8 @@ func ProvideServer(
 	// on — that older turn keeps running but loses the speaker.
 	sensingH.SetOnRealtimeHandled(agentH.CancelSpeechForNewerTurn)
 	s := &Server{
+		environmentStartup: environment.NewStartupCoordinator(),
+
 		config:            cfg,
 		healthHandler:     hh,
 		networkHandler:    nh,
@@ -654,6 +658,7 @@ func (s *Server) Serve(closeFn func()) error {
 	})
 
 	go environment.Service{
+		Startup:   s.environmentStartup,
 		Settings:  s.config.EnvironmentSettings,
 		Available: s.environmentAvailable,
 		Read:      hal.GetEnvironmentStatusContext,


### PR DESCRIPTION
Startup greetings can now include fresh, stabilized environment readings already cached by OS. Cold boots greet immediately without waiting for sensors; once readings qualify, OS sends one initial `environment.update` through the existing sensing gates. A successful greeting with environment context consumes that initial report to prevent duplication.

- Add configurable `environment.initial_report` (default `true`), per-metric cache expiry, warmup continuity from HAL, and retry handling. Update environment/wellbeing skills and English/Vietnamese docs.
- Keep hardware in a separate commit: set Lamp SEN55 `bus: 0` from OrangePi 4 Pro pin 3/5 and live device-tree inspection. Acquisition remains disabled. The inspected sensor did not ACK at `0x69`; the live bus was 400 kHz and needs configuration within the SEN55 100 kHz limit plus wiring/power verification. No device configuration was changed.

Validation:
- `go test ./system/environment ./system/server/config ./system/server`
- `go test -race ./system/environment ./system/server/config`
- `go test ./system/server -run TestWakeGreeting`
- 98 focused HAL tests passed; HAL lint passed with pyflakes in the test environment.
- `GOOS=linux GOARCH=arm64 go build -o /tmp/os-server-startup-environment ./system/cmd/os-server`
- `git diff --check`

Startup behavior has local automated coverage; real SEN55 readings and an end-to-end device greeting are not yet verified.
