### PR TITLE
docs: document Wi-Fi body onboarding after Stack-chan integration

### DIFF
--- a/robots/contract/ROBOT-SPEC.md
+++ b/robots/contract/ROBOT-SPEC.md
@@ -174,3 +174,10 @@ same rule: **names are forever.**
 
 This is the Autonomous equivalent of the Linux syscall ABI / Android API level — the
 contract facing devices and skills is stable; the drivers behind it churn freely.
+
+## Network-controlled bodies
+
+A profile may describe a robot whose firmware stays on a microcontroller while
+OS and HAL run on a separate host. See the [Wi-Fi body integration pattern](WIFI-BODY.md)
+and its [Vietnamese version](vi/WIFI-BODY_vi.md) for driver ownership, host
+selection, the experimental Stack-chan example, and qualification boundaries.

--- a/robots/contract/WIFI-BODY.md
+++ b/robots/contract/WIFI-BODY.md
@@ -1,0 +1,84 @@
+# Wi-Fi body integration pattern
+
+A robot does not need to run Autonomous OS on its microcontroller. OS and HAL
+can run on a computer while the robot firmware owns its hardware. The
+Stack-chan integration is an experimental example of this existing driver
+pattern, not a new capability or a separate OS API.
+
+[Tiếng Việt](vi/WIFI-BODY_vi.md)
+
+## Host and firmware responsibilities
+
+```text
+Agent / OS -> existing HAL routes -> MotionService driver
+                                    -> authenticated network connection
+                                       -> firmware -> actuators
+```
+
+The host loads a device profile, selects the motion driver through
+`hal/drivers/motors/factory.py`, and mounts the declared routes. The driver
+implements the existing `MotionService` contract, including body ownership,
+measured positions, bounded movement, halt, and release. A network body should
+not require skills to use a new set of robot-specific HTTP endpoints.
+
+Firmware owns physical interpolation, feedback validity, torque control, and
+an independent response to loss of the host or link. Host-side exceptions are
+not a physical stop. Specify and verify how firmware cancels motion and holds
+or enters its hardware-defined safe state when communication disappears.
+
+## Device and host selection
+
+`DEVICE_TYPE` identifies the robot profile. `HAL_BOARD` identifies the machine
+running HAL. For a computer controlling a remote body, a profile can explicitly
+declare `boards: [host]` and use `HAL_BOARD=host`. The host board skips local
+GPIO peripherals; it does not replace the network motion driver with a mock.
+`HAL_SIMULATE=1` is a separate mode that substitutes simulated drivers. Keep it
+at `0` when controlling real remote hardware.
+
+A minimal motion integration declares `motion` with its driver and `system`,
+and supplies `SAFETY.md` and `SOUL.md`. Keep body-specific HAL environment
+settings in the profile's `rootfs/opt/hal/.env`, with credentials supplied
+locally. For an unqualified motion-only profile, use an underscore-prefixed
+experimental directory rather than claiming capabilities that do not exist.
+The Stack-chan example uses `DEVICE_TYPE=stackchan` with
+`DEVICES_DIR=<repo>/robots/_experimental`.
+
+## Stack-chan reference
+
+The [host startup guide](../_experimental/stackchan/docs/runtime.md) is the
+executable reference. OS and HAL run on the same computer; the current OS HAL
+client uses `http://127.0.0.1:5001`. ESP32 firmware initiates an authenticated
+WSS connection to HAL at `/stackchan/body/v1` on its separate body listener.
+This connection direction belongs to the Stack-chan protocol, not to every
+network body. Firmware validates the certificate; both sides share the body
+identity and token. Plain WS requires an explicit isolated-development opt-in.
+
+The driver requires advertised timed-move, measured-position, halt/hold and
+torque-release capabilities. It enforces the configured speed ceiling against
+measured position, renews a controller lease, and verifies arrival instead of
+treating a scheduled-command acknowledgement as physical completion. Halt holds
+the current pose; release travels to a rest pose and verifies arrival before
+requesting torque-off. Firmware clears the lease on halt, so the host must
+reacquire it before another move. See the [safety implementation notes](../../docs/safety.md).
+
+The companion project's standalone HTTP bridge is a different entry point.
+Pulling this driver does not switch that bridge to full HAL or flash firmware.
+
+## Integration evidence and compatibility
+
+Keep these milestones separate:
+
+- Host tests: profile/env loading, driver selection, no unintended startup
+  movement, HTTP-to-transport commands, failure paths and ownership behavior.
+- Hardware verification: pinned flashed firmware, authenticated connection,
+  calibrated coordinates/rest pose, measured movement, halt, link/process loss,
+  lease expiry, recovery and torque behavior on the actual assembly.
+- Compatibility: every requirement in [COMPATIBILITY.md](COMPATIBILITY.md),
+  supported by the [CTS](cts/README.md). Motion plus a face alone does not meet
+  the audio-or-vision requirement. Static tests alone do not qualify hardware.
+
+A merged experimental driver completes host onboarding, not these later
+milestones. Add display support through the existing semantic display routes
+when a working firmware-backed implementation establishes the needed driver
+boundary; do not assume the existing SPI-rendering implementation fits a body
+that renders its own expressions.

--- a/robots/contract/vi/WIFI-BODY_vi.md
+++ b/robots/contract/vi/WIFI-BODY_vi.md
@@ -1,0 +1,78 @@
+# Mẫu tích hợp thân robot qua Wi-Fi
+
+Robot không cần chạy Autonomous OS trên vi điều khiển. OS và HAL có thể chạy
+trên máy tính, còn firmware robot quản lý phần cứng. Stack-chan là ví dụ thử
+nghiệm của mẫu driver hiện có, không phải capability mới hay API OS riêng.
+
+[English](../WIFI-BODY.md)
+
+## Trách nhiệm của host và firmware
+
+```text
+Agent / OS -> route HAL hiện có -> driver MotionService
+                                  -> kết nối mạng có xác thực
+                                     -> firmware -> cơ cấu chấp hành
+```
+
+Host nạp profile, chọn driver qua `hal/drivers/motors/factory.py` và mount các
+route được khai báo. Driver thực hiện contract `MotionService` hiện có, gồm
+quyền sở hữu thân máy, vị trí đo được, chuyển động có giới hạn, halt và release.
+Robot qua mạng không nên buộc skill dùng một bộ HTTP endpoint riêng theo robot.
+
+Firmware quản lý nội suy vật lý, tính hợp lệ của feedback, torque và phản ứng
+độc lập khi mất host hoặc đường truyền. Exception trên host không phải thao tác
+dừng vật lý. Cần xác định và kiểm chứng cách firmware hủy chuyển động, giữ vị
+trí hoặc chuyển sang trạng thái an toàn của phần cứng khi mất liên lạc.
+
+## Chọn device và host
+
+`DEVICE_TYPE` xác định profile robot. `HAL_BOARD` xác định máy chạy HAL. Máy
+tính điều khiển robot từ xa có thể được profile khai báo `boards: [host]` và
+chọn bằng `HAL_BOARD=host`. Board host bỏ qua thiết bị GPIO cục bộ; nó không
+thay driver mạng bằng mock. `HAL_SIMULATE=1` là chế độ riêng thay driver bằng
+mô phỏng. Giữ giá trị `0` khi điều khiển phần cứng từ xa thật.
+
+Tích hợp chuyển động tối thiểu khai báo `motion` cùng driver và `system`, kèm
+`SAFETY.md` và `SOUL.md`. Cấu hình HAL riêng của robot nằm trong
+`rootfs/opt/hal/.env` thuộc profile; credential được cung cấp cục bộ. Với profile
+chỉ có motion chưa qualification, dùng thư mục thử nghiệm có tiền tố gạch dưới,
+không nhận vơ capability chưa tồn tại. Ví dụ Stack-chan dùng
+`DEVICE_TYPE=stackchan`, `DEVICES_DIR=<repo>/robots/_experimental`.
+
+## Tham chiếu Stack-chan
+
+[Hướng dẫn khởi động host](../../_experimental/stackchan/docs/vi/runtime_vi.md)
+là tham chiếu có thể chạy. OS và HAL ở cùng máy tính; HAL client hiện tại của
+OS dùng `http://127.0.0.1:5001`. Firmware ESP32 chủ động kết nối WSS có xác thực
+tới `/stackchan/body/v1` trên listener riêng của HAL. Chiều kết nối này thuộc
+protocol Stack-chan, không bắt buộc với mọi robot qua mạng. Firmware xác minh
+certificate; hai bên dùng cùng định danh và token. Plain WS cần bật tường minh
+cho thử nghiệm trong mạng cô lập.
+
+Driver yêu cầu firmware công bố capability timed-move, measured-position,
+halt/hold và torque-release. Nó áp dụng giới hạn tốc độ theo vị trí đo được,
+gia hạn controller lease và xác minh tới đích thay vì coi ACK đã lập lịch là
+hoàn tất vật lý. Halt giữ tư thế hiện tại; release đi tới tư thế rest, xác minh
+đến nơi rồi mới yêu cầu nhả torque. Firmware xóa lease khi halt, nên host phải
+acquire lại trước chuyển động mới. Xem [ghi chú triển khai an toàn](../../../docs/vi/safety_vi.md).
+
+HTTP bridge độc lập của repo companion là entry point khác. Pull driver này
+không tự chuyển bridge đó sang HAL đầy đủ hay flash firmware.
+
+## Bằng chứng tích hợp và compatibility
+
+Phân biệt các mốc:
+
+- Test host: nạp profile/env, chọn driver, không tự chuyển động lúc startup,
+  lệnh HTTP tới transport, đường lỗi và hành vi ownership.
+- Kiểm chứng phần cứng: pin firmware đã flash, kết nối có xác thực, hiệu chuẩn
+  tọa độ/rest, chuyển động đo được, halt, mất kết nối/process, hết hạn lease,
+  phục hồi và torque trên cụm phần cứng thật.
+- Compatibility: toàn bộ yêu cầu trong [COMPATIBILITY.md](../COMPATIBILITY.md),
+  được hỗ trợ bởi [CTS](../cts/README.md). Motion cùng khuôn mặt chưa đáp ứng
+  yêu cầu audio hoặc vision. Test tĩnh không tự qualification phần cứng.
+
+Merge driver thử nghiệm hoàn thành onboarding host, chưa hoàn thành các mốc
+sau. Bổ sung display qua route semantic hiện có khi một implementation chạy
+được với firmware xác định ranh giới driver cần thiết; không mặc định
+implementation render qua SPI phù hợp với robot tự vẽ biểu cảm.


### PR DESCRIPTION
Documents the Wi-Fi body integration pattern requested in #301 after the experimental Stack-chan host support landed in #304. The English and Vietnamese guides explain host/firmware responsibilities, device versus board selection, profile-specific configuration, the existing MotionService boundary, and the separation between host integration, hardware verification, and full compatibility. ROBOT-SPEC links to both guides.

This completes the onboarding/documentation scope. It does not claim that Stack-chan hardware is qualified or that display/audio/vision support has shipped; those remain later milestones.

Validation: relative links resolve; git diff --check passes; contract CTS ran 16 tests successfully (14 hardware-dependent tests skipped). No runtime code changed.

Closes #301.
